### PR TITLE
The beginning of making this work happily with a linter.

### DIFF
--- a/lib/basejail.sh
+++ b/lib/basejail.sh
@@ -24,8 +24,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __create_basejail () {
-    local release="${1}"
-    local fs_list="bin
+    local release
+    release="${1}"
+    local fs_list
+    fs_list="bin
                    boot
                    lib
                    libexec
@@ -51,14 +53,16 @@ __create_basejail () {
 }
 
 __reclone_basejail () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -70,8 +74,10 @@ __reclone_basejail () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
-    local jail_release="$(__get_jail_prop release "${fulluuid}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
+    local jail_release
+    jail_release="$(__get_jail_prop release "${fulluuid}")"
 
     zfs destroy -rRf "${pool}/iocage/base@${fulluuid}"
     zfs snapshot -r  "${pool}/iocage/base@${fulluuid}"

--- a/lib/basejail.sh
+++ b/lib/basejail.sh
@@ -24,9 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __create_basejail () {
-    local release
     release="${1}"
-    local fs_list
     fs_list="bin
                    boot
                    lib
@@ -53,7 +51,6 @@ __create_basejail () {
 }
 
 __reclone_basejail () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -61,7 +58,6 @@ __reclone_basejail () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -74,9 +70,7 @@ __reclone_basejail () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
-    local jail_release
     jail_release="$(__get_jail_prop release "${fulluuid}")"
 
     zfs destroy -rRf "${pool}/iocage/base@${fulluuid}"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -479,7 +479,7 @@ __list_jails () {
         boot="$(zfs get -H -o value org.freebsd.iocage:boot "${jail}")"
         tag="$(zfs get -H -o value org.freebsd.iocage:tag "${jail}")"
         jail_path="$(zfs get -H -o value mountpoint "${jail}")"
-        state="$(jls | grep "${jail_path}" | awk '{print $1}')"
+        state="$(jls | grep "${jail_path}" | cut -w -f1)"
         template="$(zfs get -H -o value org.freebsd.iocage:template "${jail}")"
         # get jid for iocage jails
         jid="$(jls -j "ioc-${uuid}"  -h jid 2> /dev/null | grep -v -x "jid")"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -456,20 +456,14 @@ __get_jail_name () {
 }
 
 __list_jails () {
-    local jails
     jails="$(__find_jail ALL)"
-    local switch
     switch="${1}"
-    local all_jids
     all_jids="$(jls -N -h jid | grep -v -x jid )"
-    local ioc_jids
     ioc_jids=""
-    local non_ioc_jids
     non_ioc_jids=""
 
     if [ ! -z "${switch}" ] && [ "${switch}" == "-r" ] ; then
         echo "Downloaded releases:"
-        local releases
         releases="$(zfs list -o name -Hr "${pool}/iocage/releases" \
                         | grep 'RELEASE$' | cut -d '/' -f 4)"
         for rel in ${releases} ; do
@@ -492,7 +486,6 @@ __list_jails () {
         if [ -z "${jid}"  ] ; then
             jid="-"
         fi
-        local ioc_jids
         ioc_jids="${ioc_jids} ${jid}"
 
         if [ -z "${state}" ] ; then
@@ -522,17 +515,14 @@ __list_jails () {
     for all_jail in ${all_jids} ; do
         for ioc_jail in ${ioc_jids} ; do
             if [ "$all_jail" == "${ioc_jail}" ] ; then
-                local temp_loop_var
                 temp_loop_var=""
                 break
             else
-                local temp_loop_var
                 temp_loop_var="${all_jail}"
 
             fi
         done
     if [ -n "${temp_loop_var}" ] ; then
-        local non_ioc_jids
         non_ioc_jids="${non_ioc_jids} ${temp_loop_var}"
     fi
     done
@@ -555,18 +545,14 @@ __list_jails () {
 }
 
 __show () {
-    local jails
     jails="$(__find_jail ALL)"
-    local prop
     prop="${1}"
 
     printf "%-36s  %s\n" "UUID" "${prop}"
 
     for jail in ${jails} ; do
-        local name
         name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
                     "${jail}")"
-        local value
         value="$(__get_jail_prop "${prop}" "${name}")"
 
         printf "%-+.36s  %s\n" "${name}"  "${value}"
@@ -574,7 +560,6 @@ __show () {
 }
 
 __check_name () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -582,7 +567,6 @@ __check_name () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -595,7 +579,6 @@ __check_name () {
         exit 1
     fi
 
-    local uuid
     uuid="$(__get_jail_prop host_hostuuid "${name}")"
 
     echo "${uuid}"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -26,132 +26,132 @@
 unset LC_ALL
 unset LANG
 
-PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
+PATH=${PATH}:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin ; export PATH
 
 # Auto UUID
-uuid="$(uuidgen)"
+uuid="$(uuidgen)" ; export uuid
 
 # pkg list, only used with the create subcommand
-pkglist="none"
+pkglist="none" ; export pkglist
 
 # Network defaults for jails start here
 
 # detect VNET kernel and adjust jail default
 # if supported turn it on by default
 if [ ! -z "$(sysctl -qn kern.features.vimage)" ] ; then
-    vnet="on"
+    vnet="on" ; export     vnet
 else
-    vnet="off"
+    vnet="off" ; export     vnet
 fi
 
-ipv6="on"
+ipv6="on" ; export ipv6
 
-interfaces="vnet0:bridge0,vnet1:bridge1"
-host_hostname="${uuid}"
-exec_fib=0
-hostname="${uuid}"
-ip4_addr="none"
-ip4_saddrsel="1"
-ip4="new"
-ip6_addr="none"
-ip6_saddrsel="1"
-ip6="new"
-defaultrouter="none"
-defaultrouter6="none"
+interfaces="vnet0:bridge0,vnet1:bridge1" ; export interfaces
+host_hostname="${uuid}" ; export host_hostname
+exec_fib=0 ; export exec_fib
+hostname="${uuid}" ; export hostname
+ip4_addr="none" ; export ip4_addr
+ip4_saddrsel="1" ; export ip4_saddrsel
+ip4="new" ; export ip4
+ip6_addr="none" ; export ip6_addr
+ip6_saddrsel="1" ; export ip6_saddrsel
+ip6="new" ; export ip6
+defaultrouter="none" ; export defaultrouter
+defaultrouter6="none" ; export defaultrouter6
 
 # Standard jail properties
-devfs_ruleset="4"
-exec_start="/bin/sh /etc/rc"
-exec_stop="/bin/sh /etc/rc.shutdown"
-exec_prestart="/usr/bin/true"
-exec_poststart="/usr/bin/true"
-exec_prestop="/usr/bin/true"
-exec_poststop="/usr/bin/true"
-exec_clean=1
-exec_timeout=60
-stop_timeout=30
-exec_jail_user=root
-exec_system_jail_user=0
-exec_system_user=root
-mount_devfs=1
-mount_fdescfs=1
-enforce_statfs="2"
-children_max="0"
-login_flags='-f root'
-securelevel="2"
-host_hostuuid="${uuid}"
-allow_set_hostname=1
-allow_sysvipc=0
-allow_raw_sockets=0
-allow_chflags=0
-allow_mount=0
-allow_mount_devfs=0
-allow_mount_nullfs=0
-allow_mount_procfs=0
-allow_mount_tmpfs=0
-allow_mount_zfs=0
-allow_quotas=0
-allow_socket_af=0
+devfs_ruleset="4" ; export devfs_ruleset
+exec_start="/bin/sh /etc/rc" ; export exec_start
+exec_stop="/bin/sh /etc/rc.shutdown" ; export exec_stop
+exec_prestart="/usr/bin/true" ; export exec_prestart
+exec_poststart="/usr/bin/true" ; export exec_poststart
+exec_prestop="/usr/bin/true" ; export exec_prestop
+exec_poststop="/usr/bin/true" ; export exec_poststop
+exec_clean=1 ; export exec_clean
+exec_timeout=60 ; export exec_timeout
+stop_timeout=30 ; export stop_timeout
+exec_jail_user=root ; export exec_jail_user
+exec_system_jail_user=0 ; export exec_system_jail_user
+exec_system_user=root ; export exec_system_user
+mount_devfs=1 ; export mount_devfs
+mount_fdescfs=1 ; export mount_fdescfs
+enforce_statfs="2" ; export enforce_statfs
+children_max="0" ; export children_max
+login_flags='-f root' ; export login_flags
+securelevel="2" ; export securelevel
+host_hostuuid="${uuid}" ; export host_hostuuid
+allow_set_hostname=1 ; export allow_set_hostname
+allow_sysvipc=0 ; export allow_sysvipc
+allow_raw_sockets=0 ; export allow_raw_sockets
+allow_chflags=0 ; export allow_chflags
+allow_mount=0 ; export allow_mount
+allow_mount_devfs=0 ; export allow_mount_devfs
+allow_mount_nullfs=0 ; export allow_mount_nullfs
+allow_mount_procfs=0 ; export allow_mount_procfs
+allow_mount_tmpfs=0 ; export allow_mount_tmpfs
+allow_mount_zfs=0 ; export allow_mount_zfs
+allow_quotas=0 ; export allow_quotas
+allow_socket_af=0 ; export allow_socket_af
 
 # RCTL limits
-cpuset="off"
-rlimits="off"
-memoryuse="8G:log"
-memorylocked="off"
-vmemoryuse="off"
-maxproc="off"
-cputime="off"
-pcpu="off"
-datasize="off"
-stacksize="off"
-coredumpsize="off"
-openfiles="off"
-pseudoterminals="off"
-swapuse="off"
-nthr="off"
-msgqqueued="off"
-msgqsize="off"
-nmsgq="off"
-nsemop="off"
-nshm="off"
-shmsize="off"
-wallclock="off"
+cpuset="off" ; export cpuset
+rlimits="off" ; export rlimits
+memoryuse="8G:log" ; export memoryuse
+memorylocked="off" ; export memorylocked
+vmemoryuse="off" ; export vmemoryuse
+maxproc="off" ; export maxproc
+cputime="off" ; export cputime
+pcpu="off" ; export pcpu
+datasize="off" ; export datasize
+stacksize="off" ; export stacksize
+coredumpsize="off" ; export coredumpsize
+openfiles="off" ; export openfiles
+pseudoterminals="off" ; export pseudoterminals
+swapuse="off" ; export swapuse
+nthr="off" ; export nthr
+msgqqueued="off" ; export msgqqueued
+msgqsize="off" ; export msgqsize
+nmsgq="off" ; export nmsgq
+nsemop="off" ; export nsemop
+nshm="off" ; export nshm
+shmsize="off" ; export shmsize
+wallclock="off" ; export wallclock
 
 # Custom properties
-iocroot="/iocage"
-tag="$(date "+%F@%T")"
-template="no"
-boot="off"
-notes="none"
-owner="root"
-priority="99"
-last_started="none"
-type="jail"
-release="$(uname -r|cut -f 1,2 -d'-')"
-hostid="$(cat /etc/hostid)"
-jail_zfs="off"
-jail_zfs_dataset="iocage/jails/${uuid}/root/data"
-mount_procfs="0"
+iocroot="/iocage" ; export iocroot
+tag="$(date "+%F@%T")" ; export tag
+template="no" ; export template
+boot="off" ; export boot
+notes="none" ; export notes
+owner="root" ; export owner
+priority="99" ; export priority
+last_started="none" ; export last_started
+type="jail" ; export type
+release="$(uname -r|cut -f 1,2 -d'-')" ; export release
+hostid="$(cat /etc/hostid)" ; export hostid
+jail_zfs="off" ; export jail_zfs
+jail_zfs_dataset="iocage/jails/${uuid}/root/data" ; export jail_zfs_dataset
+mount_procfs="0" ; export mount_procfs
 
 # Native ZFS properties
-compression="lz4"
-origin="readonly"
-quota="none"
-mountpoint="readonly"
-compressratio="readonly"
-available="readonly"
-used="readonly"
-dedup="off"
-reservation="none"
+compression="lz4" ; export compression
+origin="readonly" ; export origin
+quota="none" ; export quota
+mountpoint="readonly" ; export mountpoint
+compressratio="readonly" ; export compressratio
+available="readonly" ; export available
+used="readonly" ; export used
+dedup="off" ; export dedup
+reservation="none" ; export reservation
 
 # Sync properties
-sync_state="none"
-sync_target="none"
-sync_tgt_zpool="none"
+sync_state="none" ; export sync_state
+sync_target="none" ; export sync_target
+sync_tgt_zpool="none" ; export sync_tgt_zpool
 
 # FTP variables
-ftphost="ftp.freebsd.org"
-ftpfiles="base.txz doc.txz lib32.txz src.txz"
+ftphost="ftp.freebsd.org" ; export ftphost
+ftpfiles="base.txz doc.txz lib32.txz src.txz" ; export ftpfiles
 
 # Resource limits
 CONF_RCTL="memoryuse
@@ -174,6 +174,7 @@ CONF_RCTL="memoryuse
            nshm
            shmsize
            wallclock"
+export CONF_RCTL
 
 # Networking configuration
 CONF_NET="interfaces
@@ -189,6 +190,7 @@ CONF_NET="interfaces
           defaultrouter
           defaultrouter6
           exec_fib"
+export CONF_NET
 
 # Native jail properties
 CONF_JAIL="devfs_ruleset
@@ -224,6 +226,7 @@ CONF_JAIL="devfs_ruleset
            allow_quotas
            allow_socket_af
            host_hostuuid"
+export CONF_JAIL
 
 # Custom properties
 CONF_CUSTOM="tag
@@ -240,6 +243,7 @@ CONF_CUSTOM="tag
              jail_zfs
              jail_zfs_dataset
              release"
+export CONF_JAIL
 
 # Native ZFS properties
 CONF_ZFS="compression
@@ -251,14 +255,16 @@ CONF_ZFS="compression
           used
           dedup
           reservation"
+export CONF_ZFS
 
 # ZFS sync (not used yet)
 CONF_SYNC="sync_stat
            sync_target
            sync_tgt_zpool"
+export CONF_SYNC
 
 # ftp properties
-CONF_FTP="ftphost ftpdir"
+CONF_FTP="ftphost ftpdir" ; export CONF_FTP
 
 # Basejail filesystems
 bfs_list="bin
@@ -276,6 +282,7 @@ bfs_list="bin
           usr/src
           usr/libdata
           usr/lib32"
+export bfs_list
 
 # Basejail directories
 bdir_list="dev
@@ -285,7 +292,7 @@ bdir_list="dev
            root
            proc
            mnt"
-
+export bdir_list
 
 # Process command line options-------------------------
 __parse_cmd () {
@@ -449,15 +456,21 @@ __get_jail_name () {
 }
 
 __list_jails () {
-    local jails="$(__find_jail ALL)"
-    local switch="${1}"
-    local all_jids="$(jls -N -h jid | grep -v -x jid )"
-    local ioc_jids=""
-    local non_ioc_jids=""
+    local jails
+    jails="$(__find_jail ALL)"
+    local switch
+    switch="${1}"
+    local all_jids
+    all_jids="$(jls -N -h jid | grep -v -x jid )"
+    local ioc_jids
+    ioc_jids=""
+    local non_ioc_jids
+    non_ioc_jids=""
 
     if [ ! -z "${switch}" ] && [ "${switch}" == "-r" ] ; then
         echo "Downloaded releases:"
-        local releases="$(zfs list -o name -Hr "${pool}/iocage/releases" \
+        local releases
+        releases="$(zfs list -o name -Hr "${pool}/iocage/releases" \
                         | grep 'RELEASE$' | cut -d '/' -f 4)"
         for rel in ${releases} ; do
             printf "%15s\n" "${rel}"
@@ -479,7 +492,8 @@ __list_jails () {
         if [ -z "${jid}"  ] ; then
             jid="-"
         fi
-        local ioc_jids="${ioc_jids} ${jid}"
+        local ioc_jids
+        ioc_jids="${ioc_jids} ${jid}"
 
         if [ -z "${state}" ] ; then
             state=down
@@ -508,15 +522,18 @@ __list_jails () {
     for all_jail in ${all_jids} ; do
         for ioc_jail in ${ioc_jids} ; do
             if [ "$all_jail" == "${ioc_jail}" ] ; then
-                local temp_loop_var=""
+                local temp_loop_var
+                temp_loop_var=""
                 break
             else
-                local temp_loop_var="${all_jail}"
+                local temp_loop_var
+                temp_loop_var="${all_jail}"
 
             fi
         done
     if [ -n "${temp_loop_var}" ] ; then
-        local non_ioc_jids="${non_ioc_jids} ${temp_loop_var}"
+        local non_ioc_jids
+        non_ioc_jids="${non_ioc_jids} ${temp_loop_var}"
     fi
     done
 
@@ -538,29 +555,35 @@ __list_jails () {
 }
 
 __show () {
-    local jails="$(__find_jail ALL)"
-    local prop="${1}"
+    local jails
+    jails="$(__find_jail ALL)"
+    local prop
+    prop="${1}"
 
     printf "%-36s  %s\n" "UUID" "${prop}"
 
     for jail in ${jails} ; do
-        local name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
+        local name
+        name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
                     "${jail}")"
-        local value="$(__get_jail_prop "${prop}" "${name}")"
+        local value
+        value="$(__get_jail_prop "${prop}" "${name}")"
 
         printf "%-+.36s  %s\n" "${name}"  "${value}"
     done
 }
 
 __check_name () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "ERROR"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: jail ${name} not found!"
@@ -572,7 +595,8 @@ __check_name () {
         exit 1
     fi
 
-    local uuid="$(__get_jail_prop host_hostuuid "${name}")"
+    local uuid
+    uuid="$(__get_jail_prop host_hostuuid "${name}")"
 
     echo "${uuid}"
 

--- a/lib/exec.sh
+++ b/lib/exec.sh
@@ -24,7 +24,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __console () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -32,7 +31,6 @@ __console () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -45,10 +43,8 @@ __console () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
-    local login_flags
     login_flags="$(zfs get -H -o value org.freebsd.iocage:login_flags \
                        "${pool}/iocage/jails/${fulluuid}")"
 
@@ -57,7 +53,6 @@ __console () {
 
 
 __exec () {
-    local jexecopts
     jexecopts=
 
     # check for -U or -u to pass to jexec
@@ -71,7 +66,6 @@ __exec () {
     done
     shift $((OPTIND-1))
 
-    local name
     name="${1}"
     shift
 
@@ -80,7 +74,6 @@ __exec () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -93,7 +86,6 @@ __exec () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
     jexec "${jexecopts}" "ioc-${fulluuid}" ${@}
@@ -101,9 +93,7 @@ __exec () {
 
 
 __chroot () {
-    local name
     name="${1}"
-    local command
     command="${2}"
 
     if [ -z "${name}" ] ; then
@@ -111,7 +101,6 @@ __chroot () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -124,7 +113,6 @@ __chroot () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
     chroot "${iocroot}/jails/${fulluuid}/root" "${command}"

--- a/lib/exec.sh
+++ b/lib/exec.sh
@@ -24,14 +24,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __console () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -43,9 +45,11 @@ __console () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
-    local login_flags="$(zfs get -H -o value org.freebsd.iocage:login_flags \
+    local login_flags
+    login_flags="$(zfs get -H -o value org.freebsd.iocage:login_flags \
                        "${pool}/iocage/jails/${fulluuid}")"
 
     jexec "ioc-${fulluuid}" login ${login_flags}
@@ -53,7 +57,8 @@ __console () {
 
 
 __exec () {
-    local jexecopts=
+    local jexecopts
+    jexecopts=
 
     # check for -U or -u to pass to jexec
     while getopts u:U: opt "${@}"; do
@@ -66,7 +71,8 @@ __exec () {
     done
     shift $((OPTIND-1))
 
-    local name="${1}"
+    local name
+    name="${1}"
     shift
 
     if [ -z "${name}" ] ; then
@@ -74,7 +80,8 @@ __exec () {
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -86,22 +93,26 @@ __exec () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
     jexec "${jexecopts}" "ioc-${fulluuid}" ${@}
 }
 
 
 __chroot () {
-    local name="${1}"
-    local command="${2}"
+    local name
+    name="${1}"
+    local command
+    command="${2}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -113,7 +124,8 @@ __chroot () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
     chroot "${iocroot}/jails/${fulluuid}/root" "${command}"
 }

--- a/lib/fetch.sh
+++ b/lib/fetch.sh
@@ -101,6 +101,7 @@ __fetch_release () {
     __create_basejail "${release}"
     chflags -R noschg "${iocroot}/base/${release}/root"
     tar --exclude \.zfs --exclude usr/sbin/chown -C "${iocroot}/releases/${release}/root" -cf - . | \
+    tar --exclude \.zfs --exclude usr/sbin/chown -C $iocroot/base/$release/root -xf -
 
     if [ ! -e "${iocroot}/base/${release}/root/usr/sbin/chown" ] ; then
        cd "${iocroot}/base/${release}/root/usr/sbin" && ln -s ../bin/chgrp chown

--- a/lib/fetch.sh
+++ b/lib/fetch.sh
@@ -25,7 +25,6 @@
 
 # Fetch release and prepare base ZFS filesystems-----------
 __fetch_release () {
-    local exist
     exist="$(zfs list | grep -w "^${pool}/iocage")"
     __print_release
     echo -n "Please select a release [${release}]: "
@@ -49,11 +48,8 @@ __fetch_release () {
         exit 1
     fi
 
-    local exist
     exist="$(zfs list | grep -w "^${pool}/iocage")"
-    local download_exist
     download_exist="$(zfs list | grep -w "^${pool}/iocage/download/${release}")"
-    local rel_exist
     rel_exist="$(zfs list | grep -w "^${pool}/iocage/releases/${release}")"
 
     if [ -z "${exist}" ] ; then
@@ -115,7 +111,6 @@ __fetch_release () {
 }
 
 __update () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -123,7 +118,6 @@ __update () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -136,16 +130,11 @@ __update () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
-    local mountpoint
     mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local date
     date="$(date "+%F_%T")"
-    local jail_type
     jail_type="$(__get_jail_prop type "${fulluuid}")"
-    local jail_release
     jail_release="$(__get_jail_prop release "${fulluuid}")"
 
     if [ "${jail_type}" == "basejail" ] ; then
@@ -169,14 +158,12 @@ __update () {
 }
 
 __upgrade () {
-    local name
     name="${1}"
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -195,17 +182,11 @@ __upgrade () {
 	exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
-    local jail_type
     jail_type="$(__get_jail_prop type "${fulluuid}")"
-    local jail_release
     jail_release="$(__get_jail_prop release "${fulluuid}")"
-    local mountpoint
     mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local date
     date="$(date "+%F_%T")"
-    local oldrelease
     oldrelease="$(zfs get -H -o value org.freebsd.iocage:release "${dataset}")"
 
     if [ "${jail_type}" == "basejail" ] ; then

--- a/lib/fetch.sh
+++ b/lib/fetch.sh
@@ -25,7 +25,8 @@
 
 # Fetch release and prepare base ZFS filesystems-----------
 __fetch_release () {
-    local exist="$(zfs list | grep -w "^${pool}/iocage")"
+    local exist
+    exist="$(zfs list | grep -w "^${pool}/iocage")"
     __print_release
     echo -n "Please select a release [${release}]: "
     read answer
@@ -48,9 +49,12 @@ __fetch_release () {
         exit 1
     fi
 
-    local exist="$(zfs list | grep -w "^${pool}/iocage")"
-    local download_exist="$(zfs list | grep -w "^${pool}/iocage/download/${release}")"
-    local rel_exist="$(zfs list | grep -w "^${pool}/iocage/releases/${release}")"
+    local exist
+    exist="$(zfs list | grep -w "^${pool}/iocage")"
+    local download_exist
+    download_exist="$(zfs list | grep -w "^${pool}/iocage/download/${release}")"
+    local rel_exist
+    rel_exist="$(zfs list | grep -w "^${pool}/iocage/releases/${release}")"
 
     if [ -z "${exist}" ] ; then
         zfs create -o compression=lz4 "${pool}/iocage"
@@ -111,14 +115,16 @@ __fetch_release () {
 }
 
 __update () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -130,12 +136,17 @@ __update () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
-    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local date="$(date "+%F_%T")"
-    local jail_type="$(__get_jail_prop type "${fulluuid}")"
-    local jail_release="$(__get_jail_prop release "${fulluuid}")"
+    local mountpoint
+    mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local date
+    date="$(date "+%F_%T")"
+    local jail_type
+    jail_type="$(__get_jail_prop type "${fulluuid}")"
+    local jail_release
+    jail_release="$(__get_jail_prop release "${fulluuid}")"
 
     if [ "${jail_type}" == "basejail" ] ; then
         # Re-clone required filesystems
@@ -158,13 +169,15 @@ __update () {
 }
 
 __upgrade () {
-    local name="${1}"
+    local name
+    name="${1}"
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -182,12 +195,18 @@ __upgrade () {
 	exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
-    local jail_type="$(__get_jail_prop type "${fulluuid}")"
-    local jail_release="$(__get_jail_prop release "${fulluuid}")"
-    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local date="$(date "+%F_%T")"
-    local oldrelease="$(zfs get -H -o value org.freebsd.iocage:release "${dataset}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
+    local jail_type
+    jail_type="$(__get_jail_prop type "${fulluuid}")"
+    local jail_release
+    jail_release="$(__get_jail_prop release "${fulluuid}")"
+    local mountpoint
+    mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local date
+    date="$(date "+%F_%T")"
+    local oldrelease
+    oldrelease="$(zfs get -H -o value org.freebsd.iocage:release "${dataset}")"
 
     if [ "${jail_type}" == "basejail" ] ; then
         zfs set org.freebsd.iocage:release="${release}" "${dataset}"

--- a/lib/importexport.sh
+++ b/lib/importexport.sh
@@ -24,7 +24,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __pkg_install () {
-    local chrootdir
     chrootdir="${1}"
 
     if [ -e "${pkglist}" ] ; then
@@ -38,7 +37,6 @@ __pkg_install () {
 __package () {
     # create package from recorded changes
     # sha256 too
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -46,7 +44,6 @@ __package () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -59,10 +56,8 @@ __package () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
-    local mountpoint
     mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
 
     if [ ! -d "${mountpoint}/recorded" ] ; then
@@ -83,7 +78,6 @@ __package () {
 }
 
 __import () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -91,14 +85,10 @@ __import () {
         exit 1
     fi
 
-    local package
     package="$(find "${iocroot}/packages/" -name "${name}*.tar.xz")"
-    local image
     image="$(find "${iocroot}/images/" -name "${name}*.tar.xz")"
-    local pcount
     pcount="$(echo "$package"|wc -w | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local icount
     icount="$(echo "$image"|wc -w | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
@@ -106,7 +96,6 @@ __import () {
         echo "  ERROR: multiple matching packages, please narrow down UUID."
         exit 1
     elif [ "${pcount}" -eq 1 ] ; then
-        local pcksum
         pcksum="$(find "${iocroot}/packages/" -name "${name}*.sha256")"
     fi
 
@@ -114,7 +103,6 @@ __import () {
         echo "  ERROR: multiple matching images, please narrow down UUID."
         exit 1
     elif [ "${icount}" -eq 1 ] ; then
-        local icksum
         icksum="$(find "${iocroot}/images/" -name "${name}*.sha256")"
     fi
 
@@ -132,13 +120,9 @@ __import () {
             exit 1
         fi
 
-        local new_cksum
         new_cksum="$(sha256 -q "${package}")"
-        local old_cksum
         old_cksum="$(cat "${pcksum}")"
-        local uuid
         uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
-        local mountpoint
         mountpoint="$(__get_jail_prop mountpoint "${uuid}")"
 
         if [ "${new_cksum}" != "${old_cksum}" ] ; then
@@ -157,13 +141,9 @@ __import () {
             exit 1
         fi
 
-        local new_cksum
         new_cksum="$(sha256 -q "${image}")"
-        local old_cksum
         old_cksum="$(cat "${icksum}")"
-        local uuid
         uuid="$(__create_jail create -e|tail -1)"
-        local mountpoint
         mountpoint="$(__get_jail_prop mountpoint "${uuid}")"
 
         if [ "${new_cksum}" != "${old_cksum}" ] ; then
@@ -189,7 +169,6 @@ __import () {
 __export () {
     # Export full jail
     # sha256
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -197,7 +176,6 @@ __export () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -210,11 +188,8 @@ __export () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
-    local jail_path
     jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local state
     state="$(jls|grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
@@ -224,7 +199,6 @@ __export () {
         exit 1
     fi
 
-    local mountpoint
     mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
 
     if [ ! -d "${iocroot}/images" ] ; then

--- a/lib/importexport.sh
+++ b/lib/importexport.sh
@@ -24,7 +24,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __pkg_install () {
-    local chrootdir="${1}"
+    local chrootdir
+    chrootdir="${1}"
 
     if [ -e "${pkglist}" ] ; then
         echo "* Installing extra packages.."
@@ -37,14 +38,16 @@ __pkg_install () {
 __package () {
     # create package from recorded changes
     # sha256 too
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -56,9 +59,11 @@ __package () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
-    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local mountpoint
+    mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
 
     if [ ! -d "${mountpoint}/recorded" ] ; then
         echo "  ERROR: nothing to package, missing recorded directory!"
@@ -78,32 +83,39 @@ __package () {
 }
 
 __import () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing package UUID"
         exit 1
     fi
 
-    local package="$(find "${iocroot}/packages/" -name "${name}*.tar.xz")"
-    local image="$(find "${iocroot}/images/" -name "${name}*.tar.xz")"
-    local pcount="$(echo "$package"|wc -w | sed -e 's/^  *//' \
+    local package
+    package="$(find "${iocroot}/packages/" -name "${name}*.tar.xz")"
+    local image
+    image="$(find "${iocroot}/images/" -name "${name}*.tar.xz")"
+    local pcount
+    pcount="$(echo "$package"|wc -w | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local icount="$(echo "$image"|wc -w | sed -e 's/^  *//' \
+    local icount
+    icount="$(echo "$image"|wc -w | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
     if [ "${pcount}" -gt 1 ] ; then
         echo "  ERROR: multiple matching packages, please narrow down UUID."
         exit 1
     elif [ "${pcount}" -eq 1 ] ; then
-        local pcksum="$(find "${iocroot}/packages/" -name "${name}*.sha256")"
+        local pcksum
+        pcksum="$(find "${iocroot}/packages/" -name "${name}*.sha256")"
     fi
 
     if [ "${icount}" -gt 1 ] ; then
         echo "  ERROR: multiple matching images, please narrow down UUID."
         exit 1
     elif [ "${icount}" -eq 1 ] ; then
-        local icksum="$(find "${iocroot}/images/" -name "${name}*.sha256")"
+        local icksum
+        icksum="$(find "${iocroot}/images/" -name "${name}*.sha256")"
     fi
 
     if [ "${pcount}" -gt 0 ] && [ "${icount}" -gt 0 ] ; then
@@ -120,10 +132,14 @@ __import () {
             exit 1
         fi
 
-        local new_cksum="$(sha256 -q "${package}")"
-        local old_cksum="$(cat "${pcksum}")"
-        local uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
-        local mountpoint="$(__get_jail_prop mountpoint "${uuid}")"
+        local new_cksum
+        new_cksum="$(sha256 -q "${package}")"
+        local old_cksum
+        old_cksum="$(cat "${pcksum}")"
+        local uuid
+        uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
+        local mountpoint
+        mountpoint="$(__get_jail_prop mountpoint "${uuid}")"
 
         if [ "${new_cksum}" != "${old_cksum}" ] ; then
             echo "  ERROR: checksum mismatch ..exiting"
@@ -141,10 +157,14 @@ __import () {
             exit 1
         fi
 
-        local new_cksum="$(sha256 -q "${image}")"
-        local old_cksum="$(cat "${icksum}")"
-        local uuid="$(__create_jail create -e|tail -1)"
-        local mountpoint="$(__get_jail_prop mountpoint "${uuid}")"
+        local new_cksum
+        new_cksum="$(sha256 -q "${image}")"
+        local old_cksum
+        old_cksum="$(cat "${icksum}")"
+        local uuid
+        uuid="$(__create_jail create -e|tail -1)"
+        local mountpoint
+        mountpoint="$(__get_jail_prop mountpoint "${uuid}")"
 
         if [ "${new_cksum}" != "${old_cksum}" ] ; then
             echo "  ERROR: checksum mismatch ..exiting"
@@ -169,14 +189,16 @@ __import () {
 __export () {
     # Export full jail
     # sha256
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -188,9 +210,12 @@ __export () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
-    local jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local state="$(jls|grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
+    local jail_path
+    jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local state
+    state="$(jls|grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
     if [ "${state}" -gt "0" ] ; then
@@ -199,7 +224,8 @@ __export () {
         exit 1
     fi
 
-    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local mountpoint
+    mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
 
     if [ ! -d "${iocroot}/images" ] ; then
         mkdir "${iocroot}/images"

--- a/lib/management.sh
+++ b/lib/management.sh
@@ -93,8 +93,8 @@ __create_jail () {
 
 # Cloning jails ----------------------------------------------------------
 __clone_jail () {
-    name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    name="$(echo "${1}" | cut -d'@' -f1)"
+    snapshot="$(echo "${1}" |  cut -d'@' -f2)"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"

--- a/lib/management.sh
+++ b/lib/management.sh
@@ -25,7 +25,6 @@
 
 # This creates jails----------------------------------------------------
 __create_jail () {
-    local installed
     installed="$(zfs list -r "${pool}/iocage/releases"|grep "${release}")"
 
     if [ -z "${installed}" ] ; then
@@ -94,9 +93,7 @@ __create_jail () {
 
 # Cloning jails ----------------------------------------------------------
 __clone_jail () {
-    local name
     name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot
     snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
     if [ -z "${name}" ] ; then
@@ -104,7 +101,6 @@ __clone_jail () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -117,7 +113,6 @@ __clone_jail () {
         exit 1
     fi
 
-    local fs_list
     fs_list="$(zfs list -rH -o name "${dataset}")"
 
     if [ -z "$snapshot" ] ; then
@@ -147,7 +142,6 @@ __clone_jail () {
 
 # Destroy jails --------------------------------------------------------------
 __destroy_jail () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -155,7 +149,6 @@ __destroy_jail () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -168,18 +161,12 @@ __destroy_jail () {
         exit 1
     fi
 
-    local origin
     origin="$(zfs get -H -o value origin "${dataset}")"
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
-    local jail_path
     jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local state
     state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local jail_type
     jail_type="$(__get_jail_prop type "${fulluuid}")"
-    local jail_release
     jail_release="$(__get_jail_prop release "${fulluuid}")"
 
     echo " "
@@ -218,7 +205,6 @@ __destroy_jail () {
 
 # Configure properties -------------------------------------------------
 __configure_jail () {
-    local CONF
     CONF="${CONF_NET}
                 ${CONF_JAIL}
                 ${CONF_RCTL}

--- a/lib/management.sh
+++ b/lib/management.sh
@@ -25,14 +25,15 @@
 
 # This creates jails----------------------------------------------------
 __create_jail () {
-    local installed="$(zfs list -r "${pool}/iocage/releases"|grep "${release}")"
+    local installed
+    installed="$(zfs list -r "${pool}/iocage/releases"|grep "${release}")"
 
     if [ -z "${installed}" ] ; then
         echo "Release ${release} not found locally, run fetch first"
         exit 1
     fi
 
-    if [ "${2}" = "-c" ] ; then
+    if [ "${2}" == "-c" ] ; then
         fs_list="$(zfs list -rH -o name "${pool}/iocage/releases/${release}")"
 
         zfs snapshot -r "${pool}/iocage/releases/${release}@${uuid}"
@@ -41,9 +42,9 @@ __create_jail () {
             #echo "cloning $fs into $cfs"
             zfs clone "${fs}@${uuid}" "${cfs}"
         done
-    elif [ "${2}" = "-e" ] ; then
+    elif [ "${2}" == "-e" ] ; then
         zfs create -o compression=lz4 -p "${pool}/iocage/jails/${uuid}/root"
-    elif [ "${2}" = "-b" ] ; then
+    elif [ "${2}" == "-b" ] ; then
        export type=basejail
        zfs snapshot -r "${pool}/iocage/base@${uuid}"
        zfs create -o compression=lz4 -p "${pool}/iocage/jails/${uuid}/root/usr"
@@ -76,7 +77,7 @@ __create_jail () {
         __jail_rc_conf >> \
         "${iocroot}/jails/${uuid}/root/etc/rc.conf"
         __resolv_conf > "${iocroot}/jails/${uuid}/root/etc/resolv.conf"
-    elif [ "${2}" = "-e" ] ; then
+    elif [ "${2}" == "-e" ] ; then
         echo "${uuid}"
     fi
 
@@ -93,15 +94,18 @@ __create_jail () {
 
 # Cloning jails ----------------------------------------------------------
 __clone_jail () {
-    local name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    local name
+    name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
+    local snapshot
+    snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -113,7 +117,8 @@ __clone_jail () {
         exit 1
     fi
 
-    local fs_list="$(zfs list -rH -o name "${dataset}")"
+    local fs_list
+    fs_list="$(zfs list -rH -o name "${dataset}")"
 
     if [ -z "$snapshot" ] ; then
         zfs snapshot -r "${dataset}@${uuid}"
@@ -142,14 +147,16 @@ __clone_jail () {
 
 # Destroy jails --------------------------------------------------------------
 __destroy_jail () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -161,13 +168,19 @@ __destroy_jail () {
         exit 1
     fi
 
-    local origin="$(zfs get -H -o value origin "${dataset}")"
-    local fulluuid="$(__check_name "${name}")"
-    local jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
+    local origin
+    origin="$(zfs get -H -o value origin "${dataset}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
+    local jail_path
+    jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local state
+    state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local jail_type="$(__get_jail_prop type "${fulluuid}")"
-    local jail_release="$(__get_jail_prop release "${fulluuid}")"
+    local jail_type
+    jail_type="$(__get_jail_prop type "${fulluuid}")"
+    local jail_release
+    jail_release="$(__get_jail_prop release "${fulluuid}")"
 
     echo " "
     echo "  WARNING: this will destroy jail ${fulluuid}"
@@ -205,7 +218,8 @@ __destroy_jail () {
 
 # Configure properties -------------------------------------------------
 __configure_jail () {
-    local CONF="${CONF_NET}
+    local CONF
+    CONF="${CONF_NET}
                 ${CONF_JAIL}
                 ${CONF_RCTL}
                 ${CONF_CUSTOM}

--- a/lib/networking.sh
+++ b/lib/networking.sh
@@ -25,23 +25,36 @@
 
 __networking () {
     action="${1}"
-    local name="${2}"
-    local jid="$(jls -j "ioc-${name}" jid)"
-    local ip4="$(__get_jail_prop ip4_addr "${name}")"
-    local ip6="$(__get_jail_prop ip6_addr "${name}")"
-    local defaultgw="$(__get_jail_prop defaultrouter "${name}")"
-    local defaultgw6="$(__get_jail_prop defaultrouter6 "${name}")"
-    local nics="$(__get_jail_prop interfaces "${name}" \
+    local name
+    name="${2}"
+    local jid
+    jid="$(jls -j "ioc-${name}" jid)"
+    local ip4
+    ip4="$(__get_jail_prop ip4_addr "${name}")"
+    local ip6
+    ip6="$(__get_jail_prop ip6_addr "${name}")"
+    local defaultgw
+    defaultgw="$(__get_jail_prop defaultrouter "${name}")"
+    local defaultgw6
+    defaultgw6="$(__get_jail_prop defaultrouter6 "${name}")"
+    local nics
+    nics="$(__get_jail_prop interfaces "${name}" \
                |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
-    local ip4_list="$(echo "${ip4}" | sed 's/,/ /g')"
-    local ip6_list="$(echo "${ip6}" | sed 's/,/ /g')"
+    local ip4_list
+    ip4_list="$(echo "${ip4}" | sed 's/,/ /g')"
+    local ip6_list
+    ip6_list="$(echo "${ip6}" | sed 's/,/ /g')"
 
     if [ "${action}" == "start" ] ; then
         for i in ${nics} ; do
-            local nic="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
-            local bridge="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
-	    local memberif="$(ifconfig "${bridge}" | grep member | head -n1 | cut -d' ' -f2)"
-	    local brmtu="$(ifconfig "${memberif}" | head -n1 |cut -d' ' -f6)"
+            local nic
+            nic="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
+            local bridge
+            bridge="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
+	    local memberif
+	    memberif="$(ifconfig "${bridge}" | grep member | head -n1 | cut -d' ' -f2)"
+	    local brmtu
+	    brmtu="$(ifconfig "${memberif}" | head -n1 |cut -d' ' -f6)"
             epair_a="$(ifconfig epair create)"
             epair_b="$(echo "${epair_a}" | sed 's/a$/b/')"
             ifconfig "${epair_a}" name "${nic}:${jid}" mtu "${brmtu}"
@@ -78,24 +91,30 @@ __networking () {
 
     elif [ "${action}" == "stop" ] ; then
         for if in ${nics} ; do
-            local nic="$(echo "${if}" | cut -f 1 -d:)"
+            local nic
+            nic="$(echo "${if}" | cut -f 1 -d:)"
             ifconfig "${nic}:${jid}" destroy
         done
     fi
 }
 
 __stop_legacy_networking () {
-    local name="${1}"
+    local name
+    name="${1}"
 
-    local ip4_addr="$(__get_jail_prop ip4_addr "${name}")"
-    local ip6_addr="$(__get_jail_prop ip6_addr "${name}")"
+    local ip4_addr
+    ip4_addr="$(__get_jail_prop ip4_addr "${name}")"
+    local ip6_addr
+    ip6_addr="$(__get_jail_prop ip6_addr "${name}")"
 
     if [ "${ip4_addr}" != "none" ] ; then
         IFS=','
         for ip in ${ip4_addr} ; do
-            local iface="$(echo "${ip}" | \
+            local iface
+            iface="$(echo "${ip}" | \
                          awk 'BEGIN { FS = "|" } ; { print $1 }')"
-            local ip4="$(echo "${ip}" | \
+            local ip4
+            ip4="$(echo "${ip}" | \
                        awk 'BEGIN { FS = "|" } ; { print $2 }' | \
                        awk 'BEGIN { FS = "/" } ; { print $1 }')"
 
@@ -106,9 +125,11 @@ __stop_legacy_networking () {
     if [ "${ip6_addr}" != "none" ] ; then
         IFS=','
         for ip6 in ${ip6_addr} ; do
-            local iface="$(echo "${ip6}" | \
+            local iface
+            iface="$(echo "${ip6}" | \
                          awk 'BEGIN { FS = "|" } ; { print $1 }')"
-            local ip6="$(echo "${ip6}" | \
+            local ip6
+            ip6="$(echo "${ip6}" | \
                        awk 'BEGIN { FS = "|" } ; { print $2 }' | \
                        awk 'BEGIN { FS = "/" } ; { print $1 }')"
             ifconfig "${iface}" inet6 "${ip6}" -alias

--- a/lib/networking.sh
+++ b/lib/networking.sh
@@ -25,35 +25,22 @@
 
 __networking () {
     action="${1}"
-    local name
     name="${2}"
-    local jid
     jid="$(jls -j "ioc-${name}" jid)"
-    local ip4
     ip4="$(__get_jail_prop ip4_addr "${name}")"
-    local ip6
     ip6="$(__get_jail_prop ip6_addr "${name}")"
-    local defaultgw
     defaultgw="$(__get_jail_prop defaultrouter "${name}")"
-    local defaultgw6
     defaultgw6="$(__get_jail_prop defaultrouter6 "${name}")"
-    local nics
     nics="$(__get_jail_prop interfaces "${name}" \
                |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
-    local ip4_list
     ip4_list="$(echo "${ip4}" | sed 's/,/ /g')"
-    local ip6_list
     ip6_list="$(echo "${ip6}" | sed 's/,/ /g')"
 
     if [ "${action}" == "start" ] ; then
         for i in ${nics} ; do
-            local nic
             nic="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
-            local bridge
             bridge="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
-	    local memberif
 	    memberif="$(ifconfig "${bridge}" | grep member | head -n1 | cut -d' ' -f2)"
-	    local brmtu
 	    brmtu="$(ifconfig "${memberif}" | head -n1 |cut -d' ' -f6)"
             epair_a="$(ifconfig epair create)"
             epair_b="$(echo "${epair_a}" | sed 's/a$/b/')"
@@ -91,7 +78,6 @@ __networking () {
 
     elif [ "${action}" == "stop" ] ; then
         for if in ${nics} ; do
-            local nic
             nic="$(echo "${if}" | cut -f 1 -d:)"
             ifconfig "${nic}:${jid}" destroy
         done
@@ -99,21 +85,16 @@ __networking () {
 }
 
 __stop_legacy_networking () {
-    local name
     name="${1}"
 
-    local ip4_addr
     ip4_addr="$(__get_jail_prop ip4_addr "${name}")"
-    local ip6_addr
     ip6_addr="$(__get_jail_prop ip6_addr "${name}")"
 
     if [ "${ip4_addr}" != "none" ] ; then
         IFS=','
         for ip in ${ip4_addr} ; do
-            local iface
             iface="$(echo "${ip}" | \
                          awk 'BEGIN { FS = "|" } ; { print $1 }')"
-            local ip4
             ip4="$(echo "${ip}" | \
                        awk 'BEGIN { FS = "|" } ; { print $2 }' | \
                        awk 'BEGIN { FS = "/" } ; { print $1 }')"
@@ -125,10 +106,8 @@ __stop_legacy_networking () {
     if [ "${ip6_addr}" != "none" ] ; then
         IFS=','
         for ip6 in ${ip6_addr} ; do
-            local iface
             iface="$(echo "${ip6}" | \
                          awk 'BEGIN { FS = "|" } ; { print $1 }')"
-            local ip6
             ip6="$(echo "${ip6}" | \
                        awk 'BEGIN { FS = "|" } ; { print $2 }' | \
                        awk 'BEGIN { FS = "/" } ; { print $1 }')"

--- a/lib/properties.sh
+++ b/lib/properties.sh
@@ -54,8 +54,8 @@ __set_jail_prop () {
         exit 1
     fi
 
-    pname="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $1 }')"
-    pval="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $2 }')"
+    pname="$(echo "${property}"| cut -d'=' -f1)"
+    pval="$(echo "${property}"| cut -d'=' -f2)"
 
     if [ -z "${pname}" ] || [ -z "${pval}" ] ; then
         echo "  ERROR: set failed, incorrect property syntax!"

--- a/lib/properties.sh
+++ b/lib/properties.sh
@@ -34,9 +34,7 @@ __export_props () {
 
 # Set properties ------------------------------------------------------
 __set_jail_prop () {
-    local name
     name="${2}"
-    local property
     property="${1}"
 
     if [ -z "${name}" ] || [ -z "${property}" ] ; then
@@ -44,7 +42,6 @@ __set_jail_prop () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -57,9 +54,7 @@ __set_jail_prop () {
         exit 1
     fi
 
-    local pname
     pname="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $1 }')"
-    local pval
     pval="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $2 }')"
 
     if [ -z "${pname}" ] || [ -z "${pval}" ] ; then
@@ -67,10 +62,8 @@ __set_jail_prop () {
         exit 1
     fi
 
-    local found
     found="0"
 
-    local CONF
     CONF="${CONF_NET}
                 ${CONF_JAIL}
                 ${CONF_RCTL}
@@ -103,9 +96,7 @@ __set_jail_prop () {
 
 # Get properties -----------------------------------------------------
 __get_jail_prop () {
-    local name
     name="${2}"
-    local property
     property="${1}"
 
     if [ -z "${property}" ] ; then
@@ -118,7 +109,6 @@ __get_jail_prop () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -131,10 +121,8 @@ __get_jail_prop () {
         exit 1
     fi
 
-    local found
     found="0"
 
-    local CONF
     CONF="${CONF_NET}
                 ${CONF_JAIL}
                 ${CONF_RCTL}
@@ -144,13 +132,11 @@ __get_jail_prop () {
     for prop in ${CONF} ; do
         if [ "${prop}" == "${property}" ] ; then
             found=1
-            local value
             value="$(zfs get -H -o value org.freebsd.iocage:"${prop}" \
                          "${dataset}")"
             echo "${value}"
         elif [ "${property}" == "all" ] ; then
             found=1
-            local value
             value="$(zfs get -H -o value org.freebsd.iocage:"${prop}" \
                          "${dataset}")"
             echo "${prop}:${value}"
@@ -160,7 +146,6 @@ __get_jail_prop () {
     for prop in ${CONF_ZFS} ; do
         if [ "${prop}" == "${property}" ] ; then
             found=1
-            local value
             value="$(zfs get -H -o value "${prop}" "${dataset}")"
             echo "${value}"
         fi
@@ -175,10 +160,7 @@ __get_jail_prop () {
 # reads tag property from given jail dataset
 # creates symlink from $iocroot/tags/<tag> to $iocroot/jails/<uuid>
 __link_tag () {
-    local dataset
     dataset="${1}"
-    local mountpoint
-    local tag
 
     if mountpoint="$(zfs get -H -o value mountpoint "${dataset}")" ; then
         if tag="$(zfs get -H -o value org.freebsd.iocage:tag "${dataset}")"; then
@@ -198,9 +180,7 @@ __link_tag () {
 
 # removes all symlinks found in $iocroot/tags pointing to the given jail dataset
 __unlink_tag () {
-    local dataset
     dataset="${1}"
-    local mountpoint
 
     if mountpoint="$(zfs get -H -o value mountpoint "${dataset}")" ; then
         find "${iocroot}/tags" -type l -lname "${mountpoint}*" -exec rm -f \{\} \;

--- a/lib/properties.sh
+++ b/lib/properties.sh
@@ -34,15 +34,18 @@ __export_props () {
 
 # Set properties ------------------------------------------------------
 __set_jail_prop () {
-    local name="${2}"
-    local property="${1}"
+    local name
+    name="${2}"
+    local property
+    property="${1}"
 
     if [ -z "${name}" ] || [ -z "${property}" ] ; then
         echo "  ERROR: missing property or UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -54,17 +57,21 @@ __set_jail_prop () {
         exit 1
     fi
 
-    local pname="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $1 }')"
-    local pval="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $2 }')"
+    local pname
+    pname="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $1 }')"
+    local pval
+    pval="$(echo "${property}"|awk 'BEGIN { FS = "=" } ; { print $2 }')"
 
     if [ -z "${pname}" ] || [ -z "${pval}" ] ; then
         echo "  ERROR: set failed, incorrect property syntax!"
         exit 1
     fi
 
-    local found="0"
+    local found
+    found="0"
 
-    local CONF="${CONF_NET}
+    local CONF
+    CONF="${CONF_NET}
                 ${CONF_JAIL}
                 ${CONF_RCTL}
                 ${CONF_CUSTOM}
@@ -96,8 +103,10 @@ __set_jail_prop () {
 
 # Get properties -----------------------------------------------------
 __get_jail_prop () {
-    local name="${2}"
-    local property="${1}"
+    local name
+    name="${2}"
+    local property
+    property="${1}"
 
     if [ -z "${property}" ] ; then
         echo "  ERROR: get failed, incorrect property syntax!"
@@ -109,7 +118,8 @@ __get_jail_prop () {
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: jail ${name} not found!"
@@ -121,9 +131,11 @@ __get_jail_prop () {
         exit 1
     fi
 
-    local found="0"
+    local found
+    found="0"
 
-    local CONF="${CONF_NET}
+    local CONF
+    CONF="${CONF_NET}
                 ${CONF_JAIL}
                 ${CONF_RCTL}
                 ${CONF_CUSTOM}
@@ -132,12 +144,14 @@ __get_jail_prop () {
     for prop in ${CONF} ; do
         if [ "${prop}" == "${property}" ] ; then
             found=1
-            local value="$(zfs get -H -o value org.freebsd.iocage:"${prop}" \
+            local value
+            value="$(zfs get -H -o value org.freebsd.iocage:"${prop}" \
                          "${dataset}")"
             echo "${value}"
         elif [ "${property}" == "all" ] ; then
             found=1
-            local value="$(zfs get -H -o value org.freebsd.iocage:"${prop}" \
+            local value
+            value="$(zfs get -H -o value org.freebsd.iocage:"${prop}" \
                          "${dataset}")"
             echo "${prop}:${value}"
         fi
@@ -146,7 +160,8 @@ __get_jail_prop () {
     for prop in ${CONF_ZFS} ; do
         if [ "${prop}" == "${property}" ] ; then
             found=1
-            local value="$(zfs get -H -o value "${prop}" "${dataset}")"
+            local value
+            value="$(zfs get -H -o value "${prop}" "${dataset}")"
             echo "${value}"
         fi
     done
@@ -160,7 +175,8 @@ __get_jail_prop () {
 # reads tag property from given jail dataset
 # creates symlink from $iocroot/tags/<tag> to $iocroot/jails/<uuid>
 __link_tag () {
-    local dataset="${1}"
+    local dataset
+    dataset="${1}"
     local mountpoint
     local tag
 
@@ -182,7 +198,8 @@ __link_tag () {
 
 # removes all symlinks found in $iocroot/tags pointing to the given jail dataset
 __unlink_tag () {
-    local dataset="${1}"
+    local dataset
+    dataset="${1}"
     local mountpoint
 
     if mountpoint="$(zfs get -H -o value mountpoint "${dataset}")" ; then

--- a/lib/rc_d.sh
+++ b/lib/rc_d.sh
@@ -24,20 +24,14 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __rc_jails () {
-    local action
     action="${1}"
-    local jails
     jails="$(__find_jail "ALL")"
-    local boot_list
     boot_list="/tmp/iocage.${$}"
 
     for jail in ${jails} ; do
-        local name
         name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
                     "${jail}")"
-        local boot
         boot="$(zfs get -H -o value org.freebsd.iocage:boot "${jail}")"
-        local priority
         priority="$(zfs get -H -o value org.freebsd.iocage:priority \
                         "${jail}")"
 
@@ -47,9 +41,7 @@ __rc_jails () {
     done
 
     if [ -e "${boot_list}" ] ; then
-        local boot_order
         boot_order="$(sort -n "${boot_list}")"
-        local shutdown_order
         shutdown_order="$(sort -rn "${boot_list}")"
     else
         echo "  ERROR: None of the jails have boot on"
@@ -60,11 +52,8 @@ __rc_jails () {
         echo "* [I|O|C] booting jails... "
 
         for i in ${boot_order} ; do
-            local jail
             jail="$(echo "${i}" | cut -f2 -d,)"
-            local jail_path
             jail_path="$(__get_jail_prop mountpoint "${jail}")"
-            local state
             state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
                       | cut -d' ' -f1)"
             if [ "${state}" -lt "1" ] ; then
@@ -76,11 +65,8 @@ __rc_jails () {
         echo "* [I|O|C] shutting down jails... "
 
         for i in ${shutdown_order} ; do
-            local jail
             jail="$(echo "${i}" | cut -f2 -d,)"
-            local jail_path
             jail_path="$(__get_jail_prop mountpoint "${jail}")"
-            local state
             state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
                       | cut -d' ' -f1)"
             if [ "${state}" -eq "1" ] ; then

--- a/lib/rc_d.sh
+++ b/lib/rc_d.sh
@@ -24,15 +24,21 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __rc_jails () {
-    local action="${1}"
-    local jails="$(__find_jail "ALL")"
-    local boot_list="/tmp/iocage.${$}"
+    local action
+    action="${1}"
+    local jails
+    jails="$(__find_jail "ALL")"
+    local boot_list
+    boot_list="/tmp/iocage.${$}"
 
     for jail in ${jails} ; do
-        local name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
+        local name
+        name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
                     "${jail}")"
-        local boot="$(zfs get -H -o value org.freebsd.iocage:boot "${jail}")"
-        local priority="$(zfs get -H -o value org.freebsd.iocage:priority \
+        local boot
+        boot="$(zfs get -H -o value org.freebsd.iocage:boot "${jail}")"
+        local priority
+        priority="$(zfs get -H -o value org.freebsd.iocage:priority \
                         "${jail}")"
 
         if [ "${boot}" == "on" ] ; then
@@ -41,8 +47,10 @@ __rc_jails () {
     done
 
     if [ -e "${boot_list}" ] ; then
-        local boot_order="$(sort -n "${boot_list}")"
-        local shutdown_order="$(sort -rn "${boot_list}")"
+        local boot_order
+        boot_order="$(sort -n "${boot_list}")"
+        local shutdown_order
+        shutdown_order="$(sort -rn "${boot_list}")"
     else
         echo "  ERROR: None of the jails have boot on"
         exit 1
@@ -52,9 +60,12 @@ __rc_jails () {
         echo "* [I|O|C] booting jails... "
 
         for i in ${boot_order} ; do
-            local jail="$(echo "${i}" | cut -f2 -d,)"
-            local jail_path="$(__get_jail_prop mountpoint "${jail}")"
-            local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
+            local jail
+            jail="$(echo "${i}" | cut -f2 -d,)"
+            local jail_path
+            jail_path="$(__get_jail_prop mountpoint "${jail}")"
+            local state
+            state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
                       | cut -d' ' -f1)"
             if [ "${state}" -lt "1" ] ; then
                 __start_jail "${jail}"
@@ -65,9 +76,12 @@ __rc_jails () {
         echo "* [I|O|C] shutting down jails... "
 
         for i in ${shutdown_order} ; do
-            local jail="$(echo "${i}" | cut -f2 -d,)"
-            local jail_path="$(__get_jail_prop mountpoint "${jail}")"
-            local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
+            local jail
+            jail="$(echo "${i}" | cut -f2 -d,)"
+            local jail_path
+            jail_path="$(__get_jail_prop mountpoint "${jail}")"
+            local state
+            state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
                       | cut -d' ' -f1)"
             if [ "${state}" -eq "1" ] ; then
                 __stop_jail "${jail}"

--- a/lib/rctl.sh
+++ b/lib/rctl.sh
@@ -24,9 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __rctl_limits () {
-    local name
     name="${1}"
-    local failed
     failed=0
 
     if [ -z "${name}" ] ; then
@@ -34,7 +32,6 @@ __rctl_limits () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -47,10 +44,8 @@ __rctl_limits () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
-    local rlimits
     rlimits="$(__get_jail_prop rlimits "${fulluuid}")"
 
     if [ "${rlimits}" == "on" ] ; then
@@ -83,18 +78,14 @@ __rctl_limits () {
 }
 
 __rctl_list () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "* All active limits:"
         rctl | grep jail
     else
-        local fulluuid
         fulluuid="$(__check_name "${name}")"
-        local jid
         jid="$(jls -j "ioc-${fulluuid}" jid)"
-        local limits
         limits="$(rctl -h | grep "${fulluuid}")"
 
         echo "* Active limits for jail: ${fulluuid}"
@@ -111,7 +102,6 @@ __rctl_list () {
 }
 
 __rctl_uncap () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -119,7 +109,6 @@ __rctl_uncap () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
     echo "  Releasing resource limits.."
@@ -130,7 +119,6 @@ __rctl_uncap () {
 
 
 __rctl_used () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -138,7 +126,6 @@ __rctl_used () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -151,7 +138,6 @@ __rctl_used () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
     echo "Consumed resources:"

--- a/lib/rctl.sh
+++ b/lib/rctl.sh
@@ -52,8 +52,8 @@ __rctl_limits () {
         echo -n "  + Applying resource limits"
         for prop in ${CONF_RCTL} ; do
             value="$(__get_jail_prop "${prop}" "${fulluuid}")"
-            limit="$(echo "${value}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
-            action="$(echo "${value}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
+            limit="$(echo "${value}" | cut -d':' -f1)"
+            action="$(echo "${value}" | cut -d':' -f2)"
 
             if [ "${limit}" == "off" ] ; then
                 continue

--- a/lib/rctl.sh
+++ b/lib/rctl.sh
@@ -24,15 +24,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __rctl_limits () {
-    local name="${1}"
-    local failed=0
+    local name
+    name="${1}"
+    local failed
+    failed=0
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -44,9 +47,11 @@ __rctl_limits () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
-    local rlimits="$(__get_jail_prop rlimits "${fulluuid}")"
+    local rlimits
+    rlimits="$(__get_jail_prop rlimits "${fulluuid}")"
 
     if [ "${rlimits}" == "on" ] ; then
         echo -n "  + Applying resource limits"
@@ -78,15 +83,19 @@ __rctl_limits () {
 }
 
 __rctl_list () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "* All active limits:"
         rctl | grep jail
     else
-        local fulluuid="$(__check_name "${name}")"
-        local jid="$(jls -j "ioc-${fulluuid}" jid)"
-        local limits="$(rctl -h | grep "${fulluuid}")"
+        local fulluuid
+        fulluuid="$(__check_name "${name}")"
+        local jid
+        jid="$(jls -j "ioc-${fulluuid}" jid)"
+        local limits
+        limits="$(rctl -h | grep "${fulluuid}")"
 
         echo "* Active limits for jail: ${fulluuid}"
 
@@ -102,14 +111,16 @@ __rctl_list () {
 }
 
 __rctl_uncap () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
     echo "  Releasing resource limits.."
     rctl -r "jail:ioc-${fulluuid}"
@@ -119,14 +130,16 @@ __rctl_uncap () {
 
 
 __rctl_used () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -138,7 +151,8 @@ __rctl_used () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
     echo "Consumed resources:"
     echo "-------------------"

--- a/lib/record.sh
+++ b/lib/record.sh
@@ -24,8 +24,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __record () {
-    local name="${2}"
-    local action="${1}"
+    local name
+    name="${2}"
+    local action
+    action="${1}"
 
     if [ -z "${action}" ] ; then
         echo "  ERROR: missing action or UUID"
@@ -37,7 +39,8 @@ __record () {
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -49,10 +52,13 @@ __record () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
-    local mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local union_mount="$(mount -t unionfs | grep "$fulluuid" | wc -l | \
+    local mountpoint
+    mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local union_mount
+    union_mount="$(mount -t unionfs | grep "$fulluuid" | wc -l | \
                         sed -e 's/^  *//' | cut -d' ' -f1)"
     if [ ! -d "${mountpoint}/recorded" ] ; then
         mkdir "${mountpoint}/recorded"

--- a/lib/record.sh
+++ b/lib/record.sh
@@ -24,9 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __record () {
-    local name
     name="${2}"
-    local action
     action="${1}"
 
     if [ -z "${action}" ] ; then
@@ -39,7 +37,6 @@ __record () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -52,12 +49,9 @@ __record () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
-    local mountpoint
     mountpoint="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local union_mount
     union_mount="$(mount -t unionfs | grep "$fulluuid" | wc -l | \
                         sed -e 's/^  *//' | cut -d' ' -f1)"
     if [ ! -d "${mountpoint}/recorded" ] ; then

--- a/lib/runstop.sh
+++ b/lib/runstop.sh
@@ -398,7 +398,7 @@ __stop_jail () {
     fi
 
     echo -n "  + Removing jail process"
-    jail -r "ioc-${fulluuid}"
+    jail -r "ioc-${fulluuid}" >/dev/null 2>&1
 
     if [ "${?}" -ne 1 ] ; then
         echo "    OK"

--- a/lib/runstop.sh
+++ b/lib/runstop.sh
@@ -24,14 +24,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __start_jail () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -43,19 +45,31 @@ __start_jail () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
-    local jail_type="$(__get_jail_prop type "${fulluuid}")"
-    local tag="$(__get_jail_prop tag "${fulluuid}")"
-    local jail_hostid="$(__get_jail_prop hostid "${fulluuid}")"
-    local jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local template="$(__get_jail_prop template "${fulluuid}")"
-    local cpuset="$(__get_jail_prop cpuset "${fulluuid}")"
-    local procfs="$(__get_jail_prop mount_procfs "${fulluuid}")"
-    local jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
+    local jail_type
+    jail_type="$(__get_jail_prop type "${fulluuid}")"
+    local tag
+    tag="$(__get_jail_prop tag "${fulluuid}")"
+    local jail_hostid
+    jail_hostid="$(__get_jail_prop hostid "${fulluuid}")"
+    local jail_path
+    jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local template
+    template="$(__get_jail_prop template "${fulluuid}")"
+    local cpuset
+    cpuset="$(__get_jail_prop cpuset "${fulluuid}")"
+    local procfs
+    procfs="$(__get_jail_prop mount_procfs "${fulluuid}")"
+    local jail_path
+    jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
+    local state
+    state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local vnet="$(__get_jail_prop vnet "${fulluuid}")"
-    local nics="$(__get_jail_prop interfaces "${fulluuid}" \
+    local vnet
+    vnet="$(__get_jail_prop vnet "${fulluuid}")"
+    local nics
+    nics="$(__get_jail_prop interfaces "${fulluuid}" \
                |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
 
     if [ "${state}" -eq "1" ] ; then
@@ -69,8 +83,10 @@ __start_jail () {
     fi
 
     for i in ${nics} ; do
-        local nic="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
-        local bridge="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
+        local nic
+        nic="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
+        local bridge
+        bridge="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
 
         if [ -z "${nic}" ] || [ -z "${bridge}" ] ; then
             echo "  ERROR  : incorrect interfaces property format"
@@ -95,8 +111,10 @@ __start_jail () {
         mount -t procfs proc "${iocroot}/jails/${fulluuid}/root/proc"
     fi
 
-    local jzfs="$(__get_jail_prop jail_zfs "${fulluuid}")"
-    local jzfs_dataset="$(__get_jail_prop jail_zfs_dataset "${fulluuid}")"
+    local jzfs
+    jzfs="$(__get_jail_prop jail_zfs "${fulluuid}")"
+    local jzfs_dataset
+    jzfs_dataset="$(__get_jail_prop jail_zfs_dataset "${fulluuid}")"
 
     if [ "${jzfs}" == "on" ] ; then
         __set_jail_prop allow_mount=1 "${fulluuid}"
@@ -105,7 +123,7 @@ __start_jail () {
         zfs set jailed=on "${pool}/${jzfs_dataset}"
     fi
 
-    if [ "${vnet}" == "on" ] || [ "${vnet}" == "-" ] ; then
+    if [ "${vnet}" = "on" ] || [ "${vnet}" == "-" ] ; then
         if [ ! -z "$(sysctl -qn kern.features.vimage)" ] ; then
             echo "* Starting ${fulluuid} (${tag})"
             __vnet_start "${fulluuid}"
@@ -147,7 +165,8 @@ __start_jail () {
 
     if [ "${cpuset}" != "off" ] ; then
         echo -n "  + Appliyng CPU affinity"
-        local jid="$(jls -j "ioc-${fulluuid}" jid)"
+        local jid
+        jid="$(jls -j "ioc-${fulluuid}" jid)"
         cpuset -l "${cpuset}" -j "${jid}"
         if [ "${?}" -eq 1 ] ; then
             echo "    FAILED"
@@ -176,10 +195,14 @@ __start_jail () {
 
 # Start a VNET jail
 __vnet_start () {
-    local name="${1}"
-    local jail_path="$(__get_jail_prop mountpoint "${name}")"
-    local fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs "${name}")"
-    local tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs "${name}")"
+    local name
+    name="${1}"
+    local jail_path
+    jail_path="$(__get_jail_prop mountpoint "${name}")"
+    local fdescfs
+    fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs "${name}")"
+    local tmpfs
+    tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs "${name}")"
 
 
     if [ "$(uname -U)" == "903000" ];
@@ -225,13 +248,19 @@ __vnet_start () {
 
 # Start a shared IP jail
 __legacy_start () {
-    local name="${1}"
-    local jail_path="$(__get_jail_prop mountpoint "${name}")"
-    local ip4_addr="$(__get_jail_prop ip4_addr "${name}")"
-    local ip6_addr="$(__get_jail_prop ip6_addr "${name}")"
+    local name
+    name="${1}"
+    local jail_path
+    jail_path="$(__get_jail_prop mountpoint "${name}")"
+    local ip4_addr
+    ip4_addr="$(__get_jail_prop ip4_addr "${name}")"
+    local ip6_addr
+    ip6_addr="$(__get_jail_prop ip6_addr "${name}")"
 
-    local fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs "${name}")"
-    local tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs "${name}")"
+    local fdescfs
+    fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs "${name}")"
+    local tmpfs
+    tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs "${name}")"
 
     if [ "$(uname -U)" == "903000" ];
     then
@@ -331,14 +360,16 @@ __legacy_start () {
 }
 
 __stop_jail () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -350,14 +381,22 @@ __stop_jail () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
-    local jail_path="$(__get_jail_prop mountpoint "${name}")"
-    local tag="$(__get_jail_prop tag "${fulluuid}")"
-    local exec_prestop="$(__findscript "${fulluuid}" prestop)"
-    local exec_stop="$(__get_jail_prop exec_stop "${fulluuid}")"
-    local exec_poststop="$(__findscript "${fulluuid}" poststop)"
-    local vnet="$(__get_jail_prop vnet "${fulluuid}")"
-    local state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
+    local jail_path
+    jail_path="$(__get_jail_prop mountpoint "${name}")"
+    local tag
+    tag="$(__get_jail_prop tag "${fulluuid}")"
+    local exec_prestop
+    exec_prestop="$(__findscript "${fulluuid}" prestop)"
+    local exec_stop
+    exec_stop="$(__get_jail_prop exec_stop "${fulluuid}")"
+    local exec_poststop
+    exec_poststop="$(__findscript "${fulluuid}" poststop)"
+    local vnet
+    vnet="$(__get_jail_prop vnet "${fulluuid}")"
+    local state
+    state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
 
@@ -425,7 +464,8 @@ __stop_jail () {
     fi
 
     if [ ! -z $(sysctl -qn kern.features.rctl) ] ; then
-        local rlimits="$(rctl | grep "$fulluuid" | wc -l | sed -e 's/^  *//' \
+        local rlimits
+        rlimits="$(rctl | grep "$fulluuid" | wc -l | sed -e 's/^  *//' \
                 | cut -d' ' -f1)"
         if [ "${rlimits}" -gt "0" ] ; then
             rctl -r "jail:ioc-${fulluuid}"
@@ -435,14 +475,16 @@ __stop_jail () {
 
 # Soft restart
 __restart_jail () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -454,11 +496,16 @@ __restart_jail () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
-    local exec_stop="$(__get_jail_prop exec_stop "${fulluuid}")"
-    local exec_start="$(__get_jail_prop exec_start "${fulluuid}")"
-    local jid="$(jls -j "ioc-${fulluuid}" jid)"
-    local tag="$(__get_jail_prop tag "${fulluuid}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
+    local exec_stop
+    exec_stop="$(__get_jail_prop exec_stop "${fulluuid}")"
+    local exec_start
+    exec_start="$(__get_jail_prop exec_start "${fulluuid}")"
+    local jid
+    jid="$(jls -j "ioc-${fulluuid}" jid)"
+    local tag
+    tag="$(__get_jail_prop tag "${fulluuid}")"
 
     echo "* Soft restarting ${fulluuid} (${tag})"
     jexec "ioc-${fulluuid}" ${exec_stop} >> \
@@ -476,14 +523,16 @@ __restart_jail () {
 }
 
 __runtime () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -495,13 +544,16 @@ __runtime () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
 
-    local state="$(jls -n -j "ioc-${fulluuid}" | wc -l | sed -e 's/^  *//' \
+    local state
+    state="$(jls -n -j "ioc-${fulluuid}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
     if [ "${state}" -eq "1" ] ; then
-        local params="$(jls -nj "ioc-${fulluuid}")"
+        local params
+        params="$(jls -nj "ioc-${fulluuid}")"
         for i in ${params} ; do
             echo "  ${i}"
         done

--- a/lib/runstop.sh
+++ b/lib/runstop.sh
@@ -55,8 +55,7 @@ __start_jail () {
     state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
     vnet="$(__get_jail_prop vnet "${fulluuid}")"
-    nics="$(__get_jail_prop interfaces "${fulluuid}" \
-               |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
+    nics="$(__get_jail_prop interfaces "${fulluuid}" | cut -d',' -f1,2,3,4)"
 
     if [ "${state}" -eq "1" ] ; then
         echo "* ${fulluuid}: is already up"
@@ -69,8 +68,8 @@ __start_jail () {
     fi
 
     for i in ${nics} ; do
-        nic="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
-        bridge="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
+        nic="$(echo "${i}" |cut -d':' -f1)"
+        bridge="$(echo "${i}" | cut -d':' -f2)"
 
         if [ -z "${nic}" ] || [ -z "${bridge}" ] ; then
             echo "  ERROR  : incorrect interfaces property format"

--- a/lib/runstop.sh
+++ b/lib/runstop.sh
@@ -24,7 +24,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 __start_jail () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -32,7 +31,6 @@ __start_jail () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -45,30 +43,18 @@ __start_jail () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
-    local jail_type
     jail_type="$(__get_jail_prop type "${fulluuid}")"
-    local tag
     tag="$(__get_jail_prop tag "${fulluuid}")"
-    local jail_hostid
     jail_hostid="$(__get_jail_prop hostid "${fulluuid}")"
-    local jail_path
     jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local template
     template="$(__get_jail_prop template "${fulluuid}")"
-    local cpuset
     cpuset="$(__get_jail_prop cpuset "${fulluuid}")"
-    local procfs
     procfs="$(__get_jail_prop mount_procfs "${fulluuid}")"
-    local jail_path
     jail_path="$(__get_jail_prop mountpoint "${fulluuid}")"
-    local state
     state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
-    local vnet
     vnet="$(__get_jail_prop vnet "${fulluuid}")"
-    local nics
     nics="$(__get_jail_prop interfaces "${fulluuid}" \
                |awk 'BEGIN { FS = "," } ; { print $1,$2,$3,$4 }')"
 
@@ -83,9 +69,7 @@ __start_jail () {
     fi
 
     for i in ${nics} ; do
-        local nic
         nic="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $1 }')"
-        local bridge
         bridge="$(echo "${i}" | awk 'BEGIN { FS = ":" } ; { print $2 }')"
 
         if [ -z "${nic}" ] || [ -z "${bridge}" ] ; then
@@ -111,9 +95,7 @@ __start_jail () {
         mount -t procfs proc "${iocroot}/jails/${fulluuid}/root/proc"
     fi
 
-    local jzfs
     jzfs="$(__get_jail_prop jail_zfs "${fulluuid}")"
-    local jzfs_dataset
     jzfs_dataset="$(__get_jail_prop jail_zfs_dataset "${fulluuid}")"
 
     if [ "${jzfs}" == "on" ] ; then
@@ -165,7 +147,6 @@ __start_jail () {
 
     if [ "${cpuset}" != "off" ] ; then
         echo -n "  + Appliyng CPU affinity"
-        local jid
         jid="$(jls -j "ioc-${fulluuid}" jid)"
         cpuset -l "${cpuset}" -j "${jid}"
         if [ "${?}" -eq 1 ] ; then
@@ -195,13 +176,9 @@ __start_jail () {
 
 # Start a VNET jail
 __vnet_start () {
-    local name
     name="${1}"
-    local jail_path
     jail_path="$(__get_jail_prop mountpoint "${name}")"
-    local fdescfs
     fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs "${name}")"
-    local tmpfs
     tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs "${name}")"
 
 
@@ -248,18 +225,12 @@ __vnet_start () {
 
 # Start a shared IP jail
 __legacy_start () {
-    local name
     name="${1}"
-    local jail_path
     jail_path="$(__get_jail_prop mountpoint "${name}")"
-    local ip4_addr
     ip4_addr="$(__get_jail_prop ip4_addr "${name}")"
-    local ip6_addr
     ip6_addr="$(__get_jail_prop ip6_addr "${name}")"
 
-    local fdescfs
     fdescfs="mount.fdescfs=$(__get_jail_prop mount_fdescfs "${name}")"
-    local tmpfs
     tmpfs="allow.mount.tmpfs=$(__get_jail_prop allow_mount_tmpfs "${name}")"
 
     if [ "$(uname -U)" == "903000" ];
@@ -360,7 +331,6 @@ __legacy_start () {
 }
 
 __stop_jail () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -368,7 +338,6 @@ __stop_jail () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -381,21 +350,13 @@ __stop_jail () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
-    local jail_path
     jail_path="$(__get_jail_prop mountpoint "${name}")"
-    local tag
     tag="$(__get_jail_prop tag "${fulluuid}")"
-    local exec_prestop
     exec_prestop="$(__findscript "${fulluuid}" prestop)"
-    local exec_stop
     exec_stop="$(__get_jail_prop exec_stop "${fulluuid}")"
-    local exec_poststop
     exec_poststop="$(__findscript "${fulluuid}" poststop)"
-    local vnet
     vnet="$(__get_jail_prop vnet "${fulluuid}")"
-    local state
     state="$(jls | grep "${jail_path}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
@@ -464,7 +425,6 @@ __stop_jail () {
     fi
 
     if [ ! -z $(sysctl -qn kern.features.rctl) ] ; then
-        local rlimits
         rlimits="$(rctl | grep "$fulluuid" | wc -l | sed -e 's/^  *//' \
                 | cut -d' ' -f1)"
         if [ "${rlimits}" -gt "0" ] ; then
@@ -475,7 +435,6 @@ __stop_jail () {
 
 # Soft restart
 __restart_jail () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -483,7 +442,6 @@ __restart_jail () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -496,15 +454,10 @@ __restart_jail () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
-    local exec_stop
     exec_stop="$(__get_jail_prop exec_stop "${fulluuid}")"
-    local exec_start
     exec_start="$(__get_jail_prop exec_start "${fulluuid}")"
-    local jid
     jid="$(jls -j "ioc-${fulluuid}" jid)"
-    local tag
     tag="$(__get_jail_prop tag "${fulluuid}")"
 
     echo "* Soft restarting ${fulluuid} (${tag})"
@@ -523,7 +476,6 @@ __restart_jail () {
 }
 
 __runtime () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -531,7 +483,6 @@ __runtime () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -544,15 +495,12 @@ __runtime () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
 
-    local state
     state="$(jls -n -j "ioc-${fulluuid}" | wc -l | sed -e 's/^  *//' \
               | cut -d' ' -f1)"
 
     if [ "${state}" -eq "1" ] ; then
-        local params
         params="$(jls -nj "ioc-${fulluuid}")"
         for i in ${params} ; do
             echo "  ${i}"

--- a/lib/setup.sh
+++ b/lib/setup.sh
@@ -50,12 +50,9 @@ __resolv_conf () {
 # search for executable prestart|poststart|prestop|poststop in jail_dir first,
 # else use jail exec_<type> property unchanged
 __findscript () {
-    local name
     name="${1}"
     # type should be one of prestart|poststart|prestop|poststop
-    local type
     type="${2}"
-    local jail_path
     jail_path="$(__get_jail_prop mountpoint "${name}")"
 
     if [ -x "${jail_path}/${type}" ]; then

--- a/lib/setup.sh
+++ b/lib/setup.sh
@@ -50,10 +50,13 @@ __resolv_conf () {
 # search for executable prestart|poststart|prestop|poststop in jail_dir first,
 # else use jail exec_<type> property unchanged
 __findscript () {
-    local name="${1}"
+    local name
+    name="${1}"
     # type should be one of prestart|poststart|prestop|poststop
-    local type="${2}"
-    local jail_path="$(__get_jail_prop mountpoint "${name}")"
+    local type
+    type="${2}"
+    local jail_path
+    jail_path="$(__get_jail_prop mountpoint "${name}")"
 
     if [ -x "${jail_path}/${type}" ]; then
         echo "${jail_path}/${type}"

--- a/lib/zfs.sh
+++ b/lib/zfs.sh
@@ -89,7 +89,7 @@ __find_mypool () {
     found="0"
 
     for i in ${pools} ; do
-        mypool="$(zpool get comment "${i}" | grep -v NAME | awk '{print $3}')"
+        mypool="$(zpool get comment "${i}" | grep -v NAME | cut -w -f3)"
 
         if [ "${mypool}" == "iocage" ] ; then
             export pool="${i}"
@@ -118,8 +118,8 @@ __find_mypool () {
 }
 
 __snapshot () {
-    name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    name="$(echo "${1}" | cut -d'@' -f1)"
+    snapshot="$(echo "${1}" | cut -d'@' -f2)"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
@@ -144,8 +144,8 @@ __snapshot () {
 
 
 __snapremove () {
-    name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    name="$(echo "${1}" | cut -d'@' -f1)"
+    snapshot="$(echo "${1}" | cut -d'@' -f2)"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
@@ -194,7 +194,7 @@ __snaplist () {
     fi
 
     fulluuid="$(__check_name "${name}")"
-    snapshots="$(zfs list -Hrt snapshot -d1 "${dataset}" | awk '{print $1}')"
+    snapshots="$(zfs list -Hrt snapshot -d1 "${dataset}" | cut -w -f1)"
 
     printf "%-36s  %-21s  %s   %s\n" "NAME" "CREATED"\
             "RSIZE" "USED"
@@ -212,8 +212,8 @@ __snaplist () {
 }
 
 __rollback () {
-    name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    name="$(echo "${1}" | cut -d'@' -f1)"
+    snapshot="$(echo "${1}" | cut -d'@' -f2)"
     dataset="$(__find_jail "${name}")"
 
     if [ "${dataset}" == "multiple" ] ; then

--- a/lib/zfs.sh
+++ b/lib/zfs.sh
@@ -25,11 +25,8 @@
 
 # Find and return the jail's top level ZFS dataset
 __find_jail () {
-    local name
     name="${1}"
-    local jlist
     jlist="/tmp/iocage-jail-list.${$}"
-    local jails
     jails="$(zfs list -rH -o name "${pool}/iocage/jails" \
                  | grep -E \
               "^$pool/iocage/jails/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}$")"
@@ -42,7 +39,6 @@ __find_jail () {
         for jail in $jails ; do
             found="$(echo "${jail}" |grep -iE "^${pool}/iocage/jails/${name}"|\
                     wc -l|sed -e 's/^  *//')"
-            local tag
             tag="$(zfs get -H -o value org.freebsd.iocage:tag "${jail}")"
 
             if [ "${found}" -eq 1 ] ; then
@@ -71,7 +67,6 @@ __find_jail () {
 }
 
 __print_disk () {
-    local jails
     jails="$(__find_jail ALL)"
 
     printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s\n" "UUID" "CRT" "RES" "QTA" "USE" "AVA"
@@ -123,9 +118,7 @@ __find_mypool () {
 }
 
 __snapshot () {
-    local name
     name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot
     snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
     if [ -z "${name}" ] ; then
@@ -133,7 +126,6 @@ __snapshot () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ "${dataset}" == "multiple" ] ; then
@@ -141,7 +133,6 @@ __snapshot () {
         exit 1
     fi
 
-    local date
     date="$(date "+%F_%T")"
 
     if [ ! -z "${snapshot}" ] ; then
@@ -153,9 +144,7 @@ __snapshot () {
 
 
 __snapremove () {
-    local name
     name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot
     snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
     if [ -z "${name}" ] ; then
@@ -163,7 +152,6 @@ __snapremove () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -186,7 +174,6 @@ __snapremove () {
 }
 
 __snaplist () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -194,7 +181,6 @@ __snaplist () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -207,22 +193,16 @@ __snaplist () {
         exit 1
     fi
 
-    local fulluuid
     fulluuid="$(__check_name "${name}")"
-    local snapshots
     snapshots="$(zfs list -Hrt snapshot -d1 "${dataset}" | awk '{print $1}')"
 
     printf "%-36s  %-21s  %s   %s\n" "NAME" "CREATED"\
             "RSIZE" "USED"
 
     for i in ${snapshots} ; do
-        local snapname
         snapname="$(echo "${i}" |cut -f 2 -d \@)"
-        local creation
         creation="$(zfs get -H -o value creation "${i}")"
-        local used
         used="$(zfs get -H -o value used "${i}")"
-        local referenced
         referenced="$(zfs get -H -o value referenced "${i}")"
 
         printf "%-36s  %-21s  %s    %s\n" "${snapname}" "${creation}"\
@@ -232,11 +212,8 @@ __snaplist () {
 }
 
 __rollback () {
-    local name
     name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot
     snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ "${dataset}" == "multiple" ] ; then
@@ -244,7 +221,6 @@ __rollback () {
         exit 1
     fi
 
-    local fs_list
     fs_list="$(zfs list -rH -o name "${dataset}")"
 
     if [ ! -z "${snapshot}" ] ; then
@@ -257,7 +233,6 @@ __rollback () {
 
 
 __promote () {
-    local name
     name="${1}"
 
     if [ -z "${name}" ] ; then
@@ -265,7 +240,6 @@ __promote () {
         exit 1
     fi
 
-    local dataset
     dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
@@ -278,7 +252,6 @@ __promote () {
         exit 1
     fi
 
-    local fs_list
     fs_list="$(zfs list -rH -o name "${dataset}")"
 
     if [ -z "${dataset}" ] ; then
@@ -287,7 +260,6 @@ __promote () {
     fi
 
     for fs in ${fs_list} ; do
-        local origin
         origin="$(zfs get -H -o value origin "${fs}")"
 
         if [ "${origin}" != "-" ] ; then

--- a/lib/zfs.sh
+++ b/lib/zfs.sh
@@ -25,9 +25,12 @@
 
 # Find and return the jail's top level ZFS dataset
 __find_jail () {
-    local name="${1}"
-    local jlist="/tmp/iocage-jail-list.${$}"
-    local jails="$(zfs list -rH -o name "${pool}/iocage/jails" \
+    local name
+    name="${1}"
+    local jlist
+    jlist="/tmp/iocage-jail-list.${$}"
+    local jails
+    jails="$(zfs list -rH -o name "${pool}/iocage/jails" \
                  | grep -E \
               "^$pool/iocage/jails/[a-zA-Z0-9]{8,}-.*-.*-.*-[a-zA-Z0-9]{12,}$")"
 
@@ -39,7 +42,8 @@ __find_jail () {
         for jail in $jails ; do
             found="$(echo "${jail}" |grep -iE "^${pool}/iocage/jails/${name}"|\
                     wc -l|sed -e 's/^  *//')"
-            local tag="$(zfs get -H -o value org.freebsd.iocage:tag "${jail}")"
+            local tag
+            tag="$(zfs get -H -o value org.freebsd.iocage:tag "${jail}")"
 
             if [ "${found}" -eq 1 ] ; then
                 echo "${jail}" >> "${jlist}"
@@ -67,7 +71,8 @@ __find_jail () {
 }
 
 __print_disk () {
-    local jails="$(__find_jail ALL)"
+    local jails
+    jails="$(__find_jail ALL)"
 
     printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s\n" "UUID" "CRT" "RES" "QTA" "USE" "AVA"
 
@@ -118,22 +123,26 @@ __find_mypool () {
 }
 
 __snapshot () {
-    local name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    local name
+    name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
+    local snapshot
+    snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local date="$(date "+%F_%T")"
+    local date
+    date="$(date "+%F_%T")"
 
     if [ ! -z "${snapshot}" ] ; then
         zfs snapshot -r "${dataset}@${snapshot}"
@@ -144,15 +153,18 @@ __snapshot () {
 
 
 __snapremove () {
-    local name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    local name
+    name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
+    local snapshot
+    snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: jail dataset not found"
@@ -174,14 +186,16 @@ __snapremove () {
 }
 
 __snaplist () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -193,17 +207,23 @@ __snaplist () {
         exit 1
     fi
 
-    local fulluuid="$(__check_name "${name}")"
-    local snapshots="$(zfs list -Hrt snapshot -d1 "${dataset}" | awk '{print $1}')"
+    local fulluuid
+    fulluuid="$(__check_name "${name}")"
+    local snapshots
+    snapshots="$(zfs list -Hrt snapshot -d1 "${dataset}" | awk '{print $1}')"
 
     printf "%-36s  %-21s  %s   %s\n" "NAME" "CREATED"\
             "RSIZE" "USED"
 
     for i in ${snapshots} ; do
-        local snapname="$(echo "${i}" |cut -f 2 -d \@)"
-        local creation="$(zfs get -H -o value creation "${i}")"
-        local used="$(zfs get -H -o value used "${i}")"
-        local referenced="$(zfs get -H -o value referenced "${i}")"
+        local snapname
+        snapname="$(echo "${i}" |cut -f 2 -d \@)"
+        local creation
+        creation="$(zfs get -H -o value creation "${i}")"
+        local used
+        used="$(zfs get -H -o value used "${i}")"
+        local referenced
+        referenced="$(zfs get -H -o value referenced "${i}")"
 
         printf "%-36s  %-21s  %s    %s\n" "${snapname}" "${creation}"\
                    "${referenced}" "${used}"
@@ -212,16 +232,20 @@ __snaplist () {
 }
 
 __rollback () {
-    local name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
-    local snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
-    local dataset="$(__find_jail "${name}")"
+    local name
+    name="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $1 }')"
+    local snapshot
+    snapshot="$(echo "${1}" |  awk 'BEGIN { FS = "@" } ; { print $2 }')"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ "${dataset}" == "multiple" ] ; then
         echo "  ERROR: multiple matching UUIDs!"
         exit 1
     fi
 
-    local fs_list="$(zfs list -rH -o name "${dataset}")"
+    local fs_list
+    fs_list="$(zfs list -rH -o name "${dataset}")"
 
     if [ ! -z "${snapshot}" ] ; then
         for fs in ${fs_list} ; do
@@ -233,14 +257,16 @@ __rollback () {
 
 
 __promote () {
-    local name="${1}"
+    local name
+    name="${1}"
 
     if [ -z "${name}" ] ; then
         echo "  ERROR: missing UUID"
         exit 1
     fi
 
-    local dataset="$(__find_jail "${name}")"
+    local dataset
+    dataset="$(__find_jail "${name}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: ${name} not found"
@@ -252,7 +278,8 @@ __promote () {
         exit 1
     fi
 
-    local fs_list="$(zfs list -rH -o name "${dataset}")"
+    local fs_list
+    fs_list="$(zfs list -rH -o name "${dataset}")"
 
     if [ -z "${dataset}" ] ; then
         echo "  ERROR: dataset not found"
@@ -260,7 +287,8 @@ __promote () {
     fi
 
     for fs in ${fs_list} ; do
-        local origin="$(zfs get -H -o value origin "${fs}")"
+        local origin
+        origin="$(zfs get -H -o value origin "${fs}")"
 
         if [ "${origin}" != "-" ] ; then
             echo "* promoting filesystem: ${fs}"


### PR DESCRIPTION
This one is kind of out-there, really.

Shellcheck, the most amazing sh linter ever designed by mankind doesn't like the all-in-one declaration and assignment of local variables. It also doesn't like the all-in-one for exporting them, and it also DOES want the global variables exported, which I sort-of agree with.

Very strictly speaking, they don't need to be. However, @skarekrow and I both agree explicit is better than "let's hope ash doesn't change this behaviour."

I considered making separate sections for the assignment and local/global, and decided that despite the ugliness presented by this method, it makes for a pretty blunt reminder that if you're going to put in a global variable, you export it right after. Same thing for the locals in the functions.

I'm also debating the necessity of even HAVING the variables declared as local. I don't think it's needed, so I'll be doing so random testing on that.