### PR TITLE
Preserve IFS in __stop_legacy_networking

### DIFF
--- a/lib/ioc-network
+++ b/lib/ioc-network
@@ -295,6 +295,7 @@ __stop_legacy_networking () {
     _ip6_addr=$(echo ${_ip6_addr} | sed "s/DEFAULT|/${_default_iface}|/g")
 
     if [ "${_ip4_addr}" != "none" ] ; then
+        local oIFS=$IFS
         local IFS=','
         for _ip4 in ${_ip4_addr} ; do
             _iface="$(echo ${_ip4} | \
@@ -306,9 +307,11 @@ __stop_legacy_networking () {
 
             ifconfig ${_iface} ${_ip4} -alias
         done
+        local IFS=$oIFS
     fi
 
     if [ "${_ip6_addr}" != "none" ] ; then
+        local oIFS=$IFS
         local IFS=','
         for _ip6 in ${_ip6_addr} ; do
             _iface="$(echo ${_ip6} | \
@@ -319,5 +322,6 @@ __stop_legacy_networking () {
                        awk 'BEGIN { FS = " " } ; { print $1 }')"
             ifconfig ${_iface} inet6 ${_ip6} -alias
         done
+        local IFS=$oIFS
     fi
 }


### PR DESCRIPTION
`__stop_legacy_networking` sets IFS to ',' without restoring it. This confuses subsequent variable expansions in the function, so IPv6 resources for jails with multiple IPv6 aliases are never released.

The bug affects v1.7.3 and master as well. The fix is pretty much the same, I can open another pull request for master if needed.

The fix has been tested on fully updated 10.2-RELEASE. VNET jails are (obviously) not affected.