### PR TITLE
README.md: remove usage, add link to iocage.8.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,49 +45,9 @@ Start the jail:
 
 `iocage start myjail`
 
-**USAGE:**
--  iocage activate ZPOOL
--  iocage cap UUID|TAG
--  iocage chroot UUID|TAG [command]
--  iocage clean [-a|-r|-j]
--  iocage clone UUID|TAG [UUID|TAG@snapshot] [property=value]
--  iocage console UUID|TAG
--  iocage create [-b|-c|-e] [release=RELEASE] [pkglist=file] [property=value]
--  iocage deactivate ZPOOL
--  iocage defaults
--  iocage destroy [-f] UUID|TAG
--  iocage df
--  iocage exec [-u username | -U username] UUID|TAG|ALL command [arg ...]
--  iocage export UUID|TAG
--  iocage fetch [release=RELEASE | ftphost=ftp.hostname.org | ftpdir=/dir/ |
-                ftpfiles="base.txz doc.txz lib32.txz src.txz"]
--  iocage get property|all UUID|TAG
--  iocage help
--  iocage import UUID [property=value]
--  iocage init-host IP ZPOOL
--  iocage inuse UUID|TAG
--  iocage limits [UUID|TAG]
--  iocage list [-t|-r]
--  iocage package UUID|TAG
--  iocage promote UUID|TAG
--  iocage rcboot
--  iocage rcshutdown
--  iocage record start|stop UUID|TAG
--  iocage reset UUID|TAG|ALL
--  iocage restart UUID|TAG
--  iocage rollback UUID|TAG@snapshotname
--  iocage runtime UUID|TAG
--  iocage set property=value UUID|TAG
--  iocage show property
--  iocage snaplist UUID|TAG
--  iocage snapremove UUID|TAG@snapshotname|ALL
--  iocage snapshot UUID|TAG [UUID|TAG@snapshotname]
--  iocage start UUID|TAG
--  iocage stop UUID|TAG
--  iocage uncap UUID|TAG
--  iocage update UUID|TAG
--  iocage upgrade UUID|TAG [release=RELEASE]
-- iocage version | --version
+**USAGE**
+
+See [iocage.8.txt](iocage.8.txt)
 
 **REQUIREMENTS**
 - FreeBSD 9.3-RELEASE amd64 or newer


### PR DESCRIPTION
Rationale: avoids having too many documentation sources as they were drifting apart, some were stale, etc.