### PR TITLE
ioc-image: fix iocage import for images

### DIFF
--- a/lib/ioc-image
+++ b/lib/ioc-image
@@ -197,7 +197,7 @@ __export () {
     _fulluuid="$(__check_name $_name)"
     _jail_path="$(__get_jail_prop mountpoint $_fulluuid)"
     _state=$(jls|grep ${_jail_path} | wc -l)
-    _mountpoint="$(__get-jail_prop mountpoint $_fulluuid)"
+    _mountpoint="$(__get_jail_prop mountpoint $_fulluuid)"
 
     if [ -z $_name ] ; then
         echo "  ERROR: Missing UUID!"

--- a/lib/ioc-image
+++ b/lib/ioc-image
@@ -111,10 +111,6 @@ __import () {
     _icount="$(echo $_image|wc -w)"
     _pcksum="$(find $iocroot/packages/ -name $_name\*.sha256)"
     _icksum="$(find $iocroot/images/ -name $_name\*.sha256)"
-    _new_cksum="$(sha256 -q $_package)"
-    _old_cksum="$(cat $_pcksum)"
-    _uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
-    _mountpoint="$(__get_jail_prop mountpoint $_uuid)"
 
     if [ -z $_name ] ; then
         echo "  ERROR: Missing package UUID!"
@@ -145,6 +141,10 @@ __import () {
             exit 1
         fi
 
+        _new_cksum="$(sha256 -q $_package)"
+        _old_cksum="$(cat $_pcksum)"
+        _uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
+        _mountpoint="$(__get_jail_prop mountpoint $_uuid)"
 
         if [ $_new_cksum != $_old_cksum ] ; then
             echo "  ERROR: Checksum mismatch. Exiting"


### PR DESCRIPTION
iocage import was broken for images. If the UUID given
did not match a package, we tried to compute a sha256
on an empty pathname in $_package and it blocked forever
on stdin.

The code in question looked like it belonged inside
the if block for $_pcount > 0 but might have been
mistakenly moved to the start of the __import() func.

This patch puts the checks where they belong.

Signed-off-by: William Katsak <wkatsak@gmail.com>