### PR TITLE
fix "unexpected operator" error

### DIFF
--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -330,7 +330,7 @@ __get_jail_prop () {
         _dataset="$(__find_jail $_name)" || exit $?
     fi
 
-    if [ -z $_dataset ] ; then
+    if [ -z "$_dataset" ] ; then
         __die "jail $_name not found!"
     fi
 


### PR DESCRIPTION
Fix error when `$_dataset` is multiline string.
Example error:

    $ iocage get ip4_addr ALL
    [: tank/iocage/jails/61add196-3576-11e5-bf45-0cc47a31451a: unexpected operator
    lo1|127.0.4.1,lagg0|172.16.100.17/24
    lo1|127.0.2.1,lagg0|172.16.100.13/24
    lo1|127.0.3.1,lagg0|172.16.100.12/24

Putting quotes around the variable resolves this.