### PR TITLE
Create helpers for getting a property from a dataset.

### DIFF
--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -302,6 +302,24 @@ __get_jail_prop () {
     fi
 }
 
+__get_dataset_zfs_prop () {
+    local _prop _dataset
+
+    _prop=${1}
+    _dataset=${2}
+
+    zfs get -Ho value ${_prop} ${_dataset}
+}
+
+__get_dataset_ioc_prop () {
+    local _prop _dataset
+
+    _prop=${1}
+    _dataset=${2}
+
+    zfs get -Ho value org.freebsd.iocage:${_prop} ${_dataset}
+}
+
 __runtime () {
     local name=$1
 


### PR DESCRIPTION
Internally we usually know the dataset for a jail and can be sure the property
we are getting is supported, so the lookups and checks in `__get_jail_prop` are
excessive. The helpers `__get_dataset_zfs_prop` and `__get_dataset_zfs_prop`
can be used to replace most occurrences of `__get_jail_prop`, and doing so should
greatly improve the performance of iocage.