### PR TITLE
added check for readonly commands

### DIFF
--- a/iocage
+++ b/iocage
@@ -85,8 +85,8 @@ if [ "$1" == "help" ] ; then
     exit 0
 fi
 
-if [ "$(whoami)" != "root" ] ; then
-    echo "* Only root can manage jails!"
+if ! __readonly_cmd $1 && [ "$(whoami)" != "root" ] ; then
+    echo "* The $1 command needs root credentials!"
     exit 1
 fi
 

--- a/lib/ioc-cmd
+++ b/lib/ioc-cmd
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# See whether given command is readonly
+# and therefore doesn't need root credentials
+__readonly_cmd () {
+    case "$1" in
+        defaults|df|get|list) return 0;;
+    esac
+
+    return 1
+}
+
 # Process command line options-------------------------
 __parse_cmd () {
     while [ $# -gt 0 ] ; do


### PR DESCRIPTION
Not all commands actually need root credentials, so we can let non-root
users issue then. Current readonly commands are defaults, df, get and list.