### PR TITLE
mount unionfs as copymode=transparent

### DIFF
--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -430,22 +430,22 @@ __chroot () {
     # If the jail is a basejail, mount all the overlays
     if [ "${_jail_type}" == "basejail" ] ; then
         if [ "${_state}" == "0" ] ; then
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/etc \
                 ${iocroot}/jails/${_fulluuid}/root/etc
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/root \
                 ${iocroot}/jails/${_fulluuid}/root/root
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/usr/home \
                 ${iocroot}/jails/${_fulluuid}/root/usr/home
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/compat \
                 ${iocroot}/jails/${_fulluuid}/root/compat
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/usr/local \
                 ${iocroot}/jails/${_fulluuid}/root/usr/local
-            mount -t unionfs -o noatime,copymode=traditional \
+            mount -t unionfs -o noatime,copymode=transparent \
                 ${iocroot}/jails/${_fulluuid}/_/var \
                 ${iocroot}/jails/${_fulluuid}/root/var
             mount -t tmpfs tmpfs ${iocroot}/jails/${_fulluuid}/root/tmp
@@ -456,7 +456,7 @@ __chroot () {
         fi
 
         # Mount the rest
-        mount -t unionfs -o noatime,copymode=traditional \
+        mount -t unionfs -o noatime,copymode=transparent \
             ${iocroot}/jails/${_fulluuid}/_/usr/ports \
             ${iocroot}/jails/${_fulluuid}/root/usr/ports
         fi

--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -547,13 +547,13 @@ __create_jail () {
         # in a basejail
         mount -t tmpfs tmpfs ${iocroot}/jails/${uuid}/root/tmp
         mount -t devfs devfs ${iocroot}/jails/${uuid}/root/dev
-        mount -t unionfs -o noatime,copymode=traditional \
+        mount -t unionfs -o noatime,copymode=transparent \
                  ${iocroot}/jails/${uuid}/_/usr/local/ \
                  ${iocroot}/jails/${uuid}/root/usr/local
-        mount -t unionfs -o noatime,copymode=traditional \
+        mount -t unionfs -o noatime,copymode=transparent \
                  ${iocroot}/jails/${uuid}/_/var/ \
                  ${iocroot}/jails/${uuid}/root/var
-        mount -t unionfs -o noatime,copymode=traditional \
+        mount -t unionfs -o noatime,copymode=transparent \
                  ${iocroot}/jails/${uuid}/_/compat/ \
                  ${iocroot}/jails/${uuid}/root/compat
 
@@ -864,7 +864,7 @@ __mount_basejail () {
     local _fulluuid="$1"
 
     # Mount the overlays needed for basejails
-    mount -t unionfs -o noatime,copymode=traditional \
+    mount -t unionfs -o noatime,copymode=transparent \
         ${iocroot}/jails/${_fulluuid}/_/ \
         ${iocroot}/jails/${_fulluuid}/root
 
@@ -886,7 +886,7 @@ __mount_template () {
     local _tag="$1"
 
     # Mount the overlays needed for basejails
-    mount -t unionfs -o noatime,copymode=traditional \
+    mount -t unionfs -o noatime,copymode=transparent \
         ${iocroot}/base/${_tag}/_/ \
         ${iocroot}/base/${_tag}/root
 


### PR DESCRIPTION
Mount unionfs as copymode=transparent so that jails have file permissions exactly as base.
Packages like Maridb fail to start becasue of /lib file permisions when using copymode=traditional and /usr/local/etc/rc.d scripts.
Error: "Can not open libgcc_s.so.1"
 