### PR TITLE
Improvements to 'fetch'

### DIFF
--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -5,6 +5,7 @@ __export_props () {
     for i in "$@" ; do
         if [ "$(echo $i | grep -e ".*=.*")" ] ; then
             export "$i"
+            export "iocset_${i}"
         fi
     done
 }
@@ -172,30 +173,34 @@ __chroot () {
 # Fetch release and prepare base ZFS filesystems-----------
 __fetch_release () {
     local _rel_exist 
+    local _default_rel
+    _default_rel=$(uname -r|cut -f 1,2 -d'-')
 
-    __print_release
+    if [ -z "$iocset_release" ] ; then
+	__print_release
 
-    echo -n "Please select a release [$release]: "
-    read answer
+	echo -n "Please select a release [$release]: "
+	read answer
 
-    if [ ! -z "$answer" ] ; then
-        release="$answer"
-    else
-        answer="$release"
+	if [ -z "$answer" ] ; then
+		answer="$release"
+	else
+		release="$answer"
+		for rel in $(echo $supported) ; do
+			if [ "$answer" == "$rel" ] ; then
+				release="$rel"
+				match="1"
+				break
+			fi
+		done
+
+		if [ -z $match ] ; then
+			echo "Invalid release $release specified, exiting.."
+			exit 1
+		fi
+	fi
     fi
 
-    for rel in $(echo $supported) ; do
-        if [ "$answer" == "$rel" ] ; then
-            release="$rel"
-            match="1"
-            break
-        fi
-    done
-
-    if [ -z $match ] ; then
-        echo "Invalid release $release specified, exiting.."
-        exit 1
-    fi
 
     _rel_exist=$(zfs list | grep -w ^${pool}${iocroot}/releases/${release})
 
@@ -210,6 +215,10 @@ __fetch_release () {
     for file in $ftpfiles ; do
         if [ ! -e "$file" ] ; then
             fetch http://${ftphost}${ftpdir}/${file}
+            if [ $? -ne 0 ] ; then
+		echo "Failed fetching $file.."
+		exit 1
+            fi
         fi
     done
 

--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -209,7 +209,9 @@ __fetch_release () {
         zfs create -o compression=lz4 -p ${pool}${iocroot}/download/${release}
     fi
 
-    ftpdir="/pub/FreeBSD/releases/amd64/$release"
+    if [ -z "$ftpdir" ] ; then
+	ftpdir="/pub/FreeBSD/releases/amd64/$release"
+    fi
 
     cd ${iocroot}/download/${release}
     for file in $ftpfiles ; do

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -6,7 +6,7 @@ NAME
   iocage - jail manager amalgamating ZFS, VNET and resource limits
 SYNOPSIS
   iocage activate ZPOOL
-  iocage fetch [release=RELEASE | ftphost=ftp.hostname.org]
+  iocage fetch [release=RELEASE | ftphost=ftp.hostname.org | ftpdir=/dir/]
   iocage create [-b|-c|-e] [release=RELEASE] [pkglist=file] [property=value]
   iocage clone UUID|TAG [UUID|TAG@snapshot] [property=value]
   iocage destroy [-f] UUID|TAG|ALL
@@ -89,7 +89,7 @@ SUBCOMMANDS
     Intended for automation tools. The pool can be activated for iocage jails
     without requiring user input.
 
-  fetch [release=RELEASE | ftphost=ftp.hostname.org]
+  fetch [release=RELEASE | ftphost=ftp.hostname.org | ftpdir=/dir/]
 
     Used for downloading and updating/patching releases.
 
@@ -1325,7 +1325,7 @@ __show () {
 __usage () {
     echo "usage:"
     echo "  iocage activate ZPOOL"
-    echo "  iocage fetch [release=RELEASE | ftphost=ftp.hostname.org]"
+    echo "  iocage fetch [release=RELEASE | ftphost=ftp.hostname.org | ftpdir=/dir/]"
     echo "  iocage create [-b|-c|-e] [release=RELEASE] [pkglist=file] [property=value]"
     echo "  iocage clone UUID|TAG@snapshot [property=value]"
     echo "  iocage destroy [-f] UUID|TAG|ALL"


### PR DESCRIPTION
These changes fix how iocage fetch handles user supplied args. It doesn't prompt to select from list if the user has already specified the version on the CLI. It also enables the 'ftpdir=' arg. With these two changes we can now pull from PC-BSD mirrors, and use non-standard versions, I.E. -CURRENT images, etc. 