### PR TITLE
mount unionfs as copymode=transparent

### DIFF
--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -430,22 +430,22 @@ __chroot () {
     # If the jail is a basejail, mount all the overlays
     if [ "${_jail_type}" == "basejail" ] ; then
         if [ "${_state}" == "0" ] ; then
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/etc \
                 ${iocroot}/jails/${_fulluuid}/root/etc
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/root \
                 ${iocroot}/jails/${_fulluuid}/root/root
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/usr/home \
                 ${iocroot}/jails/${_fulluuid}/root/usr/home
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/compat \
                 ${iocroot}/jails/${_fulluuid}/root/compat
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/usr/local \
                 ${iocroot}/jails/${_fulluuid}/root/usr/local
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/var \
                 ${iocroot}/jails/${_fulluuid}/root/var
             mount -t tmpfs tmpfs ${iocroot}/jails/${_fulluuid}/root/tmp
@@ -456,7 +456,7 @@ __chroot () {
         fi
 
         # Mount the rest
-        mount -t unionfs -o noatime,copymode=traditional \
+        mount -t unionfs -o noatime,copymode=transparent \
             ${iocroot}/jails/${_fulluuid}/_/usr/ports \
             ${iocroot}/jails/${_fulluuid}/root/usr/ports
         fi

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -3,7 +3,8 @@
 # Print supported releases----------------------------------
 __print_release () {
     supported="10.2-RELEASE
-                9.3-RELEASE"
+                9.3-RELEASE
+                11.0-CURRENT"
 
     echo "Supported releases are: "
     for rel in $(echo $supported) ; do
@@ -108,7 +109,7 @@ __list_jails () {
     if [ ! -z "${_switch}" -a "${_switch}" = "-r" ] ; then
         echo "Downloaded releases:"
         _releases="$(zfs list -o name -Hr ${pool}/iocage/base \
-                   | grep RELEASE$ | cut -d \/ -f 4)"
+                   | grep root$ | cut -d \/ -f 4)"
         for _rel in $(echo ${_releases}) ; do
             printf "%15s\n" "${_rel}"
         done

--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -356,7 +356,7 @@ __create_jail () {
 
     _installed=$(zfs list -rH ${pool}/iocage/base | grep ${base})
     _releases=$(__list_jails -r | grep -v "Downloaded releases:")
-    _supported_release=$(echo "${base}" | grep "RELEASE")
+    _supported_release=$(echo "${base}" | grep "RELEASE\|CURRENT")
     _devfs_string="$(grep -Fxq \
                   "## IOCAGE -- Add DHCP to ruleset 4" /etc/devfs.rules \
                   ; echo $?)"

--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -722,7 +722,7 @@ __destroy_jail () {
                 __die "cannot destroy ${_name} - jail is running!"
             fi
 
-            __destroy_func ${_fulluuid} ${_dataset} ${_origin} ${_jail_type}
+            __destroy_func ${_fulluuid} ${_dataset} ${_origin} ${_jail_type} ${_jail_path}
         else
             echo "  Command not confirmed.  No action taken."
         fi
@@ -730,17 +730,18 @@ __destroy_jail () {
         if [ ! -z ${_state} ] ; then
             __stop_jail ${_fulluuid} ${_dataset}
         fi
-        __destroy_func ${_fulluuid} ${_dataset} ${_origin} ${_jail_type}
+        __destroy_func ${_fulluuid} ${_dataset} ${_origin} ${_jail_type} ${_jail_path}
     fi
 }
 
 __destroy_func () {
-    local _fulluuid _dataset _origin _jail_type _base_inuse
+    local _fulluuid _dataset _origin _jail_type _base_inuse _jail_path
 
     _fulluuid="$1"
     _dataset="$2"
     _origin="$3"
     _jail_type="$4"
+    _jail_path="$5"
     _base_inuse="$(zfs get -r -H -o value origin ${pool} | \
                  grep ${pool}/iocage/base > \
                  /dev/null 2>&1 ; echo $?)"
@@ -754,11 +755,21 @@ __destroy_func () {
     if [ "${_origin}" != "-" ] ; then
         echo "  Destroying clone origin: ${_origin}"
         zfs destroy -r ${_origin}
+
+        if [ -d "${_jail_path}" ] ; then
+            rm -rf ${_jail_path}
+        fi
+
     fi
 
     if [ ${_jail_type} = "basejail" ] ; then
         if [ "${_base_inuse}" = "0" ] ; then
             zfs destroy -fr ${pool}/iocage/base@${_fulluuid} > /dev/null 2>&1
+
+            if [ -d "${_jail_path}" ] ; then
+                rm -rf ${_jail_path}
+            fi
+
         fi
     fi
 }

--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -547,13 +547,13 @@ __create_jail () {
         # in a basejail
         mount -t tmpfs tmpfs ${iocroot}/jails/${uuid}/root/tmp
         mount -t devfs devfs ${iocroot}/jails/${uuid}/root/dev
-        mount -t unionfs -o noatime,copymode=traditional \
+        mount -t unionfs -o noatime,copymode=transparent \
                  ${iocroot}/jails/${uuid}/_/usr/local/ \
                  ${iocroot}/jails/${uuid}/root/usr/local
-        mount -t unionfs -o noatime,copymode=traditional \
+        mount -t unionfs -o noatime,copymode=transparent \
                  ${iocroot}/jails/${uuid}/_/var/ \
                  ${iocroot}/jails/${uuid}/root/var
-        mount -t unionfs -o noatime,copymode=traditional \
+        mount -t unionfs -o noatime,copymode=transparent \
                  ${iocroot}/jails/${uuid}/_/compat/ \
                  ${iocroot}/jails/${uuid}/root/compat
 
@@ -875,7 +875,7 @@ __mount_basejail () {
     local _fulluuid="$1"
 
     # Mount the overlays needed for basejails
-    mount -t unionfs -o noatime,copymode=traditional \
+    mount -t unionfs -o noatime,copymode=transparent \
         ${iocroot}/jails/${_fulluuid}/_/ \
         ${iocroot}/jails/${_fulluuid}/root
 
@@ -897,7 +897,7 @@ __mount_template () {
     local _tag="$1"
 
     # Mount the overlays needed for basejails
-    mount -t unionfs -o noatime,copymode=traditional \
+    mount -t unionfs -o noatime,copymode=transparent \
         ${iocroot}/base/${_tag}/_/ \
         ${iocroot}/base/${_tag}/root
 


### PR DESCRIPTION
Mount unionfs as copymode=transparent so that iocage jails have file permisions exectly as base.
This will allow installed packages like mariadb to start correctly. Otherwise mariadb will start with an error "Can not open /lib/libgcc_s.so.1" with copymode=traditional.

