### PR TITLE
Introduce the 'pkg' command

### DIFF
--- a/iocage
+++ b/iocage
@@ -74,6 +74,7 @@ fi
 . "${LIB}/ioc-configure"
 . "${LIB}/ioc-hacks"
 . "${LIB}/ioc-git"
+. "${LIB}/ioc-pkg"
 
 if [ -z "$1" ] ; then
     __usage

--- a/iocage.8
+++ b/iocage.8
@@ -34,6 +34,7 @@
 \fBiocage\fP \fIsnaplist\fP UUID|TAG
 \fBiocage\fP \fIsnapremove\fP UUID|TAG@snapshotname|ALL
 \fBiocage\fP \fIrollback\fP UUID|TAG@snapshotname
+\fBiocage\fP \fIpkg\fP UUID|TAG \fIcommand\fP \fIflags\fP
 \fBiocage\fP \fIpromote\fP UUID|TAG
 \fBiocage\fP \fIruntime\fP UUID|TAG
 \fBiocage\fP \fIupdate\fP UUID|TAG
@@ -430,6 +431,15 @@ latest updates applied.
 .fam C
     Rollback to an existing snapshot. Any intermediate snapshots will be
     destroyed. For more information on this functionality please read zfs(8).
+
+.fam T
+.fi
+\fIpkg\fP \fIUUID\fP|TAG \fIcommand\fP \fIflags\fP
+.PP
+.nf
+.fam C
+    Run pkg(8) from the host with the correct -j switch. For more details please
+    read pkg(8).
 
 .fam T
 .fi

--- a/lib/ioc-cmd
+++ b/lib/ioc-cmd
@@ -69,6 +69,10 @@ __parse_cmd () {
             package)    __package "$2"
                         exit
                 ;;
+            pkg)        shift
+                        __pkg "$@"
+                        exit
+                ;;
             promote)    __promote "$2"
                         exit
                 ;;

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -35,6 +35,7 @@ SYNOPSIS
   iocage snaplist UUID|TAG
   iocage snapremove UUID|TAG@snapshotname|ALL
   iocage rollback UUID|TAG@snapshotname
+  iocage pkg UUID|TAG command flags
   iocage promote UUID|TAG
   iocage runtime UUID|TAG
   iocage update UUID|TAG
@@ -293,6 +294,11 @@ SUBCOMMANDS
 
     Rollback to an existing snapshot. Any intermediate snapshots will be
     destroyed. For more information on this functionality please read zfs(8).
+
+  pkg UUID|TAG command flags
+
+    Run pkg(8) from the host with the correct -j switch. For more details
+    please read pkg(8)
 
   promote UUID|TAG
 

--- a/lib/ioc-pkg
+++ b/lib/ioc-pkg
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+__pkg () {
+    local _name _fulluuid
+    _name="$1"
+    
+    _fulluuid="$(__check_name $_name)"
+    
+    if [ -z $_fulluuid ]; then
+        echo "  ERROR: $_name not found."
+        exit 1
+    fi
+    
+    shift 1
+    
+    pkg -j ioc-$_fulluuid "$@"
+}


### PR DESCRIPTION
The following commands are equivalent:
  # iocage pkg UUID|TAG command flag
  # pkg -j ioc-UUID command flag

This allows for package managment without installing pkg(8) inside the jail.
See pkg(8) for more details.