### PR TITLE
Fix "cannot create /.../root/etc/resolv.conf: Read-only file system"

### DIFF
--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -243,7 +243,12 @@ __start_jail () {
         fi
     fi
 
+    zfs set readonly=off "${_dataset}/root"
     __resolv_conf ${_fulluuid} ${_dataset} > ${_jail_path}/root/etc/resolv.conf
+    if [ "${_jail_type}" = "basejail" ] ; then
+        zfs set readonly=on "${_dataset}/root"
+    fi
+
     echo -n "  + Starting services"
     setfib ${_exec_fib} jexec ioc-${_fulluuid} ${_exec_start} \
      >> "${iocroot}/log/${_fulluuid}-console.log" 2>&1


### PR DESCRIPTION
On latest develop (f220673) when I try to start a newly-created jail I see

```
# ./iocage start zoro
* Starting e06fbbb5-c7c1-11e5-a70e-d05099264f2e (zoro)
  + Started (shared IP mode) OK
./iocage: cannot create /iocage/jails/e06fbbb5-c7c1-11e5-a70e-d05099264f2e/root/etc/resolv.conf: Read-only file system
```

I have ```jail_zfs``` set, so right before the call to ```__resolv_conf``` the root dataset is set to read-only.  Hoisting the call above the ```jail_zfs``` conditional didn't work, as the dataset was still read-only from the last time I'd tried to start it.

With the following changes, it works as expected:

```
# ./iocage start zoro
* Starting e06fbbb5-c7c1-11e5-a70e-d05099264f2e (zoro)
  + Started (shared IP mode) OK
  + Starting services        OK
```
