### PR TITLE
 - Add a new Makefile which will install iocage into FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+#
+#	Makefile
+#
+
+.include <bsd.own.mk>
+
+PREFIX?= /usr/local
+MAN=
+BINOWN=		root
+BINGRP=		wheel
+BINMODE=	0555
+BINDIR=$(PREFIX)/sbin
+FILESDIR=$(PREFIX)/lib/iocage
+RCDIR=$(PREFIX)/etc/rc.d
+MANDIR=$(PREFIX)/man/man8
+MKDIR=mkdir
+
+PROG=	iocage
+MAN=	$(PROG).8
+
+install:
+	$(MKDIR) -p $(BINDIR)
+	$(MKDIR) -p $(FILESDIR)
+	$(INSTALL) -m $(BINMODE) $(PROG) $(BINDIR)/
+	$(INSTALL) lib/* $(FILESDIR)/
+	$(INSTALL) rc.d/* $(RCDIR)/
+	rm -f $(MAN).gz
+	gzip -k $(MAN)
+	$(INSTALL) $(MAN).gz $(MANDIR)/
+	rm -f $(MAN).gz
+
+.include <bsd.prog.mk>


### PR DESCRIPTION
Added a really basic Makefile, so you can run "make install" and end up with iocage and related bits in /usr/local or whatever PREFIX

Feel free to expand upon this, but it satisfies my laziness at the moment. 