### PR TITLE
Limit scope of IFS change in ioc-network

### DIFF
--- a/lib/ioc-network
+++ b/lib/ioc-network
@@ -120,7 +120,7 @@ __stop_legacy_networking () {
     local ip6_addr="$(__get_jail_prop ip6_addr $name)"
 
     if [ $ip4_addr != "none" ] ; then
-        IFS=','
+        local IFS=','
         for ip in $ip4_addr ; do
             local iface="$(echo $ip | \
                          awk 'BEGIN { FS = "|" } ; { print $1 }')"
@@ -133,7 +133,7 @@ __stop_legacy_networking () {
     fi
 
     if [ $ip6_addr != "none" ] ; then
-        IFS=','
+        local IFS=','
         for ip6 in $ip6_addr ; do
             local iface="$(echo $ip6 | \
                          awk 'BEGIN { FS = "|" } ; { print $1 }')"


### PR DESCRIPTION
Fixes a bug affecting the shutdown of jails with shared IP networking. Setting `IFS=','` sticks for the rest of the script after the first call to `__stop_legacy_networking`, and causes many subsequent functions to misbehave. Limiting `IFS` to local scope ensures the rest of the script is not affected.