### PR TITLE
Make freebsd-update fetch operations work in non-interactive sessions on FreeBSD 10.2 and later.

### DIFF
--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -206,7 +206,7 @@ __chroot () {
 
 # Fetch release and prepare base ZFS filesystems-----------
 __fetch_release () {
-    local _rel_exist _default_rel
+    local _rel_exist _default_rel _non_interactive
     _default_rel=$(uname -r|cut -f 1,2 -d'-')
 
     if [ -z "$iocset_release" ] ; then
@@ -268,9 +268,15 @@ __fetch_release () {
         echo "* Updating base jail.."
         sleep 2
 
+        _non_interactive="--not-running-from-cron"
+        if [ $(uname -U) -lt 1002000 ] ; then
+            _non_interactive=""
+        fi
+
         if [ -e $iocroot/releases/$release/root/etc/freebsd-update.conf ] ; then
             env UNAME_r="$release" env PAGER="/bin/cat" \
                 /usr/sbin/freebsd-update \
+                $_non_interactive \
                 -b $iocroot/releases/$release/root \
                 -f $iocroot/releases/$release/root/etc/freebsd-update.conf \
                 -d $iocroot/releases/$release/root/var/db/freebsd-update/ fetch

--- a/lib/ioc-upgrade
+++ b/lib/ioc-upgrade
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 __update () {
-  local _name _dataset _fulluuid _mountpoint _date _jail_type
+  local _name _dataset _fulluuid _mountpoint _date _jail_type _non_interactive
 
   _name=$2
 
@@ -55,9 +55,15 @@ __update () {
                         release="$_jail_release"
                     fi
 
+                    _non_interactive="--not-running-from-cron"
+                    if [ $(uname -U) -lt 1002000 ] ; then
+                        _non_interactive=""
+                    fi
+
                     if [ -e $iocroot/releases/$release/root/etc/freebsd-update.conf ] ; then
                         env UNAME_r="$release" env PAGER="/bin/cat" \
                             /usr/sbin/freebsd-update \
+                            $_non_interactive \
                             -b ${_mountpoint}/root \
                             -f $iocroot/releases/$release/root/etc/freebsd-update.conf \
                             -d ${_mountpoint}/root/var/db/freebsd-update/ fetch


### PR DESCRIPTION
I have tested the changes to `ioc-common` on FreeBSD 10.2, but not earlier releases of FreeBSD. The code is intended to leave behaviour on earlier FreeBSD releases unchanged, however.

Changes to `ioc-upgrade` are identical to those to `ioc-common`, but are as yet untested.