### PR TITLE
show help output even if you are not root

### DIFF
--- a/iocage
+++ b/iocage
@@ -56,11 +56,6 @@ else
     exit 1
 fi
 
-if [ "$(whoami)" != "root" ] ; then
-    echo "* Only root can manage jails!"
-    exit 1
-fi
-
 # Source the libs needed to use the script
 . "${LIB}/ioc-cmd"
 . "${LIB}/ioc-globals"
@@ -87,6 +82,11 @@ fi
 if [ "$1" == "help" ] ; then
     __help
     exit 0
+fi
+
+if [ "$(whoami)" != "root" ] ; then
+    echo "* Only root can manage jails!"
+    exit 1
 fi
 
 # work around zpool activation chicken-egg problem


### PR DESCRIPTION
It seems useful to see the help output even if you are non root. Showing
version output as non root was already supported.

Fix simply requires moving the root check after loading libraries and
checking for the presence of a command.

Aside: also useful for generating man pages as you don't have to be root to do it.