### PR TITLE
iocage list: introduce -b switch for basejails

### DIFF
--- a/iocage.8
+++ b/iocage.8
@@ -27,7 +27,7 @@
 \fBiocage\fP \fIinit-host\fP \fIIP\fP \fIZPOOL\fP
 \fBiocage\fP \fIinuse\fP \fIUUID\fP|TAG
 \fBiocage\fP \fIlimits\fP [\fIUUID\fP|TAG]
-\fBiocage\fP \fIlist\fP [\fB-t\fP|\fB-r\fP]
+\fBiocage\fP \fIlist\fP [\fB-b\fP|\fB-t\fP|\fB-r\fP]
 \fBiocage\fP \fIpackage\fP \fIUUID\fP|TAG
 \fBiocage\fP \fIpromote\fP \fIUUID\fP|TAG
 \fBiocage\fP \fIrcboot\fP
@@ -347,12 +347,12 @@ latest updates applied.
 
 .fam T
 .fi
-\fIlist\fP [\fB-t\fP|\fB-r\fP]
+\fIlist\fP [\fB-b\fP|\fB-t\fP|\fB-r\fP]
 .PP
 .nf
 .fam C
-    List all jails, if -t is specified list only templates, with -r list
-    downloaded releases.
+    List all jails, if -b is specified list only basejails, with -t list only
+    templates, with -r list downloaded releases.
     Non iocage jail listed, only if jail is in the UP state.
 
 .fam T

--- a/iocage.8.txt
+++ b/iocage.8.txt
@@ -23,7 +23,7 @@ SYNOPSIS
   iocage init-host IP ZPOOL
   iocage inuse UUID|TAG
   iocage limits [UUID|TAG]
-  iocage list [-t|-r]
+  iocage list [-b|-t|-r]
   iocage package UUID|TAG
   iocage promote UUID|TAG
   iocage rcboot
@@ -239,10 +239,10 @@ SUBCOMMANDS
     Display active resource limits for a jail or all jails. With no UUID
     supplied display all limits active for all jails.
 
-  list [-t|-r]
+  list [-b|-t|-r]
 
-    List all jails, if -t is specified list only templates, with -r list
-    downloaded releases.
+    List all jails, if -b is specified, list only basejails, with -t list only
+    templates, with -r list downloaded releases.
     Non iocage jail listed, only if jail is in the UP state.
 
   package UUID|TAG

--- a/lib/ioc-help
+++ b/lib/ioc-help
@@ -27,7 +27,7 @@ SYNOPSIS
   iocage init-host IP ZPOOL
   iocage inuse UUID|TAG
   iocage limits [UUID|TAG]
-  iocage list [-t|-r]
+  iocage list [-b|-t|-r]
   iocage package UUID|TAG
   iocage promote UUID|TAG
   iocage rcboot
@@ -243,10 +243,10 @@ SUBCOMMANDS
     Display active resource limits for a jail or all jails. With no UUID
     supplied display all limits active for all jails.
 
-  list [-t|-r]
+  list [-b|-t|-r]
 
-    List all jails, if -t is specified list only templates, with -r list
-    downloaded releases.
+    List all jails, if -b is specified list only basejails, with -t list only
+    templates, with -r list downloaded releases.
     Non iocage jail listed, only if jail is in the UP state.
 
   package UUID|TAG

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -149,6 +149,12 @@ __list_jails () {
                 printf "%-4s  %-+.36s  %-3s   %-4s   %s\n" "$jid" "$uuid" \
                 "$boot" "$state" "$tag"
             fi
+        elif [ $switch == "-b" ] ; then
+            jail_type="$(__get_jail_prop type $uuid)"
+            if [ $jail_type == "basejail" ] ; then
+                printf "%-4s  %-+.36s  %-3s   %-4s   %s\n" "$jid" "$uuid" \
+                "$boot" "$state" "$tag"
+            fi
         elif [ $switch != "-t" ] ; then
             if [ $template != "yes" ] ; then
                 printf "%-4s  %-+.36s  %-4s  %-4s   %s\n" "$jid" "$uuid"  \


### PR DESCRIPTION
`iocage list -b` lists only basejails in the same fashion as -t or -r