### PR TITLE
call hack88 when creating a new jail

### DIFF
--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -126,6 +126,9 @@ __create_jail () {
     zfs set mountpoint=none ${pool}/$jail_zfs_dataset
     zfs set jailed=on ${pool}/$jail_zfs_dataset
 
+    # configure the jail mountpoint
+    __hack88_mount ${uuid}
+
     # Install extra packages
     # this requires working resolv.conf in jail
     if [ "$pkglist" != "none" ] ; then


### PR DESCRIPTION
Call hack88 when creating a jail. This is useful for scripts that need to get the mountpoint property before the jail first starts in order to generate an fstab.