### PR TITLE
Change library load order.

### DIFF
--- a/iocage
+++ b/iocage
@@ -47,10 +47,10 @@ if [ "$(uname -K)" -lt "903000" ]; then
 fi
 
 # Check if libs are available
-if [ -e "./lib" ] ; then
-    LIB="./lib"
-elif [ -e "/usr/local/lib/iocage" ] ; then
+if [ -e "/usr/local/lib/iocage" ] ; then
     LIB="/usr/local/lib/iocage"
+elif [ -e "./lib" ] ; then
+    LIB="./lib"
 else
     echo "ERROR: missing libraries"
     exit 1


### PR DESCRIPTION
In some cases (I ran into this when trying to run iocage's boot script), iocage will have problems with finding the library and choose `./lib` instead of `/usr/local/lib/iocage`.  I feel like you should try the "global" library location before trying the local library location.