### PR TITLE
iocage help fix

### DIFF
--- a/iocage
+++ b/iocage
@@ -2674,7 +2674,7 @@ __findscript () {
 }
 
 __help () {
-cat << 'EOT'
+cat << 'EOT' | less
 NAME
   iocage - jail manager amalgamating ZFS, VNET and resource limits
 SYNOPSIS


### PR DESCRIPTION
Make 'iocage help' resemble a 'man' output.

I add this to my iocage build to help make it easier to call 'iocage help' 