### PR TITLE
‘iocage chroot’ should allow commands with multiple arguments

### DIFF
--- a/lib/ioc-cmd
+++ b/lib/ioc-cmd
@@ -20,7 +20,7 @@ __parse_cmd () {
             cap)        __rctl_limits "$2"
                         exit
                 ;;
-            chroot)     __chroot "$2" "$3"
+            chroot)     __chroot "$@"
                         exit
                 ;;
             clean)      __clean "$2"

--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -184,8 +184,10 @@ __exec () {
 
 __chroot () {
     local _name _command
+    shift
     _name="$1"
-    _command="$2"
+    shift
+    _command="$@"
 
     if [ -z $_name ] ; then
         __die "missing UUID!"


### PR DESCRIPTION
`iocage chroot` is currently implemented so as to accept only a single argument for the command to be executed. Thus, this does not work:

```
# iocage chroot dmz0 sysrc salt_minion_enable="NO"
Usage: sysrc [OPTIONS] name[[+|-]=value] ...
Try `sysrc --help' for more information.
```

One might expect to be able to work-around this by quoting the command to be run and its arguments:

```
# iocage chroot dmz0 'sysrc salt_minion_enable="NO"'
salt_minion_enable: NO -> NO
```

This _appears_ to work but, in the case of `sysrc` at least, has side effects. Here’s what happens with a second invocation:

```
# iocage chroot dmz0 'sysrc salt_minion_enable="NO"'
salt_minion_enable: NO -> NONO

# iocage chroot dmz0 'sysrc salt_minion_enable="NO"'
salt_minion_enable: NONO -> NONONO
```

Oops!

This PR tweaks `iocage chroot` to allow arguments to be provided to the command being executed. This solves the problem with `sysrc`:

```
# iocage chroot dmz0 sysrc salt_minion_enable="NO"
salt_minion_enable: NO -> NO

# iocage chroot dmz0 sysrc salt_minion_enable="NO"
salt_minion_enable: NO -> NO

# iocage chroot dmz0 sysrc salt_minion_enable="NO"
salt_minion_enable: NO -> NO
```