### PR TITLE
lib/ioc-zfs: add a trap to __create_jail() to prevent ^C

### DIFF
--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -174,6 +174,9 @@ __create_jail () {
         exit 1
     fi
 
+    trap "printf '%s\n' 'Refusing to stop now: run \`iocage destroy\` later'" \
+    2 3
+
     if [ "${2}" = "-c" ] ; then
         fs_list=$(zfs list -rH -o name $pool/iocage/releases/$release)
         zfs snapshot -r $pool/iocage/releases/$release@$uuid


### PR DESCRIPTION
This should allow the jail to be properly set up and let the admin be able to
destroy the jail easily afterwards.