### PR TITLE
add tag to output of `iocage show`

### DIFF
--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -1322,15 +1322,17 @@ __show () {
     local jails=$(__find_jail ALL)
     local prop="$1"
 
-    printf "%-36s  %s\n" "UUID" "$prop"
+    {
+        printf "%s\t%s\t%s\n" "UUID" "TAG" "$prop"
+        for jail in $jails ; do
+            local name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
+                        $jail)"
+            local tag="$(__get_jail_prop tag $name)"
+            local value="$(__get_jail_prop $prop $name)"
 
-    for jail in $jails ; do
-        local name="$(zfs get -H -o value org.freebsd.iocage:host_hostuuid \
-                    $jail)"
-        local value="$(__get_jail_prop $prop $name)"
-
-        printf "%-+.36s  %s\n" "$name"  "$value"
-    done
+            printf "%s\t%s\t%s\n" "$name"  "$tag" "$value"
+        done
+    } | column -s $'\t' -t
 }
 
 __usage () {


### PR DESCRIPTION
Use paren grouping to collect output for piping to column (in freebsd base)
to format table for printing, to avoid having to specify column sizes which are unknown
ahead of time due to user supplied tag names.

Let me know if this is too clever, and if an alternative method is desired.

see #130