### PR TITLE
lib/ioc-info: `iocage df` now shows the tag column

### DIFF
--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -188,7 +188,7 @@ __list_jails () {
 __print_disk () {
     local jails=$(__find_jail ALL)
 
-    printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s\n" "UUID" "CRT" "RES" "QTA" "USE" "AVA"
+    printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s %-20s\n" "UUID" "CRT" "RES" "QTA" "USE" "AVA" "TAG"
 
     for jail in $jails ; do
         uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid $jail)
@@ -197,9 +197,10 @@ __print_disk () {
         qta=$(zfs get -H -o value quota $jail)
         use=$(zfs get -H -o value used $jail)
         ava=$(zfs get -H -o value available $jail)
+        tag=$(zfs get -H -o value org.freebsd.iocage:tag $jail)
 
-        printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s\n" "$uuid" "$crt" "$res" "$qta" \
-               "$use" "$ava"
+        printf "%-36s  %-6s  %-5s  %-5s  %-5s  %-5s %-20s\n" "$uuid" "$crt" "$res" "$qta" \
+               "$use" "$ava" "$tag"
     done
 }
 


### PR DESCRIPTION
Rationale: improves readability