### PR TITLE
For review only -- DO NOT MERGE

### DIFF
--- a/iocage
+++ b/iocage
@@ -745,7 +745,8 @@ __destroy_jail () {
     local origin="$(zfs get -H -o value origin $dataset)"
     local fulluuid="$(__check_name $name)"
     local jail_path="$(__get_jail_prop mountpoint $fulluuid)"
-    local state="$(jls | grep ${jail_path} | wc -l)"
+    local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+              | cut -d' ' -f1)"
     local jail_type="$(__get_jail_prop type $fulluuid)"
     local jail_release="$(__get_jail_prop release $fulluuid)"
 
@@ -1006,7 +1007,7 @@ __find_jail () {
     local jlist="/tmp/iocage-jail-list.$$"
     local jails="$(zfs list -rH -o name $pool/iocage/jails \
                  | grep -E \
-                "^$pool/iocage/jails/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}$")"
+              "^$pool/iocage/jails/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}$")"
 
     if [ "${name}" == "ALL" ] ; then
         for jail in $jails ; do
@@ -1014,7 +1015,8 @@ __find_jail () {
         done
     else
         for jail in $jails ; do
-            found="$(echo $jail |grep -iE "^$pool/iocage/jails/$name"|wc -l)"
+            found="$(echo $jail |grep -iE "^${pool}/iocage/jails/${name}"|wc \
+                      -l | sed -e 's/^  *//')"
             local tag="$(zfs get -H -o value org.freebsd.iocage:tag $jail)"
 
             if [ "$found" -eq 1 ] ; then
@@ -1030,9 +1032,11 @@ __find_jail () {
             exit 0
         fi
 
-        if [ "$(cat $jlist|wc -l)" -eq "1" ] ; then
+        if [ "$(wc -l "${jlist}" | sed -e 's/^  *//' \
+                | cut -d' ' -f1)" -eq "1" ] ; then
             cat $jlist
-        elif [ "$(cat $jlist|wc -l)" -gt "1" ] ; then
+        elif [ "$(wc -l "${jlist}" | sed -e 's/^  *//' \
+                  | cut -d' ' -f1)" -gt "1" ] ; then
             echo "multiple"
         fi
     fi
@@ -1069,7 +1073,8 @@ __start_jail () {
     local cpuset="$(__get_jail_prop cpuset $fulluuid)"
     local procfs="$(__get_jail_prop mount_procfs $fulluuid)"
     local jail_path="$(__get_jail_prop mountpoint $fulluuid)"
-    local state="$(jls | grep ${jail_path} | wc -l)"
+    local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+              | cut -d' ' -f1)"
     local vnet="$(__get_jail_prop vnet $fulluuid)"
     local nics="$(__get_jail_prop interfaces $fulluuid \
                |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
@@ -1373,7 +1378,8 @@ __stop_jail () {
     local exec_stop="$(__get_jail_prop exec_stop $fulluuid)"
     local exec_poststop="$(__findscript $fulluuid poststop)"
     local vnet="$(__get_jail_prop vnet $fulluuid)"
-    local state="$(jls | grep ${jail_path} | wc -l)"
+    local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+              | cut -d' ' -f1)"
 
     if [  "$state" -lt "1" ] ; then
         echo "* ${fulluuid}: is already down"
@@ -1439,7 +1445,8 @@ __stop_jail () {
     fi
 
     if [ ! -z $(sysctl -qn kern.features.rctl) ] ; then
-        local rlimits="$(rctl | grep $fulluuid| wc -l)"
+        local rlimits="$(rctl | grep $fulluuid| wc -l | sed -e 's/^  *//' \
+                  | cut -d' ' -f1)"
         if [ $rlimits -gt "0" ] ; then
             rctl -r jail:ioc-${fulluuid}
         fi
@@ -1517,7 +1524,8 @@ __rc_jails () {
         for i in $boot_order ; do
             local jail="$(echo $i | cut -f2 -d,)"
             local jail_path="$(__get_jail_prop mountpoint $jail)"
-            local state="$(jls | grep ${jail_path} | wc -l)"
+            local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+                      | cut -d' ' -f1)"
 
             if [ "$state" -lt "1" ] ; then
                 __start_jail $jail
@@ -1530,7 +1538,8 @@ __rc_jails () {
         for i in $shutdown_order ; do
             local jail="$(echo $i | cut -f2 -d,)"
             local jail_path="$(__get_jail_prop mountpoint $jail)"
-            local state="$(jls | grep ${jail_path} | wc -l)"
+            local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+                      | cut -d' ' -f1)"
 
             if [ "$state" -eq "1" ] ; then
                 __stop_jail $jail
@@ -2186,7 +2195,8 @@ __runtime () {
 
     local fulluuid="$(__check_name $name)"
 
-    local state="$(jls -n -j ioc-${fulluuid} | wc -l)"
+    local state="$(jls -n -j ioc-${fulluuid} | wc -l | sed -e 's/^  *//' \
+              | cut -d' ' -f1)"
 
     if [ "$state" -eq "1" ] ; then
         local params="$(jls -nj ioc-${fulluuid})"
@@ -2358,7 +2368,8 @@ __record () {
     local fulluuid="$(__check_name $name)"
 
     local mountpoint="$(__get_jail_prop mountpoint $fulluuid)"
-    local union_mount="$(mount -t unionfs | grep $fulluuid | wc -l)"
+    local union_mount="$(mount -t unionfs | grep $fulluuid | wc -l | \
+                        sed -e 's/^  *//' | cut -d' ' -f1)"
 
     if [ ! -d ${mountpoint}/recorded ] ; then
         mkdir ${mountpoint}/recorded
@@ -2441,8 +2452,10 @@ __import () {
 
     local package="$(find $iocroot/packages/ -name $name\*.tar.xz)"
     local image="$(find $iocroot/images/ -name $name\*.tar.xz)"
-    local pcount="$(echo $package|wc -w)"
-    local icount="$(echo $image|wc -w)"
+    local pcount="$(echo $package|wc -w | sed -e 's/^  *//' \
+              | cut -d' ' -f1)"
+    local icount="$(echo $image|wc -w | sed -e 's/^  *//' \
+              | cut -d' ' -f1)"
 
     if [ $pcount -gt 1 ] ; then
         echo "  ERROR: multiple matching packages, please narrow down UUID."
@@ -2542,7 +2555,8 @@ __export () {
 
     local fulluuid="$(__check_name $name)"
     local jail_path="$(__get_jail_prop mountpoint $fulluuid)"
-    local state=$(jls|grep ${jail_path} | wc -l)
+    local state=$(jls|grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+              | cut -d' ' -f1)
 
     if [ "$state" -gt "0" ] ; then
         echo "  ERROR: $fulluuid is running!"

--- a/iocage
+++ b/iocage
@@ -42,7 +42,7 @@ if [ "$(zpool list)" = 'no pools available' ] ; then
 fi
 
 # Auto UUID
-uuid=$(uuidgen)
+uuid="$(uuidgen)"
 
 # pkg list, only used with the create subcommand
 pkglist="none"
@@ -51,7 +51,7 @@ pkglist="none"
 
 # detect VNET kernel and adjust jail default
 # if supported turn it on by default
-if [ ! -z $(sysctl -qn kern.features.vimage) ] ; then
+if [ ! -z "$(sysctl -qn kern.features.vimage)" ] ; then
     vnet="on"
 else
     vnet="off"
@@ -60,9 +60,9 @@ fi
 ipv6="on"
 
 interfaces="vnet0:bridge0,vnet1:bridge1"
-host_hostname=$uuid
+host_hostname="${uuid}"
 exec_fib=0
-hostname=$uuid
+hostname="${uuid}"
 ip4_addr="none"
 ip4_saddrsel="1"
 ip4="new"
@@ -92,7 +92,7 @@ enforce_statfs="2"
 children_max="0"
 login_flags='-f root'
 securelevel="2"
-host_hostuuid=$uuid
+host_hostuuid="${uuid}"
 allow_set_hostname=1
 allow_sysvipc=0
 allow_raw_sockets=0
@@ -132,7 +132,7 @@ wallclock="off"
 
 # Custom properties
 iocroot="/iocage"
-tag=$(date "+%F@%T")
+tag="$(date "+%F@%T")"
 template="no"
 boot="off"
 notes="none"
@@ -140,8 +140,8 @@ owner="root"
 priority="99"
 last_started="none"
 type="jail"
-release=$(uname -r|cut -f 1,2 -d'-')
-hostid=$(cat /etc/hostid)
+release="$(uname -r|cut -f 1,2 -d'-')"
+hostid="$(cat /etc/hostid)"
 jail_zfs="off"
 jail_zfs_dataset="iocage/jails/${uuid}/root/data"
 mount_procfs="0"
@@ -302,53 +302,53 @@ bdir_list="dev
 
 # Process command line options-------------------------
 __parse_cmd () {
-    while [ $# -gt 0 ] ; do
-        case "$1" in
-            list)       __list_jails "$2"
+    while [ "${#}" -gt 0 ] ; do
+        case "${1}" in
+            list)       __list_jails "${2}"
                         exit
                 ;;
-            console)    __console "$2"
+            console)    __console "${2}"
                         exit
                 ;;
             exec)       shift
-                        __exec "$@"
+                        __exec "${@}"
                         exit
                 ;;
-            chroot)     __chroot "$2" "$3"
+            chroot)     __chroot "${2}" "${3}"
                         exit
                 ;;
             defaults)   __print_defaults
                         exit
                 ;;
-            create)     __export_props "$@"
-                        __create_jail "$@"
+            create)     __export_props "${@}"
+                        __create_jail "${@}"
                         exit
                 ;;
-            destroy)    __destroy_jail "$2"
+            destroy)    __destroy_jail "${2}"
                         exit
                 ;;
-            clone)      __export_props "$@"
-                        __clone_jail "$2"
+            clone)      __export_props "${@}"
+                        __clone_jail "${2}"
                         exit
                 ;;
-            fetch)      __export_props "$@"
+            fetch)      __export_props "${@}"
                         __fetch_release
                         exit
                 ;;
-            get)        __get_jail_prop "$2" "$3"
+            get)        __get_jail_prop "${2}" "${3}"
                         exit
                 ;;
-            set)        __export_props "$@"
-                        __set_jail_prop "$2" "$3"
+            set)        __export_props "${@}"
+                        __set_jail_prop "${2}" "${3}"
                         exit
                 ;;
-            start)      __start_jail "$2"
+            start)      __start_jail "${2}"
                         exit
                 ;;
-            stop)       __stop_jail "$2"
+            stop)       __stop_jail "${2}"
                         exit
                 ;;
-            restart)    __restart_jail "$2"
+            restart)    __restart_jail "${2}"
                         exit
                 ;;
             rcboot)     __rc_jails boot
@@ -360,56 +360,56 @@ __parse_cmd () {
             df)         __print_disk
                         exit
                 ;;
-            snapshot)   __snapshot "$2"
+            snapshot)   __snapshot "${2}"
                         exit
                 ;;
-            snaplist)   __snaplist "$2"
+            snaplist)   __snaplist "${2}"
                         exit
                 ;;
-            snapremove) __snapremove "$2"
+            snapremove) __snapremove "${2}"
                         exit
                 ;;
-            promote)    __promote "$2"
+            promote)    __promote "${2}"
                         exit
                 ;;
-            rollback)   __rollback "$2"
+            rollback)   __rollback "${2}"
                         exit
                 ;;
-            uncap)      __rctl_uncap "$2"
+            uncap)      __rctl_uncap "${2}"
                         exit
                 ;;
-            cap)        __rctl_limits "$2"
+            cap)        __rctl_limits "${2}"
                         exit
                 ;;
-            limits)     __rctl_list "$2"
+            limits)     __rctl_list "${2}"
                         exit
                 ;;
-            inuse)      __rctl_used "$2"
+            inuse)      __rctl_used "${2}"
                         exit
                 ;;
-            runtime)    __runtime "$2"
+            runtime)    __runtime "${2}"
                         exit
                 ;;
-            update)     __update "$2"
+            update)     __update "${2}"
                         exit
                 ;;
-            upgrade)     __upgrade "$2"
+            upgrade)     __upgrade "${2}"
                         exit
                 ;;
-            record)     __record "$2" "$3"
+            record)     __record "${2}" "${3}"
                         exit
                 ;;
-            package)    __package "$2"
+            package)    __package "${2}"
                         exit
                 ;;
-            export)     __export "$2"
+            export)     __export "${2}"
                         exit
                 ;;
-            import)     __export_props "$@"
-                        __import "$2"
+            import)     __export_props "${@}"
+                        __import "${2}"
                         exit
                 ;;
-            show)       __show "$2"
+            show)       __show "${2}"
                         exit
                 ;;
             help)       __help
@@ -425,19 +425,19 @@ __parse_cmd () {
 
 # Print defaults set in this script---------------------------
 __print_defaults () {
-    CONF="$CONF_NET
-          $CONF_JAIL
-          $CONF_RCTL
-          $CONF_CUSTOM
-          $CONF_ZFS
-          $CONF_SYNC
-          $CONF_FTP"
+    CONF="${CONF_NET}
+          ${CONF_JAIL}
+          ${CONF_RCTL}
+          ${CONF_CUSTOM}
+          ${CONF_ZFS}
+          ${CONF_SYNC}
+          ${CONF_FTP}"
 
-    for prop in $(echo $CONF)  ; do
-        prop_name=$prop
+    for prop in ${CONF} ; do
+        prop_name="${prop}"
         eval prop="\$${prop}"
-        if [ ! -z "$prop" ] ; then
-            echo "$prop_name=$prop"
+        if [ ! -z "${prop}" ] ; then
+            echo "${prop_name}=${prop}"
         fi
     done
 }
@@ -448,13 +448,13 @@ __print_release () {
                 9.3-RELEASE"
 
     echo "Supported releases are: "
-    for rel in $(echo $supported) ; do
-        printf "%15s\n" "$rel"
+    for rel in ${supported} ; do
+        printf "%15s\n" "${rel}"
     done
 }
 
 __create_basejail () {
-    local release="$1"
+    local release="${1}"
     local fs_list="bin
                    boot
                    lib
@@ -475,306 +475,305 @@ __create_basejail () {
     echo ""
     echo "Creating basejail ZFS datasets... please wait."
 
-    for fs in $(echo $fs_list) ; do
-        zfs create -o compression=lz4 -p $pool/iocage/base/${release}/root/$fs
+    for fs in ${fs_list} ; do
+        zfs create -o compression=lz4 -p "${pool}/iocage/base/${release}/root/${fs}"
     done
 }
 
 __reclone_basejail () {
-    local name=$1
+    local name=""${1}
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "$dataset" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
-    local jail_release="$(__get_jail_prop release $fulluuid)"
+    local fulluuid="$(__check_name "${name}")"
+    local jail_release="$(__get_jail_prop release "${fulluuid}")"
 
-    zfs destroy -rRf $pool/iocage/base@$fulluuid
-    zfs snapshot -r  $pool/iocage/base@$fulluuid
+    zfs destroy -rRf "${pool}/iocage/base@${fulluuid}"
+    zfs snapshot -r  "${pool}/iocage/base@${fulluuid}"
 
-    echo "* $fulluuid is a basejail, re-cloning jail.."
+    echo "* ${fulluuid} is a basejail, re-cloning jail.."
 
     # Re-clone required filesystems
     for fs in $bfs_list ; do
         # echo "  re-cloning: $pool/iocage/jails/$fulluuid/root/$fs"
-        zfs clone $pool/iocage/base/$jail_release/root/$fs@$fulluuid \
-                  $pool/iocage/jails/$fulluuid/root/$fs
+        zfs clone "${pool}/iocage/base/${jail_release}/root/${fs}@${fulluuid} \
+                  ${pool}/iocage/jails/${fulluuid}/root/${fs}"
     done
 }
 
 # Fetch release and prepare base ZFS filesystems-----------
 __fetch_release () {
-    local exist=$(zfs list | grep -w ^$pool/iocage)
+    local exist="$(zfs list | grep -w "^${pool}/iocage")"
     __print_release
-    echo -n "Please select a release [$release]: "
+    echo -n "Please select a release [${release}]: "
     read answer
     if [ ! -z "$answer" ] ; then
-        release="$answer"
+        release="${answer}"
     else
-        answer="$release"
+        answer="${release}"
     fi
 
-    for rel in $(echo $supported) ; do
-        if [ "$answer" == "$rel" ] ; then
-            release="$rel"
+    for rel in ${supported} ; do
+        if [ "${answer}" == "${rel}" ] ; then
+            release="${rel}"
             match="1"
             break
         fi
     done
 
-    if [ -z $match ] ; then
-        echo "Invalid release $release specified, exiting.."
+    if [ -z "${match}" ] ; then
+        echo "Invalid release ${release} specified, exiting.."
         exit 1
     fi
 
-    local exist=$(zfs list | grep -w ^$pool/iocage)
-    local download_exist=$(zfs list | grep -w ^$pool/iocage/download/$release)
-    local rel_exist=$(zfs list | grep -w ^$pool/iocage/releases/$release)
+    local exist="$(zfs list | grep -w "^${pool}/iocage")"
+    local download_exist="$(zfs list | grep -w "^${pool}/iocage/download/${release}")"
+    local rel_exist="$(zfs list | grep -w "^${pool}/iocage/releases/${release}")"
 
-    if [ -z "$exist" ] ; then
-        zfs create -o compression=lz4 $pool/iocage
-        zfs set mountpoint=$iocroot $pool/iocage
-        zfs create -o compression=lz4 $pool/iocage/jails
+    if [ -z "${exist}" ] ; then
+        zfs create -o compression=lz4 "${pool}/iocage"
+        zfs set mountpoint="${iocroot}" "${pool}/iocage"
+        zfs create -o compression=lz4 "${pool}/iocage/jails"
         zfs mount -a
     fi
 
-    if [ -z "$download_exist" ] ; then
-        zfs create -o compression=lz4 -p $pool/iocage/download/$release
+    if [ -z "${download_exist}" ] ; then
+        zfs create -o compression=lz4 -p "${pool}/iocage/download/${release}"
     fi
 
-    ftpdir="/pub/FreeBSD/releases/amd64/$release"
+    ftpdir="/pub/FreeBSD/releases/amd64/${release}"
 
-    cd $iocroot/download/$release
-    for file in $ftpfiles ; do
-        if [ ! -e "$file" ] ; then
-            fetch http://$ftphost$ftpdir/$file
+    cd "${iocroot}/download/${release}"
+    for file in ${ftpfiles} ; do
+        if [ ! -e "${file}" ] ; then
+            fetch "http://${ftphost}${ftpdir}/${file}"
         fi
     done
 
-    if [ -z "$rel_exist" ] ; then
-        zfs create -o compression=lz4 -p $pool/iocage/releases/$release/root
+    if [ -z "${rel_exist}" ] ; then
+        zfs create -o compression=lz4 -p "${pool}/iocage/releases/${release}/root"
     fi
 
-    for file in $(echo $ftpfiles) ; do
-        if [ -e "$file" ] ; then
-            echo "Extracting: $file"
-            chflags -R noschg $iocroot/releases/$release/root
-            tar -C $iocroot/releases/$release/root -xf $file
+    for file in ${ftpfiles} ; do
+        if [ -e "${file}" ] ; then
+            echo "Extracting: ${file}"
+            chflags -R noschg "${iocroot}/releases/${release}/root"
+            tar -C "${iocroot}/releases/${release}/root" -xf "${file}"
         fi
     done
 
         echo "* Updating base jail.."
         sleep 2
 
-        env UNAME_r="$release" /usr/sbin/freebsd-update \
-            -b $iocroot/releases/$release/root \
-            -d $iocroot/releases/$release/root/var/db/freebsd-update/ fetch
-        env UNAME_r="$release" /usr/sbin/freebsd-update \
-            -b $iocroot/releases/$release/root \
-            -d $iocroot/releases/$release/root/var/db/freebsd-update/ install
+        env UNAME_r="${release}" /usr/sbin/freebsd-update \
+            -b "${iocroot}/releases/${release}/root" \
+            -d "${iocroot}/releases/${release}/root/var/db/freebsd-update/" fetch
+        env UNAME_r="${release}" /usr/sbin/freebsd-update \
+            -b "${iocroot}/releases/${release}/root" \
+            -d "${iocroot}/releases/${release}/root/var/db/freebsd-update/" install
 
-    if [ ! -d $iocroot/log ] ; then
-        mkdir $iocroot/log
+    if [ ! -d "${iocroot}/log" ] ; then
+        mkdir "${iocroot}/log"
     fi
 
-    __create_basejail $release
-    chflags -R noschg $iocroot/base/$release/root
-    tar --exclude \.zfs --exclude usr/sbin/chown -C $iocroot/releases/$release/root -cf - . | \
-    tar --exclude \.zfs --exclude usr/sbin/chown -C $iocroot/base/$release/root -xf -
+    __create_basejail "${release}"
+    chflags -R noschg "${iocroot}/base/${release}/root"
+    tar --exclude \.zfs --exclude usr/sbin/chown -C "${iocroot}/releases/${release}/root" -cf - . | \
 
-    if [ ! -e "$iocroot/base/$release/root/usr/sbin/chown" ] ; then
-       cd $iocroot/base/$release/root/usr/sbin && ln -s ../bin/chgrp chown
+    if [ ! -e "${iocroot}/base/${release}/root/usr/sbin/chown" ] ; then
+       cd "${iocroot}/base/${release}/root/usr/sbin" && ln -s ../bin/chgrp chown
     fi
 
-    etcupdate extract -D $iocroot/base/$release/root \
-    -s $iocroot/base/$release/root/usr/src
+    etcupdate extract -D "${iocroot}/base/${release}/root" \
+    -s "${iocroot}/base/${release}/root/usr/src"
 }
 
 # This creates jails----------------------------------------------------
 __create_jail () {
-    local installed=$(zfs list -r $pool/iocage/releases|grep $release)
+    local installed=$(zfs list -r "${pool}/iocage/releases"|grep "${release}")
 
-    if [ -z "$installed" ] ; then
-        echo "Release $release not found locally, run fetch first"
+    if [ -z "${installed}" ] ; then
+        echo "Release ${release} not found locally, run fetch first"
         exit 1
     fi
 
     if [ "${2}" = "-c" ] ; then
-        fs_list=$(zfs list -rH -o name $pool/iocage/releases/$release)
+        fs_list=$(zfs list -rH -o name "${pool}/iocage/releases/${release}")
 
-        zfs snapshot -r $pool/iocage/releases/$release@$uuid
+        zfs snapshot -r "${pool}/iocage/releases/${release}@${uuid}"
         for fs in $fs_list ; do
-            cfs=$(echo $fs | sed s#/releases/$release#/jails/$uuid#g)
+            cfs="$(echo "$fs" | sed "s#/releases/${release}#/jails/${uuid}#g")"
             #echo "cloning $fs into $cfs"
-            zfs clone $fs@$uuid $cfs
+            zfs clone "${fs}@${uuid}" "${cfs}"
         done
     elif [ "${2}" = "-e" ] ; then
-        zfs create -o compression=lz4 -p $pool/iocage/jails/$uuid/root
+        zfs create -o compression=lz4 -p "${pool}/iocage/jails/${uuid}/root"
     elif [ "${2}" = "-b" ] ; then
        export type=basejail
-       zfs snapshot -r $pool/iocage/base@$uuid
-       zfs create -o compression=lz4 -p $pool/iocage/jails/$uuid/root/usr
+       zfs snapshot -r "${pool}/iocage/base@${uuid}"
+       zfs create -o compression=lz4 -p "${pool}/iocage/jails/${uuid}/root/usr"
 
        for fs in $bfs_list ; do
            zfs clone -o compression=lz4 -o readonly=on \
-           $pool/iocage/base/${release}/root/$fs@$uuid \
-           $pool/iocage/jails/$uuid/root/$fs
+           "${pool}/iocage/base/${release}/root/${fs}@${uuid}" \
+           "${pool}/iocage/jails/${uuid}/root/${fs}"
        done
 
        for dir in $bdir_list ; do
-           cp -a $iocroot/base/${release}/root/$dir \
-                 $iocroot/jails/$uuid/root/$dir
+           cp -a "${iocroot}/base/${release}/root/${dir}" \
+                 "${iocroot}/jails/${uuid}/root/${dir}"
        done
 
     else
-        zfs snapshot -r $pool/iocage/releases/$release@$uuid
-        zfs send     -R $pool/iocage/releases/$release@$uuid | \
-        zfs recv        $pool/iocage/jails/$uuid
-        zfs destroy  -r $pool/iocage/releases/$release@$uuid
-        zfs destroy  -r $pool/iocage/jails/$uuid@$uuid
+        zfs snapshot -r "${pool}/iocage/releases/${release}@${uuid}"
+        zfs send     -R "${pool}/iocage/releases/${release}@${uuid}" | \
+        zfs recv        "${pool}/iocage/jails/${uuid}"
+        zfs destroy  -r "${pool}/iocage/releases/${release}@${uuid}"
+        zfs destroy  -r "${pool}/iocage/jails/${uuid}@${uuid}"
     fi
 
-    __configure_jail $pool/iocage/jails/$uuid
-    touch $iocroot/jails/$uuid/fstab
+    __configure_jail "${pool}/iocage/jails/${uuid}"
+    touch "${iocroot}/jails/${uuid}/fstab"
 
     # at create time set the default rc.conf
     if [ "${2}" != "-e" ] ; then
-        echo "hostname=\"${hostname}\"" > $iocroot/jails/${uuid}/root/etc/rc.conf
+        echo "hostname=\"${hostname}\"" > "${iocroot}/jails/${uuid}/root/etc/rc.conf"
         __jail_rc_conf >> \
-        $iocroot/jails/${uuid}/root/etc/rc.conf
-        __resolv_conf > $iocroot/jails/${uuid}/root/etc/resolv.conf
+        "${iocroot}/jails/${uuid}/root/etc/rc.conf"
+        __resolv_conf > "${iocroot}/jails/${uuid}/root/etc/resolv.conf"
     elif [ "${2}" = "-e" ] ; then
-        echo $uuid
+        echo "${uuid}"
     fi
 
-    zfs create -o compression=lz4 ${pool}/$jail_zfs_dataset
-    zfs set mountpoint=none ${pool}/$jail_zfs_dataset
-    zfs set jailed=on ${pool}/$jail_zfs_dataset
+    zfs create -o compression=lz4 "${pool}/$jail_zfs_dataset"
+    zfs set mountpoint=none "${pool}/$jail_zfs_dataset"
+    zfs set jailed=on "${pool}/$jail_zfs_dataset"
 
     # Install extra packages
     # this requires working resolv.conf in jail
-    if [ "$pkglist" != "none" ] ; then
-        __pkg_install "$iocroot/jails/${uuid}/root"
+    if [ "${pkglist}" != "none" ] ; then
+        __pkg_install "${iocroot}/jails/${uuid}/root"
     fi
 }
 
 # Cloning jails ----------------------------------------------------------
 __clone_jail () {
-    local name="$(echo $1 |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot="$(echo $1 |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    local name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
+    local snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail $name)"
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fs_list="$(zfs list -rH -o name $dataset)"
+    local fs_list="$(zfs list -rH -o name "${dataset}")"
 
     if [ -z "$snapshot" ] ; then
-        zfs snapshot -r ${dataset}@${uuid}
+        zfs snapshot -r "${dataset}@${uuid}"
         for fs in $fs_list ; do
-            cfs="$(echo $fs | sed s#$dataset#$pool/iocage/jails/$uuid#g)"
-            zfs clone $fs@$uuid $cfs
+            cfs="$(echo "${fs}" | sed "s#${dataset}#${pool}/iocage/jails/${uuid}#g")"
+            zfs clone "${fs}@${uuid}" "${cfs}"
         done
     else
         for fs in $fs_list ; do
-            cfs="$(echo $fs | sed s#$dataset#$pool/iocage/jails/$uuid#g)"
-            zfs clone $fs@$snapshot $cfs
+            cfs="$(echo "${fs}" | sed "s#${dataset}#${pool}/iocage/jails/${uuid}#g")"
+            zfs clone "${fs}@${snapshot}" "${cfs}"
         done
     fi
 
-    __configure_jail $pool/iocage/jails/$uuid
-    mv $iocroot/jails/$uuid/fstab $iocroot/jails/$uuid/fstab.$name
-    touch $iocroot/jails/$uuid/fstab
+    __configure_jail "${pool}/iocage/jails/${uuid}"
+    mv "${iocroot}/jails/${uuid}/fstab" "${iocroot}/jails/${uuid}/fstab.${name}"
+    touch "${iocroot}/jails/${uuid}/fstab"
 
-    cat $iocroot/jails/${uuid}/root/etc/rc.conf | \
-    sed -E "s/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}/$uuid/g" \
-    > $iocroot/jails/${uuid}/rc.conf
+    cat "${iocroot}/jails/${uuid}/root/etc/rc.conf" | \
+    sed -E "s/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}/${uuid}/g" \
+    > "${iocroot}/jails/${uuid}/rc.conf"
 
-    mv $iocroot/jails/${uuid}/rc.conf \
-    $iocroot/jails/${uuid}/root/etc/rc.conf
+    mv "${iocroot}/jails/${uuid}/rc.conf" \
+    "${iocroot}/jails/${uuid}/root/etc/rc.conf"
 }
 
 # Destroy jails --------------------------------------------------------------
 __destroy_jail () {
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail $name)"
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local origin="$(zfs get -H -o value origin $dataset)"
-    local fulluuid="$(__check_name $name)"
-    local jail_path="$(__get_jail_prop mountpoint $fulluuid)"
-    local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+    local origin="$(zfs get -H -o value origin "${dataset}")"
+    local fulluuid="$(__check_name "${name}")"
+    local jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local jail_type="$(__get_jail_prop type $fulluuid)"
-    local jail_release="$(__get_jail_prop release $fulluuid)"
+    local jail_type="$(__get_jail_prop type "${fulluuid}")"
+    local jail_release="$(__get_jail_prop release "${fulluuid}")"
 
     echo " "
-    echo "  WARNING: this will destroy jail $fulluuid"
-    echo "  Dataset: $dataset"
+    echo "  WARNING: this will destroy jail ${fulluuid}"
+    echo "  Dataset: ${dataset}"
     echo " "
     echo -n "  Are you sure ? Y[n]: "
     read answer
 
-    if [ "$answer" == "Y" ]; then
-        if [ "$state" -lt "1" ] ; then
-            echo "  Destroying: $fulluuid"
+    if [ "${answer}" == "Y" ]; then
+        if [ "${state}" -lt "1" ] ; then
+            echo "  Destroying: ${fulluuid}"
 
-            __unlink_tag $dataset
+            __unlink_tag "${dataset}"
 
-            zfs destroy -fr $dataset
+            zfs destroy -fr "${dataset}"
 
-            if [ "$origin" != "-" ] ; then
-                echo "  Destroying clone origin: $origin"
-                zfs destroy -r $origin
+            if [ "${origin}" != "-" ] ; then
+                echo "  Destroying clone origin: ${origin}"
+                zfs destroy -r "${origin}"
             fi
 
-            if [ $jail_type == "basejail" ] ; then
-                zfs destroy -fr $pool/iocage/base/$jail_release@$fulluuid
+            if [ "${jail_type}" == "basejail" ] ; then
+                zfs destroy -fr "${pool}/iocage/base/${jail_release}@${fulluuid}"
             fi
 
-        elif [ "$state" -eq "1" ] ; then
+        elif [ "${state}" -eq "1" ] ; then
             echo "  ERROR: Jail is up and running ..exiting"
             exit 1
         fi
@@ -786,164 +785,164 @@ __destroy_jail () {
 
 # Configure properties -------------------------------------------------
 __configure_jail () {
-    local CONF="$CONF_NET
-                $CONF_JAIL
-                $CONF_RCTL
-                $CONF_CUSTOM
-                $CONF_SYNC"
+    local CONF="${CONF_NET}
+                ${CONF_JAIL}
+                ${CONF_RCTL}
+                ${CONF_CUSTOM}
+                ${CONF_SYNC}"
 
     echo "Configuring jail.."
-    for prop in $CONF ; do
-        prop_name=$prop
+    for prop in ${CONF} ; do
+        prop_name="${prop}"
         eval prop="\$${prop}"
-        if [ ! -z "$prop" ] ; then
-            echo "** $prop_name=$prop"
-            zfs set org.freebsd.iocage:$prop_name="$prop" $1
-            if [ "$prop_name" == "tag" ] ; then
-                __link_tag $1
+        if [ ! -z "${prop}" ] ; then
+            echo "** ${prop_name}=${prop}"
+            zfs set org.freebsd.iocage:"${prop_name}=${prop}" "${1}"
+            if [ "${prop_name}" == "tag" ] ; then
+                __link_tag "${1}"
             fi
         fi
     done
 
-    for prop in $CONF_ZFS ; do
-        prop_name=$prop
+    for prop in ${CONF_ZFS} ; do
+        prop_name="${prop}"
         eval prop="\$${prop}"
-        if [ ! -z "$prop" ] && [ "$prop" != "readonly" ] ; then
-            zfs set $prop_name="$prop" $1
+        if [ ! -z "${prop}" ] && [ "${prop}" != "readonly" ] ; then
+            zfs set "${prop_name}=${prop}" "${1}"
         fi
     done
 }
 
 # Export every property specified on command line ----------------------
 __export_props () {
-    for i in "$@" ; do
-        if [ "$(echo $i | grep -e ".*=.*")" ] ; then
-            export "$i"
+    for i in "${@}" ; do
+        if [ "$(echo "${i}" | grep -e ".*=.*")" ] ; then
+            export "${i}"
         fi
     done
 }
 
 # Set properties ------------------------------------------------------
 __set_jail_prop () {
-    local name="$2"
-    local property="$1"
+    local name="${2}"
+    local property="${1}"
 
-    if [ -z "$name" ] || [ -z "$property" ] ; then
+    if [ -z "${name}" ] || [ -z "${property}" ] ; then
         echo "  ERROR: missing property or UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail $name)"
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z "$dataset" ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ "$dataset" == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local pname="$(echo $property|awk 'BEGIN { FS = "=" } ; { print $1 }')"
-    local pval="$(echo $property|awk 'BEGIN { FS = "=" } ; { print $2 }')"
+    local pname="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $1 }')"
+    local pval="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $2 }')"
 
-    if [ -z "$pname" ] || [ -z "$pval" ] ; then
+    if [ -z "${pname}" ] || [ -z "${pval}" ] ; then
         echo "  ERROR: set failed, incorrect property syntax!"
         exit 1
     fi
 
     local found="0"
 
-    local CONF="$CONF_NET
-                $CONF_JAIL
-                $CONF_RCTL
-                $CONF_CUSTOM
-                $CONF_SYNC"
+    local CONF="${CONF_NET}
+                ${CONF_JAIL}
+                ${CONF_RCTL}
+                ${CONF_CUSTOM}
+                ${CONF_SYNC}"
 
-    for prop in $CONF ; do
-        if [ "$prop" == "$pname" ] ; then
+    for prop in ${CONF} ; do
+        if [ "${prop}" == "${pname}" ] ; then
             found=1
-            zfs set org.freebsd.iocage:${prop}="${pval}" $dataset
-            if [ "$pname" == "tag" ] ; then
-                __unlink_tag $dataset
-                __link_tag $dataset
+            zfs set org.freebsd.iocage:"${prop}=${pval}" "${dataset}"
+            if [ "${pname}" == "tag" ] ; then
+                __unlink_tag "${dataset}"
+                __link_tag "${dataset}"
             fi
         fi
     done
 
-    for prop in $CONF_ZFS ; do
-        if [ "$prop" == "$pname" ] ; then
-            zfs set $prop="$pval" $dataset
+    for prop in ${CONF_ZFS} ; do
+        if [ "${prop}" == "${pname}" ] ; then
+            zfs set "${prop}=${pval}" "${dataset}"
             found=1
         fi
     done
 
-    if [ $found -ne "1" ] ; then
-        echo "  ERROR: unsupported property: $pname !"
+    if [ "${found}" -ne "1" ] ; then
+        echo "  ERROR: unsupported property: ${pname} !"
         exit 1
     fi
 }
 
 # Get properties -----------------------------------------------------
 __get_jail_prop () {
-    local name="$2"
-    local property="$1"
+    local name="${2}"
+    local property="${1}"
 
-    if [ -z "$property" ] ; then
+    if [ -z "${property}" ] ; then
         echo "  ERROR: get failed, incorrect property syntax!"
         exit 1
     fi
 
-    if [ -z "$name" ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: mising UUID!"
         exit 1
     fi
 
-    local dataset="$(__find_jail $name)"
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z "$dataset" ] ; then
-        echo "  ERROR: jail $name not found!"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: jail ${name} not found!"
         exit 1
     fi
 
-    if [ "$dataset" == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
     local found="0"
 
-    local CONF="$CONF_NET
-                $CONF_JAIL
-                $CONF_RCTL
-                $CONF_CUSTOM
-                $CONF_SYNC"
+    local CONF="${CONF_NET}
+                ${CONF_JAIL}
+                ${CONF_RCTL}
+                ${CONF_CUSTOM}
+                ${CONF_SYNC}"
 
-    for prop in $CONF ; do
-        if [ $prop == $property ] ; then
+    for prop in ${CONF} ; do
+        if [ "${prop}" == "${property}" ] ; then
             found=1
-            local value="$(zfs get -H -o value org.freebsd.iocage:$prop \
-                         $dataset)"
-            echo "$value"
-        elif [ $property == "all" ] ; then
+            local value="$(zfs get -H -o value org.freebsd.iocage:"${prop}" \
+                         "${dataset}")"
+            echo "${value}"
+        elif [ "${property}" == "all" ] ; then
             found=1
-            local value="$(zfs get -H -o value org.freebsd.iocage:$prop \
-                         $dataset)"
-            echo "$prop:$value"
+            local value="$(zfs get -H -o value org.freebsd.iocage:"${prop}" \
+                         "${dataset}")"
+            echo "${prop}:${value}"
         fi
     done
 
-    for prop in $CONF_ZFS ; do
-        if [ $prop == $property ] ; then
+    for prop in ${CONF_ZFS} ; do
+        if [ "${prop}" == "${property}" ] ; then
             found=1
-            local value="$(zfs get -H -o value $prop $dataset)"
-            echo "$value"
+            local value="$(zfs get -H -o value "${prop}" "${dataset}")"
+            echo "${value}"
         fi
     done
 
-    if [ $found -ne "1" ] ; then
-        echo "  ERROR: unsupported property: $property !"
+    if [ "${found}" -ne "1" ] ; then
+        echo "  ERROR: unsupported property: ${property} !"
         exit 1
     fi
 }
@@ -994,41 +993,41 @@ __usage () {
 }
 
 __get_jail_name () {
-    for i in $@; do
+    for i in ${@}; do
         :;
     done
 
-    echo $i
+    echo "${i}"
 }
 
 # Find and return the jail's top level ZFS dataset
 __find_jail () {
-    local name=$1
-    local jlist="/tmp/iocage-jail-list.$$"
-    local jails="$(zfs list -rH -o name $pool/iocage/jails \
+    local name="${1}"
+    local jlist="/tmp/iocage-jail-list.${$}"
+    local jails="$(zfs list -rH -o name "${pool}/iocage/jails" \
                  | grep -E \
               "^$pool/iocage/jails/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}$")"
 
     if [ "${name}" == "ALL" ] ; then
-        for jail in $jails ; do
-            echo $jail
+        for jail in ${jails} ; do
+            echo "${jail}"
         done
     else
         for jail in $jails ; do
-            found="$(echo $jail |grep -iE "^${pool}/iocage/jails/${name}"|wc \
-                      -l | sed -e 's/^  *//')"
-            local tag="$(zfs get -H -o value org.freebsd.iocage:tag $jail)"
+            found="$(echo "${jail}" |grep -iE "^${pool}/iocage/jails/${name}"|\
+                    wc -l|sed -e 's/^  *//')"
+            local tag="$(zfs get -H -o value org.freebsd.iocage:tag "${jail}")"
 
-            if [ "$found" -eq 1 ] ; then
-                echo $jail >> $jlist
+            if [ "${found}" -eq 1 ] ; then
+                echo "${jail}" >> "${jlist}"
             fi
 
-            if [ $tag == $name ] ; then
-                echo $jail >> $jlist
+            if [ "${tag}" == "${name}" ] ; then
+                echo "${jail}" >> "${jlist}"
             fi
         done
 
-        if [ ! -e $jlist ] ; then
+        if [ ! -e "${jlist}" ] ; then
             exit 0
         fi
 
@@ -1041,97 +1040,97 @@ __find_jail () {
         fi
     fi
 
-    rm  -f $jlist
+    rm  -f "${jlist}"
 }
 
 __start_jail () {
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail $name)"
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
-    local jail_type="$(__get_jail_prop type $fulluuid)"
-    local tag="$(__get_jail_prop tag $fulluuid)"
-    local jail_hostid="$(__get_jail_prop hostid $fulluuid)"
-    local jail_path="$(__get_jail_prop mountpoint $fulluuid)"
-    local template="$(__get_jail_prop template $fulluuid)"
-    local cpuset="$(__get_jail_prop cpuset $fulluuid)"
-    local procfs="$(__get_jail_prop mount_procfs $fulluuid)"
-    local jail_path="$(__get_jail_prop mountpoint $fulluuid)"
-    local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+    local fulluuid="$(__check_name "${name}")"
+    local jail_type="$(__get_jail_prop type "${fulluuid}")"
+    local tag="$(__get_jail_prop tag "${fulluuid}")"
+    local jail_hostid="$(__get_jail_prop hostid "${fulluuid}")"
+    local jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local template="$(__get_jail_prop template "${fulluuid}")"
+    local cpuset="$(__get_jail_prop cpuset "${fulluuid}")"
+    local procfs="$(__get_jail_prop mount_procfs "${fulluuid}")"
+    local jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local vnet="$(__get_jail_prop vnet $fulluuid)"
-    local nics="$(__get_jail_prop interfaces $fulluuid \
+    local vnet="$(__get_jail_prop vnet "${fulluuid}")"
+    local nics="$(__get_jail_prop interfaces "${fulluuid}" \
                |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
 
-    if [ "$state" -eq "1" ] ; then
+    if [ "${state}" -eq "1" ] ; then
         echo "* ${fulluuid}: is already up"
         exit 1
     fi
 
-    if [ $jail_type == "basejail" ] ; then
+    if [ "${jail_type}" == "basejail" ] ; then
         # Re-clone required filesystems
-        __reclone_basejail $name
+        __reclone_basejail "${name}"
     fi
 
-    for i in $nics ; do
-        local nic="$(echo $i | awk 'BEGIN { FS = ":" } ; { print $1 }')"
-        local bridge="$(echo $i | awk 'BEGIN { FS = ":" } ; { print $2 }')"
+    for i in ${nics} ; do
+        local nic="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
+        local bridge="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
 
-        if [ -z $nic ] || [ -z $bridge ] ; then
+        if [ -z "${nic}" ] || [ -z "${bridge}" ] ; then
             echo "  ERROR  : incorrect interfaces property format"
-            echo "  HINT   : check with \"iocage get interfaces $fulluuid\""
+            echo "  HINT   : check with \"iocage get interfaces ${fulluuid}\""
             echo "  Example: vnet0:bridge0"
             exit 1
         fi
     done
 
-    if [ $template == "yes" ] ; then
+    if [ "${template}" == "yes" ] ; then
         return
     fi
 
-    if [ "$jail_hostid" != "$hostid" ] ; then
+    if [ "${jail_hostid}" != "${hostid}" ] ; then
         echo "ERROR: hostid mismatch, start failed!"
-        echo "    jail hostid: $jail_hostid"
-        echo "  host's hostid: $hostid"
+        echo "    jail hostid: ${jail_hostid}"
+        echo "  hosts hostid: ${hostid}"
         exit 1
     fi
 
-    if [ "$procfs" == "1" ] ; then
-        mount -t procfs proc $iocroot/jails/${fulluuid}/root/proc
+    if [ "${procfs}" == "1" ] ; then
+        mount -t procfs proc "${iocroot}/jails/${fulluuid}/root/proc"
     fi
 
-    local jzfs="$(__get_jail_prop jail_zfs $fulluuid)"
-    local jzfs_dataset="$(__get_jail_prop jail_zfs_dataset $fulluuid)"
+    local jzfs="$(__get_jail_prop jail_zfs "${fulluuid}")"
+    local jzfs_dataset="$(__get_jail_prop jail_zfs_dataset "${fulluuid}")"
 
-    if [ $jzfs == "on" ] ; then
-        __set_jail_prop allow_mount=1 $fulluuid
-        __set_jail_prop enforce_statfs=1 $fulluuid
-        __set_jail_prop allow_mount_zfs=1 $fulluuid
-        zfs set jailed=on ${pool}/$jzfs_dataset
+    if [ "${jzfs}" == "on" ] ; then
+        __set_jail_prop allow_mount=1 "${fulluuid}"
+        __set_jail_prop enforce_statfs=1 "${fulluuid}"
+        __set_jail_prop allow_mount_zfs=1 "${fulluuid}"
+        zfs set jailed=on "${pool}/${jzfs_dataset}"
     fi
 
-    if [ $vnet == "on" ] || [ $vnet == "-" ] ; then
-        if [ ! -z $(sysctl -qn kern.features.vimage) ] ; then
-            echo "* Starting $fulluuid ($tag)"
-            __vnet_start $fulluuid
+    if [ "${vnet}" == "on" ] || [ "${vnet}" == "-" ] ; then
+        if [ ! -z "$(sysctl -qn kern.features.vimage)" ] ; then
+            echo "* Starting ${fulluuid} (${tag})"
+            __vnet_start "${fulluuid}"
 
-            if [ $? -eq 1 ] ; then
+            if [ "${?}" -eq 1 ] ; then
                 echo "  ! Start                FAILED"
                 exit 1
             else
@@ -1139,38 +1138,38 @@ __start_jail () {
             fi
 
             echo -n "  + Configuring VNET"
-            __networking start $fulluuid
+            __networking start "${fulluuid}"
 
-            if [ $? -eq 1 ] ; then
+            if [ "${?}" -eq 1 ] ; then
                 echo "         FAILED"
             else
                 echo "         OK"
             fi
         else
-            echo "  ERR: start failed for $fulluuid"
+            echo "  ERR: start failed for ${fulluuid}"
             echo "  vnet=on but kernel is not VNET capable!"
             echo "  Turn vnet off for this jail or recompile kernel with VNET."
             exit 1
         fi
     else
-        echo "* Starting $fulluuid ($tag)"
-        __legacy_start $fulluuid
-        if [ $? -eq 1 ] ; then
+        echo "* Starting ${fulluuid} (${tag})"
+        __legacy_start "${fulluuid}"
+        if [ "${?}" -eq 1 ] ; then
             echo "  ! Start                FAILED"
         else
             echo "  + Started (shared IP mode) OK"
         fi
     fi
 
-    cd ${jail_path}/root/dev && ln -s ../var/run/log log
+    cd "${jail_path}/root/dev" && ln -s ../var/run/log log
 
-    __rctl_limits $fulluuid
+    __rctl_limits "${fulluuid}"
 
-    if [ $cpuset != "off" ] ; then
+    if [ "${cpuset}" != "off" ] ; then
         echo -n "  + Appliyng CPU affinity"
-        local jid="$(jls -j ioc-${fulluuid} jid)"
-        cpuset -l $cpuset -j $jid
-        if [ $? -eq 1 ] ; then
+        local jid="$(jls -j "ioc-${fulluuid}" jid)"
+        cpuset -l "${cpuset}" -j "${jid}"
+        if [ "${?}" -eq 1 ] ; then
             echo "    FAILED"
         else
             echo "    OK"
@@ -1178,29 +1177,30 @@ __start_jail () {
     fi
 
     echo -n "  + Starting services"
-    jexec ioc-${fulluuid} $(__get_jail_prop exec_start $fulluuid) \
-     >> $iocroot/log/${fulluuid}-console.log 2>&1
+    jexec "ioc-${fulluuid}" $(__get_jail_prop exec_start "$fulluuid") \
+     >> "${iocroot}/log/${fulluuid}-console.log" 2>&1
 
-    if [ $? -eq 1 ] ; then
+    if [ "${?}" -eq 1 ] ; then
         echo "        FAILED"
     else
         echo "        OK"
     fi
 
-    if [ $jzfs == "on" ] ; then
-        zfs jail ioc-${fulluuid} ${pool}/$jzfs_dataset
+    if [ "${jzfs}" == "on" ] ; then
+        zfs jail "ioc-${fulluuid}" "${pool}/${jzfs_dataset}"
     fi
 
-    zfs set org.freebsd.iocage:last_started=$(date "+%F_%T") $dataset
+    zfs set org.freebsd.iocage:last_started="$(date "+%F_%T")" "${dataset}"
 
 }
 
 # Start a VNET jail
 __vnet_start () {
-    local name="$1"
-    local jail_path="$(__get_jail_prop mountpoint $name)"
-    local fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs $name)"
-    local tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs $name)"
+    local name="${1}"
+    local jail_path="$(__get_jail_prop mountpoint "${name}")"
+    local fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs "${name}")"
+    local tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs "${name}")"
+
 
     if [ "$(uname -U)" == "903000" ];
     then
@@ -1209,35 +1209,34 @@ __vnet_start () {
     fi
 
     jail -c vnet \
-    name="ioc-$(__get_jail_prop host_hostuuid $name)" \
-    host.hostname="$(__get_jail_prop hostname $name)" \
+    name="ioc-$(__get_jail_prop host_hostuuid "${name}")" \
+    host.hostname="$(__get_jail_prop hostname "${name}")" \
     path="${jail_path}/root" \
-    securelevel="$(__get_jail_prop securelevel $name)" \
-    host.hostuuid="$(__get_jail_prop host_hostuuid $name)" \
-    devfs_ruleset="$(__get_jail_prop devfs_ruleset $name)" \
-    enforce_statfs="$(__get_jail_prop enforce_statfs $name)" \
-    children.max="$(__get_jail_prop children_max $name)" \
-    allow.set_hostname="$(__get_jail_prop allow_set_hostname $name)" \
-    allow.sysvipc="$(__get_jail_prop allow_sysvipc $name)" \
-    allow.raw_sockets="$(__get_jail_prop allow_raw_sockets $name)" \
-    allow.chflags="$(__get_jail_prop allow_chflags $name)" \
-    allow.mount="$(__get_jail_prop allow_mount $name)" \
-    allow.mount.devfs="$(__get_jail_prop allow_mount_devfs $name)" \
-    allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs $name)" \
-    allow.mount.procfs="$(__get_jail_prop allow_mount_procfs $name)" \
+    securelevel="$(__get_jail_prop securelevel "${name}")" \
+    host.hostuuid="$(__get_jail_prop host_hostuuid "${name}")" \
+    devfs_ruleset="$(__get_jail_prop devfs_ruleset "${name}")" \
+    enforce_statfs="$(__get_jail_prop enforce_statfs "${name}")" \
+    children.max="$(__get_jail_prop children_max "${name}")" \
+    allow.set_hostname="$(__get_jail_prop allow_set_hostname "${name}")" \
+    allow.sysvipc="$(__get_jail_prop allow_sysvipc "${name}")" \
+    allow.raw_sockets="$(__get_jail_prop allow_raw_sockets "${name}")" \
+    allow.chflags="$(__get_jail_prop allow_chflags "${name}")" \
+    allow.mount="$(__get_jail_prop allow_mount "${name}")" \
+    allow.mount.devfs="$(__get_jail_prop allow_mount_devfs "${name}")" \
+    allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs "${name}")" \
+    allow.mount.procfs="$(__get_jail_prop allow_mount_procfs "${name}")" \
     ${tmpfs} \
-    allow.mount.zfs="$(__get_jail_prop allow_mount_zfs $name)" \
-    allow.quotas="$(__get_jail_prop allow_quotas $name)" \
-    allow.socket_af="$(__get_jail_prop allow_socket_af $name)" \
-    exec.prestart="$(__findscript $name prestart)" \
-    exec.poststart="$(__findscript $name poststart)" \
-    exec.prestop="$(__findscript $name prestop)" \
-    exec.stop="$(__get_jail_prop exec_stop $name)" \
-    exec.clean="$(__get_jail_prop exec_clean $name)" \
-    exec.timeout="$(__get_jail_prop exec_timeout $name)" \
-    stop.timeout="$(__get_jail_prop stop_timeout $name)" \
+    allow.mount.zfs="$(__get_jail_prop allow_mount_zfs "${name}")" \
+    allow.quotas="$(__get_jail_prop allow_quotas "${name}")" \
+    allow.socket_af="$(__get_jail_prop allow_socket_af "${name}")" \
+    exec.poststart="$(__findscript "${name}" poststart)" \
+    exec.prestop="$(__findscript "${name}" prestop)" \
+    exec.stop="$(__get_jail_prop exec_stop "${name}")" \
+    exec.clean="$(__get_jail_prop exec_clean "${name}")" \
+    exec.timeout="$(__get_jail_prop exec_timeout "${name}")" \
+    stop.timeout="$(__get_jail_prop stop_timeout "${name}")" \
     mount.fstab="${jail_path}/fstab" \
-    mount.devfs="$(__get_jail_prop mount_devfs $name)" \
+    mount.devfs="$(__get_jail_prop mount_devfs "${name}")" \
     ${fdescfs} \
     allow.dying \
     exec.consolelog="$iocroot/log/${name}-console.log" \
@@ -1246,13 +1245,13 @@ __vnet_start () {
 
 # Start a shared IP jail
 __legacy_start () {
-    local name="$1"
-    local jail_path="$(__get_jail_prop mountpoint $name)"
-    local ip4_addr="$(__get_jail_prop ip4_addr $name)"
-    local ip6_addr="$(__get_jail_prop ip6_addr $name)"
+    local name="${1}"
+    local jail_path="$(__get_jail_prop mountpoint "${name}")"
+    local ip4_addr="$(__get_jail_prop ip4_addr "${name}")"
+    local ip6_addr="$(__get_jail_prop ip6_addr "${name}")"
 
-    local fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs $name)"
-    local tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs $name)"
+    local fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs "${name}")"
+    local tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs "${name}")"
 
     if [ "$(uname -U)" == "903000" ];
     then
@@ -1261,136 +1260,137 @@ __legacy_start () {
     fi
 
 
-    if [ $ip4_addr == "none" ] ; then
+    if [ "${ip4_addr}" == "none" ] ; then
         ip4_addr=""
     fi
 
-    if [ $ip6_addr == "none" ] ; then
+    if [ "${ip6_addr}" == "none" ] ; then
         ip6_addr=""
     fi
 
-    if [ $ipv6 == "on" ] ; then
+    if [ "${ipv6}" == "on" ] ; then
         jail -c \
-        ip4.addr="$ip4_addr" \
-        ip4.saddrsel="$(__get_jail_prop ip4_saddrsel $name)" \
-        ip4="$(__get_jail_prop ip4 $name)" \
-        ip6.addr="$ip6_addr" \
-        ip6.saddrsel="$(__get_jail_prop ip6_saddrsel $name)" \
-        ip6="$(__get_jail_prop ip6 $name)" \
-        name="ioc-$(__get_jail_prop host_hostuuid $name)" \
-        host.hostname="$(__get_jail_prop hostname $name)" \
+        ip4.addr="${ip4_addr}" \
+        ip4.saddrsel="$(__get_jail_prop ip4_saddrsel "${name}")" \
+        ip4="$(__get_jail_prop ip4 "${name}")" \
+        ip6.addr="${ip6_addr}" \
+        ip6.saddrsel="$(__get_jail_prop ip6_saddrsel "${name}")" \
+        ip6="$(__get_jail_prop ip6 "${name}")" \
+        name="ioc-$(__get_jail_prop host_hostuuid "${name}")" \
+        host.hostname="$(__get_jail_prop hostname "${name}")" \
         path="${jail_path}/root" \
-        securelevel="$(__get_jail_prop securelevel $name)" \
-        host.hostuuid="$(__get_jail_prop host_hostuuid $name)" \
-        devfs_ruleset="$(__get_jail_prop devfs_ruleset $name)" \
-        enforce_statfs="$(__get_jail_prop enforce_statfs $name)" \
-        children.max="$(__get_jail_prop children_max $name)" \
-        allow.set_hostname="$(__get_jail_prop allow_set_hostname $name)" \
-        allow.sysvipc="$(__get_jail_prop allow_sysvipc $name)" \
-        allow.raw_sockets="$(__get_jail_prop allow_raw_sockets $name)" \
-        allow.chflags="$(__get_jail_prop allow_chflags $name)" \
-        allow.mount="$(__get_jail_prop allow_mount $name)" \
-        allow.mount.devfs="$(__get_jail_prop allow_mount_devfs $name)" \
-        allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs $name)" \
-        allow.mount.procfs="$(__get_jail_prop allow_mount_procfs $name)" \
-	${tmpfs} \
-        allow.mount.zfs="$(__get_jail_prop allow_mount_zfs $name)" \
-        allow.quotas="$(__get_jail_prop allow_quotas $name)" \
-        allow.socket_af="$(__get_jail_prop allow_socket_af $name)" \
-        exec.prestart="$(__findscript $name prestart)" \
-        exec.poststart="$(__findscript $name poststart)" \
-        exec.prestop="$(__findscript $name prestop)" \
-        exec.stop="$(__get_jail_prop exec_stop $name)" \
-        exec.clean="$(__get_jail_prop exec_clean $name)" \
-        exec.timeout="$(__get_jail_prop exec_timeout $name)" \
-        stop.timeout="$(__get_jail_prop stop_timeout $name)" \
+        securelevel="$(__get_jail_prop securelevel "${name}")" \
+        host.hostuuid="$(__get_jail_prop host_hostuuid "${name}")" \
+        devfs_ruleset="$(__get_jail_prop devfs_ruleset "${name}")" \
+        enforce_statfs="$(__get_jail_prop enforce_statfs "${name}")" \
+        children.max="$(__get_jail_prop children_max "${name}")" \
+        allow.set_hostname="$(__get_jail_prop allow_set_hostname "${name}")" \
+        allow.sysvipc="$(__get_jail_prop allow_sysvipc "${name}")" \
+        allow.raw_sockets="$(__get_jail_prop allow_raw_sockets "${name}")" \
+        allow.chflags="$(__get_jail_prop allow_chflags "${name}")" \
+        allow.mount="$(__get_jail_prop allow_mount "${name}")" \
+        allow.mount.devfs="$(__get_jail_prop allow_mount_devfs "${name}")" \
+        allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs "${name}")" \
+        allow.mount.procfs="$(__get_jail_prop allow_mount_procfs "${name}")" \
+        ${tmpfs} \
+        allow.mount.zfs="$(__get_jail_prop allow_mount_zfs "${name}")" \
+        allow.quotas="$(__get_jail_prop allow_quotas "${name}")" \
+        allow.socket_af="$(__get_jail_prop allow_socket_af "${name}")" \
+        exec.prestart="$(__findscript "${name}" prestart)" \
+        exec.poststart="$(__findscript "${name}" poststart)" \
+        exec.prestop="$(__findscript "${name}" prestop)" \
+        exec.stop="$(__get_jail_prop exec_stop "${name}")" \
+        exec.clean="$(__get_jail_prop exec_clean "${name}")" \
+        exec.timeout="$(__get_jail_prop exec_timeout "${name}")" \
+        stop.timeout="$(__get_jail_prop stop_timeout "${name}")" \
         mount.fstab="${jail_path}/fstab" \
-        mount.devfs="$(__get_jail_prop mount_devfs $name)" \
-	${fdescfs} \
+        mount.devfs="$(__get_jail_prop mount_devfs "${name}")" \
+        ${fdescfs} \
         allow.dying \
-        exec.consolelog="$iocroot/log/${name}-console.log" \
+        exec.consolelog="${iocroot}/log/${name}-console.log" \
         persist
     else
         jail -c \
-        ip4.addr="$ip4_addr" \
-        ip4.saddrsel="$(__get_jail_prop ip4_saddrsel $name)" \
-        ip4="$(__get_jail_prop ip4 $name)" \
-        name="ioc-$(__get_jail_prop host_hostuuid $name)" \
-        host.hostname="$(__get_jail_prop hostname $name)" \
+        ip4.addr="${ip4_addr}" \
+        ip4.saddrsel="$(__get_jail_prop ip4_saddrsel "${name}")" \
+        ip4="$(__get_jail_prop ip4 "${name}")" \
+        name="ioc-$(__get_jail_prop host_hostuuid "${name}")" \
+        host.hostname="$(__get_jail_prop hostname "${name}")" \
         path="${jail_path}/root" \
-        securelevel="$(__get_jail_prop securelevel $name)" \
-        host.hostuuid="$(__get_jail_prop host_hostuuid $name)" \
-        devfs_ruleset="$(__get_jail_prop devfs_ruleset $name)" \
-        enforce_statfs="$(__get_jail_prop enforce_statfs $name)" \
-        children.max="$(__get_jail_prop children_max $name)" \
-        allow.set_hostname="$(__get_jail_prop allow_set_hostname $name)" \
-        allow.sysvipc="$(__get_jail_prop allow_sysvipc $name)" \
-        allow.raw_sockets="$(__get_jail_prop allow_raw_sockets $name)" \
-        allow.chflags="$(__get_jail_prop allow_chflags $name)" \
-        allow.mount="$(__get_jail_prop allow_mount $name)" \
-        allow.mount.devfs="$(__get_jail_prop allow_mount_devfs $name)" \
-        allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs $name)" \
-        allow.mount.procfs="$(__get_jail_prop allow_mount_procfs $name)" \
-	${tmpfs} \
-        allow.mount.zfs="$(__get_jail_prop allow_mount_zfs $name)" \
-        allow.quotas="$(__get_jail_prop allow_quotas $name)" \
-        allow.socket_af="$(__get_jail_prop allow_socket_af $name)" \
-        exec.prestart="$(__findscript $name prestart)" \
-        exec.poststart="$(__findscript $name poststart)" \
-        exec.prestop="$(__findscript $name prestop)" \
-        exec.stop="$(__get_jail_prop exec_stop $name)" \
-        exec.clean="$(__get_jail_prop exec_clean $name)" \
-        exec.timeout="$(__get_jail_prop exec_timeout $name)" \
-        stop.timeout="$(__get_jail_prop stop_timeout $name)" \
+        securelevel="$(__get_jail_prop securelevel "${name}")" \
+        host.hostuuid="$(__get_jail_prop host_hostuuid "${name}")" \
+        devfs_ruleset="$(__get_jail_prop devfs_ruleset "${name}")" \
+        enforce_statfs="$(__get_jail_prop enforce_statfs "${name}")" \
+        children.max="$(__get_jail_prop children_max "${name}")" \
+        allow.set_hostname="$(__get_jail_prop allow_set_hostname "${name}")" \
+        allow.sysvipc="$(__get_jail_prop allow_sysvipc "${name}")" \
+        allow.raw_sockets="$(__get_jail_prop allow_raw_sockets "${name}")" \
+        allow.chflags="$(__get_jail_prop allow_chflags "${name}")" \
+        allow.mount="$(__get_jail_prop allow_mount "${name}")" \
+        allow.mount.devfs="$(__get_jail_prop allow_mount_devfs "${name}")" \
+        allow.mount.nullfs="$(__get_jail_prop allow_mount_nullfs "${name}")" \
+        allow.mount.procfs="$(__get_jail_prop allow_mount_procfs "${name}")" \
+        ${tmpfs} \
+        allow.mount.zfs="$(__get_jail_prop allow_mount_zfs "${name}")" \
+        allow.quotas="$(__get_jail_prop allow_quotas "${name}")" \
+        allow.socket_af="$(__get_jail_prop allow_socket_af "${name}")" \
+        exec.prestart="$(__findscript "${name}" prestart)" \
+        exec.poststart="$(__findscript "${name}" poststart)" \
+        exec.prestop="$(__findscript "${name}" prestop)" \
+        exec.stop="$(__get_jail_prop exec_stop "${name}")" \
+        exec.clean="$(__get_jail_prop exec_clean "${name}")" \
+        exec.timeout="$(__get_jail_prop exec_timeout "${name}")" \
+        stop.timeout="$(__get_jail_prop stop_timeout "${name}")" \
         mount.fstab="${jail_path}/fstab" \
-        mount.devfs="$(__get_jail_prop mount_devfs $name)" \
-	${fdescfs} \
+        mount.devfs="$(__get_jail_prop mount_devfs "${name}")" \
+        ${fdescfs} \
         allow.dying \
-        exec.consolelog="$iocroot/log/${name}-console.log" \
+        exec.consolelog="${iocroot}/log/${name}-console.log" \
         persist
     fi
 }
 
 __stop_jail () {
-    local name="$1"
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset=$(__find_jail "${name}")
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
-    local jail_path="$(__get_jail_prop mountpoint $name)"
-    local tag="$(__get_jail_prop tag $fulluuid)"
-    local exec_prestop="$(__findscript $fulluuid prestop)"
-    local exec_stop="$(__get_jail_prop exec_stop $fulluuid)"
-    local exec_poststop="$(__findscript $fulluuid poststop)"
-    local vnet="$(__get_jail_prop vnet $fulluuid)"
-    local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+    local fulluuid="$(__check_name "${name}")"
+    local jail_path="$(__get_jail_prop mountpoint "${name}")"
+    local tag="$(__get_jail_prop tag "${fulluuid}")"
+    local exec_prestop="$(__findscript "${fulluuid}" prestop)"
+    local exec_stop="$(__get_jail_prop exec_stop "${fulluuid}")"
+    local exec_poststop="$(__findscript "${fulluuid}" poststop)"
+    local vnet="$(__get_jail_prop vnet "${fulluuid}")"
+    local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
-    if [  "$state" -lt "1" ] ; then
+
+    if [  "${state}" -lt "1" ] ; then
         echo "* ${fulluuid}: is already down"
         exit 1
     fi
 
-    echo "* Stopping $fulluuid ($tag)"
+    echo "* Stopping ${fulluuid} (${tag})"
 
     echo -n "  + Running pre-stop"
-    echo "$exec_prestop" | sh
-    if [ $? -ne 1 ] ; then
+    echo "${exec_prestop}" | sh
+    if [ "${?}" -ne 1 ] ; then
         echo "         OK"
     else
         echo "     FAILED"
@@ -1398,95 +1398,97 @@ __stop_jail () {
 
     echo -n "  + Stopping services"
 
-    jexec ioc-${fulluuid} $exec_stop >> $iocroot/log/${fulluuid}-console.log 2>&1
+    jexec "ioc-${fulluuid}" ${exec_stop} >> "${iocroot}/log/${fulluuid}-console.log" 2>&1
 
-    if [ $? -ne 1 ] ; then
+    if [ "${?}" -ne 1 ] ; then
         echo "        OK"
     else
         echo "    FAILED"
     fi
 
-    if [ $vnet == "on" ] ; then
+    if [ "${vnet}" == "on" ] ; then
         echo -n "  + Tearing down VNET"
-        __networking stop $fulluuid
-        if [ $? -eq 1 ] ; then
+        __networking stop "${fulluuid}"
+        if [ "${?}" -eq 1 ] ; then
             echo "        FAILED"
         else
             echo "        OK"
         fi
     else
-        __stop_legacy_networking $name
+        __stop_legacy_networking "${name}"
     fi
 
     echo -n "  + Removing jail process"
-    jail -r ioc-${fulluuid}
+    jail -r "ioc-${fulluuid}"
 
-    if [ $? -ne 1 ] ; then
+    if [ "${?}" -ne 1 ] ; then
         echo "    OK"
     else
         echo "FAILED"
     fi
 
     echo -n "  + Running post-stop"
-    echo "$exec_poststop" | sh
-    if [ $? -ne 1 ] ; then
+    echo "${exec_poststop}" | sh
+    if [ "${?}" -ne 1 ] ; then
         echo "        OK"
     else
         echo "    FAILED"
     fi
 
-    umount -afvF ${jail_path}/fstab > /dev/null 2>&1
-    umount ${jail_path}/root/dev/fd > /dev/null 2>&1
-    umount ${jail_path}/root/dev    > /dev/null 2>&1
-    umount ${jail_path}/root/proc   > /dev/null 2>&1
+    umount -afvF "${jail_path}/fstab" > /dev/null 2>&1
+    umount "${jail_path}/root/dev/fd" > /dev/null 2>&1
+    umount "${jail_path}/root/dev"    > /dev/null 2>&1
+    umount "${jail_path}/root/proc"   > /dev/null 2>&1
 
-    if [ -d $iocroot/jails/${fulluuid}/recorded ] ; then
-        umount -ft unionfs $iocroot/jails/${fulluuid}/root > /dev/null 2>&1
+    if [ -d "${iocroot}/jails/${fulluuid}/recorded" ] ; then
+        umount -ft unionfs "${iocroot}/jails/${fulluuid}/root" > /dev/null 2>&1
     fi
 
     if [ ! -z $(sysctl -qn kern.features.rctl) ] ; then
-        local rlimits="$(rctl | grep $fulluuid| wc -l | sed -e 's/^  *//' \
-                  | cut -d' ' -f1)"
-        if [ $rlimits -gt "0" ] ; then
-            rctl -r jail:ioc-${fulluuid}
+        local rlimits="$(rctl | grep "$fulluuid" | wc -l | sed -e 's/^  *//' \
+                | cut -d' ' -f1)"
+        if [ "${rlimits}" -gt "0" ] ; then
+            rctl -r "jail:ioc-${fulluuid}"
         fi
     fi
 }
 
 # Soft restart
 __restart_jail () {
-    local name="$1"
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail $name)"
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
-    local exec_stop="$(__get_jail_prop exec_stop $fulluuid)"
-    local exec_start="$(__get_jail_prop exec_start $fulluuid)"
-    local jid="$(jls -j ioc-${fulluuid} jid)"
-    local tag="$(__get_jail_prop tag $fulluuid)"
+    local fulluuid="$(__check_name "${name}")"
+    local exec_stop="$(__get_jail_prop exec_stop "${fulluuid}")"
+    local exec_start="$(__get_jail_prop exec_start "${fulluuid}")"
+    local jid="$(jls -j "ioc-${fulluuid}" jid)"
+    local tag="$(__get_jail_prop tag "${fulluuid}")"
 
-    echo "* Soft restarting $fulluuid ($tag)"
-    jexec ioc-${fulluuid} $exec_stop >> $iocroot/log/${fulluuid}-console.log 2>&1
+    echo "* Soft restarting ${fulluuid} (${tag})"
+    jexec "ioc-${fulluuid}" ${exec_stop} >> \
+      "${iocroot}/log/${fulluuid}-console.log" 2>&1
 
-    if [ $? -ne "1" ] ; then
-        pkill -j $jid
-        jexec ioc-${fulluuid} $exec_start >> $iocroot/log/${fulluuid}-console.log 2>&1
-        zfs set org.freebsd.iocage:last_started=$(date "+%F_%T") $dataset
+    if [ "${?}" -ne "1" ] ; then
+        pkill -j "${jid}"
+        jexec "ioc-${fulluuid}" ${exec_start} >> \
+          "${iocroot}/log/${fulluuid}-console.log" 2>&1
+        zfs set org.freebsd.iocage:last_started="$(date "+%F_%T")" "${dataset}"
     else
         echo "  ERROR: soft restart failed.."
         exit 1
@@ -1494,182 +1496,180 @@ __restart_jail () {
 }
 
 __rc_jails () {
-    local action=$1
-    local jails=$(__find_jail ALL)
-    local boot_list="/tmp/iocage.$$"
+    local action="${1}"
+    local jails=$(__find_jail "ALL")
+    local boot_list="/tmp/iocage.${$}"
 
-    for jail in $jails ; do
+    for jail in ${jails} ; do
         local name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
-                    $jail)"
-        local boot="$(zfs get -H -o value org.freebsd.iocage:boot $jail)"
+                    "${jail}")"
+        local boot="$(zfs get -H -o value org.freebsd.iocage:boot "${jail}")"
         local priority="$(zfs get -H -o value org.freebsd.iocage:priority \
-                        $jail)"
+                        "${jail}")"
 
-        if [ "$boot" == "on" ] ; then
-            echo "${priority},${name}" >> $boot_list
+        if [ "${boot}" == "on" ] ; then
+            echo "${priority},${name}" >> "${boot_list}"
         fi
     done
 
-    if [ -e $boot_list ] ; then
-        local boot_order=$(sort -n $boot_list)
-        local shutdown_order=$(sort -rn $boot_list)
+    if [ -e "${boot_list}" ] ; then
+        local boot_order="$(sort -n "${boot_list}")"
+        local shutdown_order="$(sort -rn "${boot_list}")"
     else
         echo "  ERROR: None of the jails have boot on"
         exit 1
     fi
 
-    if [ "$action" == "boot" ] ; then
+    if [ "${action}" == "boot" ] ; then
         echo "* [I|O|C] booting jails... "
 
-        for i in $boot_order ; do
-            local jail="$(echo $i | cut -f2 -d,)"
-            local jail_path="$(__get_jail_prop mountpoint $jail)"
-            local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+        for i in ${boot_order} ; do
+            local jail="$(echo "${i}" | cut -f2 -d,)"
+            local jail_path="$(__get_jail_prop mountpoint "${jail}")"
+            local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
                       | cut -d' ' -f1)"
-
-            if [ "$state" -lt "1" ] ; then
-                __start_jail $jail
+            if [ "${state}" -lt "1" ] ; then
+                __start_jail "${jail}"
             fi
         done
 
-    elif [ "$action" == "shutdown" ] ; then
+    elif [ "${action}" == "shutdown" ] ; then
         echo "* [I|O|C] shutting down jails... "
 
-        for i in $shutdown_order ; do
-            local jail="$(echo $i | cut -f2 -d,)"
-            local jail_path="$(__get_jail_prop mountpoint $jail)"
-            local state="$(jls | grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+        for i in ${shutdown_order} ; do
+            local jail="$(echo "${i}" | cut -f2 -d,)"
+            local jail_path="$(__get_jail_prop mountpoint "${jail}")"
+            local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
                       | cut -d' ' -f1)"
-
-            if [ "$state" -eq "1" ] ; then
-                __stop_jail $jail
+            if [ "${state}" -eq "1" ] ; then
+                __stop_jail "${jail}"
             fi
         done
 
     fi
 
-    rm $boot_list
+    rm "${boot_list}"
 }
 
 __list_jails () {
     local jails=$(__find_jail ALL)
-    local switch=$1
+    local switch="${1}"
     local all_jids=$(jls -N -h jid | grep -v -x jid )
     local ioc_jids=""
     local non_ioc_jids=""
 
-    if [ ! -z ${switch} ] && [ $switch == "-r" ] ; then
+    if [ ! -z "${switch}" ] && [ "${switch}" == "-r" ] ; then
         echo "Downloaded releases:"
-        local releases="$(zfs list -o name -Hr $pool/iocage/releases \
-                        | grep RELEASE$ | cut -d \/ -f 4)"
-        for rel in $(echo $releases) ; do
-            printf "%15s\n" "$rel"
+        local releases="$(zfs list -o name -Hr "${pool}/iocage/releases" \
+                        | grep RELEASE$ | cut -d '/' -f 4)"
+        for rel in ${releases} ; do
+            printf "%15s\n" "${rel}"
         done
         exit 0
     fi
 
     printf "%-4s  %-36s  %s  %s  %s\n" "JID" "UUID"  "BOOT"\
            "STATE" "TAG"
-    for jail in $jails ; do
-        uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid $jail)
-        boot=$(zfs get -H -o value org.freebsd.iocage:boot $jail)
-        tag=$(zfs get -H -o value org.freebsd.iocage:tag $jail)
-        jail_path=$(zfs get -H -o value mountpoint $jail)
-        state=$(jls | grep ${jail_path} | awk '{print$1}')
-        template=$(zfs get -H -o value org.freebsd.iocage:template $jail)
+    for jail in ${jails} ; do
+        uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid "${jail}")
+        boot=$(zfs get -H -o value org.freebsd.iocage:boot "${jail}")
+        tag=$(zfs get -H -o value org.freebsd.iocage:tag "${jail}")
+        jail_path=$(zfs get -H -o value mountpoint "${jail}")
+        state=$(jls | grep "${jail_path}" | awk '{print $1}')
+        template=$(zfs get -H -o value org.freebsd.iocage:template "${jail}")
         # get jid for iocage jails
-        jid=$(jls -j "ioc-"$uuid  -h jid 2> /dev/null | grep -v -x "jid")
-        if [ -z "$jid"  ] ; then
+        jid="$(jls -j "ioc-${uuid}"  -h jid 2> /dev/null | grep -v -x "jid")"
+        if [ -z "${jid}"  ] ; then
             jid="-"
         fi
-        local ioc_jids=$ioc_jids" "$jid
+        local ioc_jids="${ioc_jids} ${jid}"
 
-        if [ -z "$state" ] ; then
+        if [ -z "${state}" ] ; then
             state=down
         else
             state=up
         fi
 
-        if [ -z ${switch} ] ; then
+        if [ -z "${switch}" ] ; then
             switch=zero
         fi
 
-        if [ $switch == "-t" ] ; then
-            if [ $template == "yes" ] ; then
-                printf "%-4s  %-+.36s  %-3s   %-4s   %s\n" "$jid" "$uuid" \
-                "$boot" "$state" "$tag"
+        if [ "${switch}" == "-t" ] ; then
+            if [ "${template}" == "yes" ] ; then
+                printf "%-4s  %-+.36s  %-3s   %-4s   %s\n" "${jid}" "${uuid}" \
+                "${boot}" "${state}" "${tag}"
             fi
-        elif [ $switch != "-t" ] ; then
-            if [ $template != "yes" ] ; then
-                printf "%-4s  %-+.36s  %-4s  %-4s   %s\n" "$jid" "$uuid"  \
-                "$boot" "$state" "$tag"
+        elif [ "${switch}" != "-t" ] ; then
+            if [ "${template}" != "yes" ] ; then
+                printf "%-4s  %-+.36s  %-4s  %-4s   %s\n" "${jid}" "${uuid}"  \
+                "${boot}" "${state}" "${tag}"
             fi
         fi
     done
 
     # create list of active jids not registered in iocage
-    for all_jail in $all_jids ; do
-        for ioc_jail in $ioc_jids ; do
-            if [ "$all_jail" == "$ioc_jail" ] ; then
+    for all_jail in ${all_jids} ; do
+        for ioc_jail in ${ioc_jids} ; do
+            if [ "$all_jail" == "${ioc_jail}" ] ; then
                 local temp_loop_var=""
                 break
             else
-                local temp_loop_var=$all_jail
+                local temp_loop_var="${all_jail}"
 
             fi
         done
-    if [ -n "$temp_loop_var" ] ; then
-        local non_ioc_jids=$non_ioc_jids" "$temp_loop_var
+    if [ -n "${temp_loop_var}" ] ; then
+        local non_ioc_jids="${non_ioc_jids} ${temp_loop_var}"
     fi
     done
 
     # output non iocage jails currently active
-    if [ -n "$non_ioc_jids" ] ; then
-        if [ $switch != "-t" ] ; then
+    if [ -n "${non_ioc_jids}" ] ; then
+        if [ "${switch}" != "-t" ] ; then
             printf "%-+40s\n" "--- non iocage jails currently active ---"
             printf "%-4s  %-36s  %-15s  %s \n" "JID" "PATH"\
                   "IP4" "HOSTNAME"
-            for jid in $non_ioc_jids ; do
-                path=$(jls -j $jid  -h path | grep -v -x "path")
-                ip4=$(jls -j $jid  -h ip4.addr | grep -v -x "ip4.addr")
-                host_hostname=$(jls -j $jid  -h host.hostname | grep -v -x "host.hostname")
-                printf "%-4s  %-36.36s  %-15s  %s\n" "$jid" "$path"  \
-                        "$ip4" "$host_hostname"
+            for jid in ${non_ioc_jids} ; do
+                path=$(jls -j "${jid}"  -h path | grep -v -x "path")
+                ip4=$(jls -j "${jid}"  -h ip4.addr | grep -v -x "ip4.addr")
+                host_hostname=$(jls -j "${jid}"  -h host.hostname | grep -v -x "host.hostname")
+                printf "%-4s  %-36.36s  %-15s  %s\n" "${jid}" "${path}"  \
+                        "${ip4}" "${host_hostname}"
             done
         fi
     fi
 }
 
 __show () {
-    local jails=$(__find_jail ALL)
-    local prop="$1"
+    local jails="$(__find_jail ALL)"
+    local prop="${1}"
 
-    printf "%-36s  %s\n" "UUID" "$prop"
+    printf "%-36s  %s\n" "UUID" "${prop}"
 
-    for jail in $jails ; do
+    for jail in ${jails} ; do
         local name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
-                    $jail)"
-        local value="$(__get_jail_prop $prop $name)"
+                    "${jail}")"
+        local value="$(__get_jail_prop "${prop}" "${name}")"
 
-        printf "%-+.36s  %s\n" "$name"  "$value"
+        printf "%-+.36s  %s\n" "${name}"  "${value}"
     done
 }
 
 __print_disk () {
-    local jails=$(__find_jail ALL)
+    local jails="$(__find_jail ALL)"
 
     printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s\n" "UUID" "CRT" "RES" "QTA" "USE" "AVA"
 
-    for jail in $jails ; do
-        uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid $jail)
-        crt=$(zfs get -H -o value compressratio $jail)
-        res=$(zfs get -H -o value reservation $jail)
-        qta=$(zfs get -H -o value quota $jail)
-        use=$(zfs get -H -o value used $jail)
-        ava=$(zfs get -H -o value available $jail)
+    for jail in ${jails} ; do
+        uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid "${jail}")
+        crt=$(zfs get -H -o value compressratio "${jail}")
+        res=$(zfs get -H -o value reservation "${jail}")
+        qta=$(zfs get -H -o value quota "${jail}")
+        use=$(zfs get -H -o value used "${jail}")
+        ava=$(zfs get -H -o value available "${jail}")
 
-        printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s\n" "$uuid" "$crt" "$res" "$qta" \
-               "$use" "$ava"
+        printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s\n" "${uuid}" "${crt}" "${res}" "${qta}" \
+               "${use}" "${ava}"
     done
 }
 
@@ -1677,277 +1677,277 @@ __find_mypool () {
     pools="$(zpool list -H -o name)"
     found="0"
 
-    for i in $pools ; do
-        mypool="$(zpool get comment $i | grep -v NAME | awk '{print $3}')"
+    for i in ${pools} ; do
+        mypool="$(zpool get comment "${i}" | grep -v NAME | awk '{print $3}')"
 
-        if [ "$mypool" == "iocage" ] ; then
-            export pool=$i
+        if [ "${mypool}" == "iocage" ] ; then
+            export pool="${i}"
             found=1
             break
         fi
     done
 
-    if [ $found -ne 1 ] ; then
-        if [ -n "$RC_PID" ]; then
+    if [ "${found}" -ne 1 ] ; then
+        if [ -n "${RC_PID}" ]; then
             # RC_PID set means we are running from rc
             echo "ERROR: No pool for iocage jails found on boot ..exiting"
             exit 1
         else
-            echo -n "  please select a pool for iocage jails [$i]: "
+            echo -n "  please select a pool for iocage jails [${i}]: "
             read answer
 
-            if [ -z "$answer" ] ; then
-                answer=$i
+            if [ -z "${answer}" ] ; then
+                answer="${i}"
             fi
 
-            zpool set comment=iocage $answer
-            export pool=$answer
+            zpool set comment=iocage "${answer}"
+            export pool="${answer}"
         fi
     fi
 }
 
 __networking () {
-    action="$1"
-    local name="$2"
-    local jid="$(jls -j ioc-$name jid)"
-    local ip4="$(__get_jail_prop ip4_addr $name)"
-    local ip6="$(__get_jail_prop ip6_addr $name)"
-    local defaultgw="$(__get_jail_prop defaultrouter $name)"
-    local defaultgw6="$(__get_jail_prop defaultrouter6 $name)"
-    local nics="$(__get_jail_prop interfaces $name \
+    action="${1}"
+    local name="${2}"
+    local jid="$(jls -j "ioc-${name}" jid)"
+    local ip4="$(__get_jail_prop ip4_addr "${name}")"
+    local ip6="$(__get_jail_prop ip6_addr "${name}")"
+    local defaultgw="$(__get_jail_prop defaultrouter "${name}")"
+    local defaultgw6="$(__get_jail_prop defaultrouter6 "${name}")"
+    local nics="$(__get_jail_prop interfaces "${name}" \
                |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
-    local ip4_list="$(echo $ip4 | sed 's/,/ /g')"
-    local ip6_list="$(echo $ip6 | sed 's/,/ /g')"
+    local ip4_list="$(echo "${ip4}" | sed 's/,/ /g')"
+    local ip6_list="$(echo "${ip6}" | sed 's/,/ /g')"
 
-    if [ $action == "start" ] ; then
-        for i in $nics ; do
-            local nic=$(echo $i | awk 'BEGIN { FS = ":" } ; { print $1 }')
-            local bridge=$(echo $i | awk 'BEGIN { FS = ":" } ; { print $2 }')
-	    local memberif=$(ifconfig $bridge | grep member | head -n1 | cut -d' ' -f2)
-	    local brmtu=$(ifconfig $memberif | head -n1 |cut -d' ' -f6)
+    if [ "${action}" == "start" ] ; then
+        for i in ${nics} ; do
+            local nic=$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')
+            local bridge=$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')
+	    local memberif=$(ifconfig "${bridge}" | grep member | head -n1 | cut -d' ' -f2)
+	    local brmtu=$(ifconfig "${memberif}" | head -n1 |cut -d' ' -f6)
             epair_a=$(ifconfig epair create)
-            epair_b=$(echo $epair_a | sed s/a\$/b/)
-            ifconfig ${epair_a} name ${nic}:${jid} mtu $brmtu
-            ifconfig ${nic}:${jid} description "associated with jail: $name"
-            ifconfig $epair_b vnet ioc-${2}
-            jexec ioc-${2} ifconfig $epair_b name $nic mtu $brmtu
-            ifconfig $bridge addm ${nic}:${jid} up
-            ifconfig ${nic}:${jid} up
+            epair_b=$(echo "${epair_a}" | sed s/a\$/b/)
+            ifconfig "${epair_a}" name "${nic}:${jid}" mtu "${brmtu}"
+            ifconfig "${nic}:${jid}" description "associated with jail: ${name}"
+            ifconfig "${epair_b}" vnet "ioc-${2}"
+            jexec "ioc-${2}" ifconfig "${epair_b}" name "${nic}" mtu "${brmtu}"
+            ifconfig "${bridge}" addm "${nic}:${jid}" up
+            ifconfig "${nic}:${jid}" up
         done
 
-        if [ "$ip4" != "none" ] ; then
-            for i in $ip4_list ; do
-                iface="$(echo $i |awk 'BEGIN { FS = "|" } ; { print $1 }')"
-                ip="$(echo $i |awk 'BEGIN { FS = "|" } ; { print $2 }')"
-                jexec ioc-${2} ifconfig $iface $ip up
+        if [ "${ip4}" != "none" ] ; then
+            for i in ${ip4_list} ; do
+                iface="$(echo "${i}" |awk 'BEGIN { FS = "|" } ; { print $1 }')"
+                ip="$(echo "${i}" |awk 'BEGIN { FS = "|" } ; { print $2 }')"
+                jexec "ioc-${2}" ifconfig "${iface}" "${ip}" up
             done
         fi
 
-        if [ "$ip6" != "none" ] ; then
+        if [ "${ip6}" != "none" ] ; then
             for i in $ip6_list ; do
-                iface="$(echo $i |awk 'BEGIN { FS = "|" } ; { print $1 }')"
-                ip="$(echo $i |awk 'BEGIN { FS = "|" } ; { print $2 }')"
-                jexec ioc-${2} ifconfig $iface inet6 $ip up
+                iface="$(echo "${i}" |awk 'BEGIN { FS = "|" } ; { print $1 }')"
+                ip="$(echo "${i}" |awk 'BEGIN { FS = "|" } ; { print $2 }')"
+                jexec "ioc-${2}" ifconfig "${iface}" inet6 "${ip}" up
             done
         fi
 
-        if [ "$defaultgw" != "none" ] ; then
-            jexec ioc-${2} route add default $defaultgw > /dev/null
+        if [ "${defaultgw}" != "none" ] ; then
+            jexec "ioc-${2}" route add default "${defaultgw}" > /dev/null
         fi
 
 	if [ "$defaultgw6" != "none" ] ; then
-	    jexec ioc-${2} route add -6 default $defaultgw6 >/dev/null
+	    jexec "ioc-${2}" route add -6 default "${defaultgw6}" >/dev/null
 	fi
 
-    elif [ $action == "stop" ] ; then
-        for if in $nics ; do
-            local nic=$(echo $if | cut -f 1 -d:)
-            ifconfig ${nic}:${jid} destroy
+    elif [ "${action}" == "stop" ] ; then
+        for if in ${nics} ; do
+            local nic=$(echo "${if}" | cut -f 1 -d:)
+            ifconfig "${nic}:${jid}" destroy
         done
     fi
 }
 
 __stop_legacy_networking () {
-    local name="$1"
+    local name="${1}"
 
-    local ip4_addr="$(__get_jail_prop ip4_addr $name)"
-    local ip6_addr="$(__get_jail_prop ip6_addr $name)"
+    local ip4_addr="$(__get_jail_prop ip4_addr "${name}")"
+    local ip6_addr="$(__get_jail_prop ip6_addr "${name}")"
 
-    if [ $ip4_addr != "none" ] ; then
+    if [ "${ip4_addr}" != "none" ] ; then
         IFS=','
-        for ip in $ip4_addr ; do
-            local iface="$(echo $ip | \
+        for ip in ${ip4_addr} ; do
+            local iface="$(echo "${ip}" | \
                          awk 'BEGIN { FS = "|" } ; { print $1 }')"
-            local ip4="$(echo $ip | \
+            local ip4="$(echo "${ip}" | \
                        awk 'BEGIN { FS = "|" } ; { print $2 }' | \
                        awk 'BEGIN { FS = "/" } ; { print $1 }')"
 
-            ifconfig $iface $ip4 -alias
+            ifconfig "${iface}" "${ip4}" -alias
         done
     fi
 
-    if [ $ip6_addr != "none" ] ; then
+    if [ "${ip6_addr}" != "none" ] ; then
         IFS=','
-        for ip6 in $ip6_addr ; do
-            local iface="$(echo $ip6 | \
+        for ip6 in ${ip6_addr} ; do
+            local iface="$(echo "${ip6}" | \
                          awk 'BEGIN { FS = "|" } ; { print $1 }')"
-            local ip6="$(echo $ip6 | \
+            local ip6="$(echo "${ip6}" | \
                        awk 'BEGIN { FS = "|" } ; { print $2 }' | \
                        awk 'BEGIN { FS = "/" } ; { print $1 }')"
-            ifconfig $iface inet6 $ip6 -alias
+            ifconfig "${iface}" inet6 "${ip6}" -alias
         done
     fi
 }
 
 __rctl_limits () {
-    local name="$1"
+    local name="${1}"
     local failed=0
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
-    local rlimits="$(__get_jail_prop rlimits $fulluuid)"
+    local rlimits="$(__get_jail_prop rlimits "${fulluuid}")"
 
-    if [ $rlimits == "on" ] ; then
+    if [ "${rlimits}" == "on" ] ; then
         echo -n "  + Applying resource limits"
-        for prop in $CONF_RCTL ; do
-            value="$(__get_jail_prop $prop $fulluuid)"
-            limit=$(echo $value | awk 'BEGIN { FS = ":" } ; { print $1 }')
-            action=$(echo $value | awk 'BEGIN { FS = ":" } ; { print $2 }')
+        for prop in ${CONF_RCTL} ; do
+            value="$(__get_jail_prop "${prop}" "${fulluuid}")"
+            limit=$(echo "${value}" | awk 'BEGIN { FS = ":" } ; { print $1 }')
+            action=$(echo "${value}" | awk 'BEGIN { FS = ":" } ; { print $2 }')
 
-            if [ $limit == "off" ] ; then
+            if [ "${limit}" == "off" ] ; then
                 continue
             else
-                if [ -z "$limit" ] || [ -z "$action" ] ; then
-                    echo -n "  ERROR: incorrect resource limit: $limit action: "
-                    echo "$action for property: $prop"
+                if [ -z "${limit}" ] || [ -z "${action}" ] ; then
+                    echo -n "  ERROR: incorrect resource limit: ${limit} action: "
+                    echo "${action} for property: ${prop}"
                     echo "  HINT : check man page for syntax."
                 else
-                    rctl -a jail:ioc-${fulluuid}:${prop}:${action}=${limit}
-                    if [ $? -eq 1 ] ; then
+                    rctl -a "jail:ioc-${fulluuid}:${prop}:${action}=${limit}"
+                    if [ "${?}" -eq 1 ] ; then
                         echo "    FAILED to apply ${prop}=${action}:${limit}"
                         failed=1
                     fi
                 fi
             fi
         done
-        if [ $failed -ne 1 ] ; then
+        if [ "${failed}" -ne 1 ] ; then
             echo " OK"
         fi
     fi
 }
 
 __rctl_list () {
-    local name="$1"
+    local name="${1}"
 
-    if [ -z "$name" ] ; then
+    if [ -z "${name}" ] ; then
         echo "* All active limits:"
         rctl | grep jail
     else
-        local fulluuid="$(__check_name $name)"
-        local jid="$(jls -j ioc-${fulluuid} jid)"
-        local limits="$(rctl -h | grep $fulluuid)"
+        local fulluuid="$(__check_name "${name}")"
+        local jid="$(jls -j "ioc-${fulluuid}" jid)"
+        local limits="$(rctl -h | grep "${fulluuid}")"
 
-        echo "* Active limits for jail: $fulluuid"
+        echo "* Active limits for jail: ${fulluuid}"
 
-        for i in $limits ; do
-            limit=$(echo $i | cut -f 3,4 -d:)
-            echo "  - $limit"
+        for i in ${limits} ; do
+            limit=$(echo "${i}" | cut -f 3,4 -d:)
+            echo "  - ${limit}"
         done
 
-        if [ ! -z "$jid" ] ; then
-            echo "* CPU set: $(cpuset -g -j $jid | cut -f2 -d:)"
+        if [ ! -z "${jid}" ] ; then
+            echo "* CPU set: $(cpuset -g -j "${jid}" | cut -f2 -d:)"
         fi
     fi
 }
 
 __rctl_uncap () {
-    local name="$1"
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
     echo "  Releasing resource limits.."
-    rctl -r jail:ioc-${fulluuid}
+    rctl -r "jail:ioc-${fulluuid}"
     echo "  Listing active rules for jail:"
-    rctl | grep $fulluuid
+    rctl | grep "${fulluuid}"
 }
 
 
 __rctl_used () {
-    local name="$1"
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
     echo "Consumed resources:"
     echo "-------------------"
-    rctl -hu jail:ioc-${fulluuid}
+    rctl -hu "jail:ioc-${fulluuid}"
 }
 
 
 __console () {
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
-    local login_flags=$(zfs get -H -o value org.freebsd.iocage:login_flags \
-                       $pool/iocage/jails/$fulluuid)
+    local login_flags="$(zfs get -H -o value org.freebsd.iocage:login_flags \
+                       "${pool}/iocage/jails/${fulluuid}")"
 
-    jexec ioc-${fulluuid} login $login_flags
+    jexec "ioc-${fulluuid}" login ${login_flags}
 }
 
 
@@ -1955,119 +1955,119 @@ __exec () {
     local jexecopts=
 
     # check for -U or -u to pass to jexec
-    while getopts u:U: opt "$@"; do
-        case "$opt" in
-            [uU]) jexecopts="$jexecopts -$opt $OPTARG";;
-            ?)    echo "  ERROR: invalid exec option: $opt"
+    while getopts u:U: opt "${@}"; do
+        case "${opt}" in
+            [uU]) jexecopts="${jexecopts} -${opt} ${OPTARG}";;
+            ?)    echo "  ERROR: invalid exec option: ${opt}"
                   exit 1
                   ;;
         esac
     done
-    shift $(expr $OPTIND - 1)
+    shift $((OPTIND-1))
 
-    local name=$1
+    local name="${1}"
     shift
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
-    jexec $jexecopts ioc-${fulluuid} "$@"
+    jexec "${jexecopts}" "ioc-${fulluuid}" ${@}
 }
 
 
 __chroot () {
-    local name="$1"
-    local command="$2"
+    local name="${1}"
+    local command="${2}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
-    chroot $iocroot/jails/${fulluuid}/root $command
+    chroot "${iocroot}/jails/${fulluuid}/root" "${command}"
 }
 
 
 __snapshot () {
-    local name="$(echo $1 |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot="$(echo $1 |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    local name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
+    local snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local date=$(date "+%F_%T")
+    local date="$(date "+%F_%T")"
 
-    if [ ! -z $snapshot ] ; then
-        zfs snapshot -r ${dataset}@${snapshot}
+    if [ ! -z "${snapshot}" ] ; then
+        zfs snapshot -r "${dataset}@${snapshot}"
     else
-        zfs snapshot -r ${dataset}@ioc-${date}
+        zfs snapshot -r "${dataset}@ioc-${date}"
     fi
 }
 
 
 __snapremove () {
-    local name="$(echo $1 |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot="$(echo $1 |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    local name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
+    local snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
+    if [ -z "${dataset}" ] ; then
         echo "  ERROR: jail dataset not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    if [ ! -z $snapshot ] ; then
+    if [ ! -z "${snapshot}" ] ; then
         echo "* removing snapshot: ${snapshot}"
-        zfs destroy -r ${dataset}@${snapshot}
+        zfs destroy -r "${dataset}@${snapshot}"
     else
         echo "  ERROR: snapshot not found"
         exit 1
@@ -2075,180 +2075,180 @@ __snapremove () {
 }
 
 __snaplist () {
-    local name="$1"
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
-    local snapshots="$(zfs list -Hrt snapshot -d1 $dataset | awk '{print $1}')"
+    local fulluuid="$(__check_name "${name}")"
+    local snapshots="$(zfs list -Hrt snapshot -d1 "${dataset}" | awk '{print $1}')"
 
     printf "%-36s  %-21s  %s   %s\n" "NAME" "CREATED"\
             "RSIZE" "USED"
 
-    for i in $snapshots ; do
-        local snapname=$(echo $i|cut -f 2 -d \@)
-        local creation="$(zfs get -H -o value creation $i)"
-        local used="$(zfs get -H -o value used $i)"
-        local referenced="$(zfs get -H -o value referenced $i)"
+    for i in ${snapshots} ; do
+        local snapname=$(echo "${i}" |cut -f 2 -d \@)
+        local creation="$(zfs get -H -o value creation "${i}")"
+        local used="$(zfs get -H -o value used "${i}")"
+        local referenced="$(zfs get -H -o value referenced "${i}")"
 
-        printf "%-36s  %-21s  %s    %s\n" "$snapname" "$creation"\
-                   "$referenced" "$used"
+        printf "%-36s  %-21s  %s    %s\n" "${snapname}" "${creation}"\
+                   "${referenced}" "${used}"
     done
 
 }
 
 __rollback () {
-    local name="$(echo $1 |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot="$(echo $1 |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
-    local dataset=$(__find_jail $name)
+    local name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
+    local snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    local dataset=$(__find_jail "${name}")
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fs_list=$(zfs list -rH -o name $dataset)
+    local fs_list=$(zfs list -rH -o name "${dataset}")
 
-    if [ ! -z "$snapshot" ] ; then
-        for fs in $fs_list ; do
+    if [ ! -z "${snapshot}" ] ; then
+        for fs in ${fs_list} ; do
             echo "* Rolling back to ${fs}@${snapshot}"
-            zfs rollback -r ${fs}@${snapshot}
+            zfs rollback -r "${fs}@${snapshot}"
         done
     fi
 }
 
 
 __promote () {
-    local name="$1"
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fs_list=$(zfs list -rH -o name $dataset)
+    local fs_list="$(zfs list -rH -o name "${dataset}")"
 
-    if [ -z $dataset ] ; then
+    if [ -z "${dataset}" ] ; then
         echo "  ERROR: dataset not found"
         exit 1
     fi
 
-    for fs in $fs_list ; do
-        local origin="$(zfs get -H -o value origin $fs)"
+    for fs in ${fs_list} ; do
+        local origin="$(zfs get -H -o value origin "${fs}")"
 
-        if [ "$origin" != "-" ] ; then
-            echo "* promoting filesystem: $fs"
-            zfs promote $fs
+        if [ "${origin}" != "-" ] ; then
+            echo "* promoting filesystem: ${fs}"
+            zfs promote "${fs}"
             continue
         else
-            echo "  INFO: filesystem $fs is not a clone"
+            echo "  INFO: filesystem ${fs} is not a clone"
         fi
     done
 }
 
 __runtime () {
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
-    local state="$(jls -n -j ioc-${fulluuid} | wc -l | sed -e 's/^  *//' \
+    local state="$(jls -n -j "ioc-${fulluuid}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
-    if [ "$state" -eq "1" ] ; then
-        local params="$(jls -nj ioc-${fulluuid})"
-        for i in $params ; do
-            echo "  $i"
+    if [ "${state}" -eq "1" ] ; then
+        local params="$(jls -nj "ioc-${fulluuid}")"
+        for i in ${params} ; do
+            echo "  ${i}"
         done
     else
-        echo " ERROR: jail $fulluuid is not up.."
+        echo " ERROR: jail ${fulluuid} is not up.."
     fi
 }
 
 __update () {
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
-    local mountpoint="$(__get_jail_prop mountpoint $fulluuid)"
-    local date=$(date "+%F_%T")
-    local jail_type="$(__get_jail_prop type $fulluuid)"
-    local jail_release="$(__get_jail_prop release $fulluuid)"
+    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local date="$(date "+%F_%T")"
+    local jail_type="$(__get_jail_prop type "${fulluuid}")"
+    local jail_release="$(__get_jail_prop release "${fulluuid}")"
 
-    if [ $jail_type == "basejail" ] ; then
+    if [ "${jail_type}" == "basejail" ] ; then
         # Re-clone required filesystems
-        __reclone_basejail $name
+        __reclone_basejail "${name}"
     else
         echo "* creating back-out snapshot.."
-        __snapshot ${fulluuid}@ioc-update_${date}
+        __snapshot "${fulluuid}@ioc-update_${date}"
 
         echo "* Updating jail.."
-        env UNAME_r="$release" /usr/sbin/freebsd-update \
-            -b ${mountpoint}/root \
-            -d ${mountpoint}/root/var/db/freebsd-update/ fetch
-        env UNAME_r="$release" /usr/sbin/freebsd-update \
-            -b ${mountpoint}/root \
-            -d ${mountpoint}/root/var/db/freebsd-update/ install
+        env UNAME_r="${release}" /usr/sbin/freebsd-update \
+            -b "${mountpoint}/root" \
+            -d "${mountpoint}/root/var/db/freebsd-update/" fetch
+        env UNAME_r="${release}" /usr/sbin/freebsd-update \
+            -b "${mountpoint}/root" \
+            -d "${mountpoint}/root/var/db/freebsd-update/" install
 
         echo " "
         echo "* Once finished don't forget to remove the snapshot!"
@@ -2256,80 +2256,80 @@ __update () {
 }
 
 __upgrade () {
-    local name=$1
-    if [ -z $name ] ; then
+    local name="${1}"
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    if [ ! -d $iocroot/download/$release ] ; then
-        echo "  ERROR: $release not found."
+    if [ ! -d "${iocroot}/download/${release}" ] ; then
+        echo "  ERROR: ${release} not found."
         echo "  Please run iocage fetch first."
 	exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
-    local jail_type="$(__get_jail_prop type $fulluuid)"
-    local jail_release="$(__get_jail_prop release $fulluuid)"
-    local mountpoint="$(__get_jail_prop mountpoint $fulluuid)"
-    local date=$(date "+%F_%T")
-    local oldrelease="$(zfs get -H -o value org.freebsd.iocage:release $dataset)"
+    local fulluuid="$(__check_name "${name}")"
+    local jail_type="$(__get_jail_prop type "${fulluuid}")"
+    local jail_release="$(__get_jail_prop release "${fulluuid}")"
+    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local date="$(date "+%F_%T")"
+    local oldrelease="$(zfs get -H -o value org.freebsd.iocage:release "${dataset}")"
 
-    if [ $jail_type == "basejail" ] ; then
-        zfs set org.freebsd.iocage:release="$release" $dataset
+    if [ "${jail_type}" == "basejail" ] ; then
+        zfs set org.freebsd.iocage:release="${release}" "${dataset}"
         # Re-clone required filesystems
-        __reclone_basejail $name
-        cp -Rp ${mountpoint}/root/etc ${mountpoint}/root/etc.old
-        etcupdate -D ${mountpoint}/root -F \
-        -s $iocroot/base/$release/root/usr/src
-        chroot ${mountpoint}/root /bin/sh -c "newaliases"
+        __reclone_basejail "${name}"
+        cp -Rp "${mountpoint}/root/etc" "${mountpoint}/root/etc.old"
+        etcupdate -D "${mountpoint}/root" -F \
+        -s "${iocroot}/base/${release}/root/usr/src"
+        chroot "${mountpoint}/root" /bin/sh -c "newaliases"
 
-    if [ $? -eq 0 ] ; then
+    if [ "${?}" -eq 0 ] ; then
         echo ""
         echo "  Upgrade successful. Please restart jail and inspect. Remove ${mountpoint}/root/etc.old if everything is OK."
         exit 0
     else
         echo ""
         echo "  Mergemaster failed! Backing out."
-	zfs set org.freebsd.iocage:release="$oldrelease" $dataset
-	rm -rf ${mountpoint}/root/etc
-	mv ${mountpoint}/root/etc.old ${mountpoint}/root/etc
+	zfs set org.freebsd.iocage:release="${oldrelease}" "${dataset}"
+	rm -rf "${mountpoint}/root/etc"
+	mv "${mountpoint}/root/etc.old" "${mountpoint}/root/etc"
         exit 1
       fi
     fi
 
     echo "* creating back-out snapshot.."
-    __snapshot ${fulluuid}@ioc-upgrade_${date}
+    __snapshot "${fulluuid}@ioc-upgrade_${date}"
 
     echo "* Upgrading jail.."
 
-    env UNAME_r=${oldrelease} /usr/sbin/freebsd-update \
-    -b ${mountpoint}/root \
-    -d ${mountpoint}/root/var/db/freebsd-update/ \
-    -r $release upgrade
+    env UNAME_r="${oldrelease}" /usr/sbin/freebsd-update \
+    -b "${mountpoint}/root" \
+    -d "${mountpoint}/root/var/db/freebsd-update/" \
+    -r "${release}" upgrade
 
-    if [ $? -eq 0 ] ; then
-        while [ $? -eq 0 ] ; do
-        env UNAME_r=${oldrelease} /usr/sbin/freebsd-update \
-        -b ${mountpoint}/root \
-        -d ${mountpoint}/root/var/db/freebsd-update/ \
-        -r $release install
+    if [ "${?}" -eq 0 ] ; then
+        while [ "${?}" -eq 0 ] ; do
+        env UNAME_r="${oldrelease}" /usr/sbin/freebsd-update \
+        -b "${mountpoint}/root" \
+        -d "${mountpoint}/root/var/db/freebsd-update/" \
+        -r "${release}" install
     done
 
     # Set jail's zfs property to new release
-    zfs set org.freebsd.iocage:release="$release" $dataset
+    zfs set org.freebsd.iocage:release="${release}" "${dataset}"
     else
        echo "  Upgrade failed, aborting install."
        exit 1
@@ -2340,61 +2340,60 @@ __upgrade () {
 }
 
 __record () {
-    local name=$2
-    local action=$1
+    local name="${2}"
+    local action="${1}"
 
-    if [ -z $action ] ; then
+    if [ -z "${action}" ] ; then
         echo "  ERROR: missing action or UUID"
         exit 1
     fi
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing action or UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
-    local mountpoint="$(__get_jail_prop mountpoint $fulluuid)"
-    local union_mount="$(mount -t unionfs | grep $fulluuid | wc -l | \
+    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local union_mount="$(mount -t unionfs | grep "$fulluuid" | wc -l | \
                         sed -e 's/^  *//' | cut -d' ' -f1)"
-
-    if [ ! -d ${mountpoint}/recorded ] ; then
-        mkdir ${mountpoint}/recorded
+    if [ ! -d "${mountpoint}/recorded" ] ; then
+        mkdir "${mountpoint}/recorded"
     fi
 
 
-    if [ $action == "start" ] ; then
+    if [ "${action}" == "start" ] ; then
         echo "* Recording to: ${mountpoint}/recorded"
 
-        if [ $union_mount -lt 1 ] ; then
+        if [ "${union_mount}" -lt 1 ] ; then
             mount -t unionfs -o noatime,copymode=transparent \
-            ${mountpoint}/recorded/ ${mountpoint}/root
+            "${mountpoint}/recorded/" "${mountpoint}/root"
         fi
 
-    elif [ $action == "stop" ] ; then
-        umount -ft unionfs $iocroot/jails/${fulluuid}/root > /dev/null 2>&1
+    elif [ "${action}" == "stop" ] ; then
+        umount -ft unionfs "${iocroot}/jails/${fulluuid}/root" > /dev/null 2>&1
         echo "* Stopped recording to: ${mountpoint}/recorded"
 
-        find ${mountpoint}/recorded/ -type d -empty -exec rm -rf {} \; \
+        find "${mountpoint}/recorded/" -type d -empty -exec rm -rf {} \; \
         > /dev/null 2>&1
-        find ${mountpoint}/recorded/ -type f -size 0 -exec rm -f {} \; \
+        find "${mountpoint}/recorded/" -type f -size 0 -exec rm -f {} \; \
         > /dev/null 2>&1
-        find ${mountpoint}/recorded/ -name "utx.*" -exec rm -f {} \; \
+        find "${mountpoint}/recorded/" -name "utx.*" -exec rm -f {} \; \
         > /dev/null 2>&1
-        find ${mountpoint}/recorded/ -name .history -exec rm -f {} \; \
+        find "${mountpoint}/recorded/" -name .history -exec rm -f {} \; \
         > /dev/null 2>&1
     fi
 }
@@ -2402,248 +2401,248 @@ __record () {
 __package () {
     # create package from recorded changes
     # sha256 too
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
+    local fulluuid="$(__check_name "${name}")"
 
-    local mountpoint="$(__get_jail_prop mountpoint $fulluuid)"
+    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
 
-    if [ ! -d ${mountpoint}/recorded ] ; then
+    if [ ! -d "${mountpoint}/recorded" ] ; then
         echo "  ERROR: nothing to package, missing recorded directory!"
         echo "  HINT: have you recorded the jail?"
         exit 1
     fi
 
-    if [ ! -d "$iocroot/packages" ] ; then
-        mkdir $iocroot/packages
+    if [ ! -d "${iocroot}/packages" ] ; then
+        mkdir "${iocroot}/packages"
     fi
 
     echo "* Creating package..."
-    tar -cvJf $iocroot/packages/$fulluuid.tar.xz -C ${mountpoint}/recorded . && \
-    sha256 -q $iocroot/packages/$fulluuid.tar.xz > $iocroot/packages/$fulluuid.sha256
-    echo "* Package saved to: $iocroot/packages/$fulluuid.tar.xz"
-    echo "* Checksum created: $iocroot/packages/$fulluuid.sha256"
+    tar -cvJf "${iocroot}/packages/${fulluuid}.tar.xz" -C "${mountpoint}/recorded" . && \
+    sha256 -q "${iocroot}/packages/${fulluuid}.tar.xz" > "${iocroot}/packages/${fulluuid}.sha256"
+    echo "* Package saved to: ${iocroot}/packages/${fulluuid}.tar.xz"
+    echo "* Checksum created: ${iocroot}/packages/${fulluuid}.sha256"
 }
 
 __import () {
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing package UUID"
         exit 1
     fi
 
-    local package="$(find $iocroot/packages/ -name $name\*.tar.xz)"
-    local image="$(find $iocroot/images/ -name $name\*.tar.xz)"
-    local pcount="$(echo $package|wc -w | sed -e 's/^  *//' \
+    local package="$(find "${iocroot}/packages/" -name "${name}*.tar.xz")"
+    local image="$(find "${iocroot}/images/" -name "${name}*.tar.xz")"
+    local pcount="$(echo "$package"|wc -w | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local icount="$(echo $image|wc -w | sed -e 's/^  *//' \
+    local icount="$(echo "$image"|wc -w | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
-    if [ $pcount -gt 1 ] ; then
+    if [ "${pcount}" -gt 1 ] ; then
         echo "  ERROR: multiple matching packages, please narrow down UUID."
         exit 1
-    elif [ $pcount -eq 1 ] ; then
-        local pcksum="$(find $iocroot/packages/ -name $name\*.sha256)"
+    elif [ "${pcount}" -eq 1 ] ; then
+        local pcksum="$(find "${iocroot}/packages/" -name "${name}*.sha256")"
     fi
 
-    if [ $icount -gt 1 ] ; then
+    if [ "${icount}" -gt 1 ] ; then
         echo "  ERROR: multiple matching images, please narrow down UUID."
         exit 1
-    elif [ $icount -eq 1 ] ; then
-        local icksum="$(find $iocroot/images/ -name $name\*.sha256)"
+    elif [ "${icount}" -eq 1 ] ; then
+        local icksum="$(find "${iocroot}/images/" -name "${name}*.sha256")"
     fi
 
-    if [ $pcount -gt 0 ] && [ $icount -gt 0 ] ; then
+    if [ "${pcount}" -gt 0 ] && [ "${icount}" -gt 0 ] ; then
         echo "  ERROR: same UUID is matching both a package and an image."
         exit 1
     fi
 
-    if [ $pcount -gt 0 ] ; then
-        echo "* Found package $package"
-        echo "* Importing package $package"
+    if [ "${pcount}" -gt 0 ] ; then
+        echo "* Found package ${package}"
+        echo "* Importing package ${package}"
 
-        if [ ! -f $pcksum ] ; then
+        if [ ! -f "${pcksum}" ] ; then
             echo "  ERROR: missing checksum file!"
             exit 1
         fi
 
-        local new_cksum="$(sha256 -q $package)"
-        local old_cksum="$(cat $pcksum)"
+        local new_cksum="$(sha256 -q "${package}")"
+        local old_cksum="$(cat "${pcksum}")"
         local uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
-        local mountpoint="$(__get_jail_prop mountpoint $uuid)"
+        local mountpoint="$(__get_jail_prop mountpoint "${uuid}")"
 
-        if [ $new_cksum != $old_cksum ] ; then
+        if [ "${new_cksum}" != "${old_cksum}" ] ; then
             echo "  ERROR: checksum mismatch ..exiting"
             exit 1
         else
-            tar -xvJf $package -C $mountpoint/root
+            tar -xvJf "${package}" -C "${mountpoint}/root"
         fi
 
-    elif [ $icount -gt 0 ] ; then
-        echo "* Found image $image"
-        echo "* Importing image $image"
+    elif [ "${icount}" -gt 0 ] ; then
+        echo "* Found image ${image}"
+        echo "* Importing image ${image}"
 
-        if [ ! -f $icksum ] ; then
+        if [ ! -f "${icksum}" ] ; then
             echo "  ERROR: missing checksum file!"
             exit 1
         fi
 
-        local new_cksum="$(sha256 -q $image)"
-        local old_cksum="$(cat $icksum)"
+        local new_cksum="$(sha256 -q "${image}")"
+        local old_cksum="$(cat "${icksum}")"
         local uuid="$(__create_jail create -e|tail -1)"
-        local mountpoint="$(__get_jail_prop mountpoint $uuid)"
+        local mountpoint="$(__get_jail_prop mountpoint "${uuid}")"
 
-        if [ $new_cksum != $old_cksum ] ; then
+        if [ "${new_cksum}" != "${old_cksum}" ] ; then
             echo "  ERROR: checksum mismatch ..exiting"
             exit 1
         else
-            tar -xvJf $image -C $mountpoint/root
+            tar -xvJf "${image}" -C "${mountpoint}/root"
         fi
 
     else
-        echo "  ERROR: package or image $name not found!"
+        echo "  ERROR: package or image ${name} not found!"
         exit 1
     fi
 
-    cat $iocroot/jails/${uuid}/root/etc/rc.conf | \
-    sed -E "s/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}/$uuid/g" \
-    > $iocroot/jails/${uuid}/rc.conf
+    cat "${iocroot}/jails/${uuid}/root/etc/rc.conf" | \
+    sed -E "s/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}/${uuid}/g" \
+    > "${iocroot}/jails/${uuid}/rc.conf"
 
-    mv $iocroot/jails/${uuid}/rc.conf \
-    $iocroot/jails/${uuid}/root/etc/rc.conf
+    mv "${iocroot}/jails/${uuid}/rc.conf" \
+    "${iocroot}/jails/${uuid}/root/etc/rc.conf"
 }
 
 __export () {
     # Export full jail
     # sha256
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: $name not found"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: ${name} not found"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fulluuid="$(__check_name $name)"
-    local jail_path="$(__get_jail_prop mountpoint $fulluuid)"
-    local state=$(jls|grep ${jail_path} | wc -l | sed -e 's/^  *//' \
+    local fulluuid="$(__check_name "${name}")"
+    local jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local state=$(jls|grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)
 
-    if [ "$state" -gt "0" ] ; then
-        echo "  ERROR: $fulluuid is running!"
+    if [ "${state}" -gt "0" ] ; then
+        echo "  ERROR: ${fulluuid} is running!"
         echo "  Stop jail before exporting!"
         exit 1
     fi
 
-    local mountpoint="$(__get_jail_prop mountpoint $fulluuid)"
+    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
 
-    if [ ! -d "$iocroot/images" ] ; then
-        mkdir $iocroot/images
+    if [ ! -d "${iocroot}/images" ] ; then
+        mkdir "${iocroot}/images"
     fi
 
-    echo "* Exporting $fulluuid .."
-    tar -cvJf $iocroot/images/$fulluuid.tar.xz -C ${mountpoint}/root . && \
-    sha256 -q $iocroot/images/$fulluuid.tar.xz > $iocroot/images/$fulluuid.sha256
-    echo "* Image saved to: $iocroot/images/$fulluuid.tar.xz"
-    echo "* Checksum created: $iocroot/images/$fulluuid.sha256"
+    echo "* Exporting ${fulluuid} .."
+    tar -cvJf "${iocroot}/images/${fulluuid}.tar.xz" -C "${mountpoint}/root" . && \
+    sha256 -q "${iocroot}/images/${fulluuid}.tar.xz" > "${iocroot}/images/${fulluuid}.sha256"
+    echo "* Image saved to: ${iocroot}/images/${fulluuid}.tar.xz"
+    echo "* Checksum created: ${iocroot}/images/${fulluuid}.sha256"
 
 }
 
 __check_name () {
-    local name=$1
+    local name="${1}"
 
-    if [ -z $name ] ; then
+    if [ -z "${name}" ] ; then
         echo "ERROR"
         exit 1
     fi
 
-    local dataset=$(__find_jail $name)
+    local dataset="$(__find_jail "${name}")"
 
-    if [ -z $dataset ] ; then
-        echo "  ERROR: jail $name not found!"
+    if [ -z "${dataset}" ] ; then
+        echo "  ERROR: jail ${name} not found!"
         exit 1
     fi
 
-    if [ $dataset == "multiple" ] ; then
+    if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local uuid="$(__get_jail_prop host_hostuuid $name)"
+    local uuid="$(__get_jail_prop host_hostuuid "${name}")"
 
-    echo "$uuid"
+    echo "${uuid}"
 
 }
 
 # reads tag property from given jail dataset
 # creates symlink from $iocroot/tags/<tag> to $iocroot/jails/<uuid>
 __link_tag () {
-    local dataset=$1
+    local dataset="${1}"
     local mountpoint
     local tag
 
-    if mountpoint=$(zfs get -H -o value mountpoint $dataset) ; then
-        if tag=$(zfs get -H -o value org.freebsd.iocage:tag $dataset); then
-            mkdir -p $iocroot/tags
-            if [ ! -e $iocroot/tags/$tag ] ; then
-                ln -s $mountpoint $iocroot/tags/$tag
+    if mountpoint="$(zfs get -H -o value mountpoint "${dataset}")" ; then
+        if tag="$(zfs get -H -o value org.freebsd.iocage:tag "${dataset}")"; then
+            mkdir -p "${iocroot}/tags"
+            if [ ! -e "${iocroot}/tags/${tag}" ] ; then
+                ln -s "${mountpoint}" "${iocroot}/tags/${tag}"
             else
-                echo "  ERROR: tag already exists, can not symlink: $tag"
+                echo "  ERROR: tag already exists, can not symlink: ${tag}"
                 exit 1
             fi
         fi
     else
-        echo "  ERROR: no such dataset: $dataset"
+        echo "  ERROR: no such dataset: ${dataset}"
         exit 1
     fi
 }
 
 # removes all symlinks found in $iocroot/tags pointing to the given jail dataset
 __unlink_tag () {
-    local dataset=$1
+    local dataset="${1}"
     local mountpoint
 
-    if mountpoint=$(zfs get -H -o value mountpoint $dataset) ; then
-        find $iocroot/tags -type l -lname "${mountpoint}*" -exec rm -f \{\} \;
+    if mountpoint="$(zfs get -H -o value mountpoint "${dataset}")" ; then
+        find "${iocroot}/tags" -type l -lname "${mountpoint}*" -exec rm -f \{\} \;
     fi
 }
 
 __pkg_install () {
-    local chrootdir="$1"
+    local chrootdir="${1}"
 
-    if [ -e $pkglist ] ; then
+    if [ -e "${pkglist}" ] ; then
         echo "* Installing extra packages.."
-        for i in $(cat $pkglist) ; do
-            pkg -c $chrootdir install -qy $i
+        for i in $(cat "${pkglist}") ; do
+            pkg -c "${chrootdir}" install -qy "${i}"
         done
     fi
 }
@@ -2651,7 +2650,7 @@ __pkg_install () {
 __jail_rc_conf () {
 cat << EOT
 
-cron_flags="$cron_flags -J 15"
+cron_flags="${cron_flags} -J 15"
 
 # Disable Sendmail by default
 sendmail_enable="NONE"
@@ -2675,15 +2674,15 @@ __resolv_conf () {
 # search for executable prestart|poststart|prestop|poststop in jail_dir first,
 # else use jail exec_<type> property unchanged
 __findscript () {
-    local name=$1
+    local name="${1}"
     # type should be one of prestart|poststart|prestop|poststop
-    local type=$2
-    local jail_path="$(__get_jail_prop mountpoint $name)"
+    local type="${2}"
+    local jail_path="$(__get_jail_prop mountpoint "${name}")"
 
     if [ -x "${jail_path}/${type}" ]; then
         echo "${jail_path}/${type}"
     else
-        echo "$(__get_jail_prop exec_${type} $name)"
+        echo "$(__get_jail_prop "exec_${type}" "${name}")"
     fi
 }
 
@@ -3966,12 +3965,12 @@ EOT
 }
 
 
-if [ -z "$1" ] ; then
+if [ -z "${1}" ] ; then
     __usage
     exit 0
 fi
 
-if [ "$1" == "help" ] ; then
+if [ "${1}" == "help" ] ; then
     __help
     exit 0
 fi
@@ -3983,4 +3982,4 @@ if [ "$(whoami)" != "root" ] ; then
 fi
 
 __find_mypool
-__parse_cmd "$@"
+__parse_cmd "${@}"


### PR DESCRIPTION
This branch presents a massive overhaul in the usage of quotes and braces, and in some case reliance on fickle shell globbing, along with several other less than opportune things. It basically boils down to: All variables will be in double quotes and braces (e.g. "${var}") except in circumstances where that is contraindicated. All command substitutions shall be in double quotes to prevent globbing. Among the circumstances where this is not desirable are the replies from __get_jail_prop and some places that require an unquoted return to allow globbing where needed. This pull request should not be merged as-is. Instead, please make contact with me so I can merge it in my upstream system external to GitHub and re-submit a pull request. Testing of some features has been performed on my 9.3 box (non-VNET only) and my 11-CURRENT r281393M box (non-VNET and VNET), but should not by any means be considered adequate testing.