### PR TITLE
Properly handle properties with "=" in the value

### DIFF
--- a/lib/ioc-cmd
+++ b/lib/ioc-cmd
@@ -247,8 +247,8 @@ __parse_cmd () {
                             while [ "${_j}" -lt "${_nprops}" ] ; do
                                 _var=\$$(printf "_prop_${_j}")
                                 _prop=$(eval "echo ${_var}")
-                                _pname=$(echo "${_prop}" | cut -f1 -d'=' -s)
-                                _pval=$(echo "${_prop}" | cut -f2 -d'=' -s)
+                                _pname=$(__get_prop_name "${_prop}")
+                                _pval=$(__get_prop_value "${_prop}")
 
                                 __set_jail_prop "${_pname}=${_pval}" \
                                     "${_fulluuid}"

--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -50,8 +50,8 @@ __set_jail_prop () {
 
     _fulluuid="$(__check_name ${_name})"
 
-    _pname="$(echo ${_property}|awk 'BEGIN { FS = "=" } ; { print $1 }')"
-    _pval="$(echo ${_property}|awk 'BEGIN { FS = "=" } ; { print $2 }')"
+    _pname=$(__get_prop_name "${_property}")
+    _pval=$(__get_prop_value "${_property}")
     _jail_type="$(__get_jail_prop type ${_fulluuid} ${_dataset})"
 
     if [ -z "${_pname}" -o -z "${_pval}" ] ; then
@@ -689,4 +689,14 @@ __get_default_iface() {
     else
         netstat -f inet -nrW | grep '^default' | awk '{ print $6 }'
     fi
+}
+
+# Split a property as specified on the command line into name or value
+__get_prop_name () {
+    echo "${1}" | cut -f1 -d'=' -s
+}
+
+__get_prop_value () {
+    # Preserve '=' in property values
+    echo "${1}" | sed -e 's/^[^=]*=//'
 }


### PR DESCRIPTION
Oops... Rather than rebase a ton of commits from 6 months ago, I nuked and re-created the branch.  I shouldn't be surprised that github closed the other pull request, but I was.  Anyway, this is exactly the same thing without all the old cruft:

This commit moves a couple of instances of code to separate a property name and value from the string stored as a ZFS prop into its component name and corresponding value. The code in both places was different but designed to do the same things.

In both cases, if a value contained an equals sign ('='), the value returned was everything AFTER the last equals sign. Since a name isn't going to contain an equals (and the stuff that populated that was correct), the property value should be everything after the first equals sign.

This doesn't have any effect on current operation in my testing, nor should it. I'm planning on opening a pull request for allowing a jail to have multiple ZFS datasets, and this is required for that.

This is my first pull request. As far as I know I've adhered to the guidelines for contributing. If I've done anything wrong, please do let me know.