### PR TITLE
Documentation: HTTP mirrors are supported for iocage fetch

### DIFF
--- a/doc/source/basic-use.rst
+++ b/doc/source/basic-use.rst
@@ -19,11 +19,11 @@ If a specific RELEASE is required run:
 
 ``iocage fetch release=9.3-RELEASE``
 
-In case a specific download mirror is required simply run:
+In case a specific download mirror (FTP or HTTP) is required simply run:
 
 ``iocage fetch ftphost=ftp.hostname.org``
 
-You can also specify a ftp directory to fetch the base files from:
+You can also specify a directory to fetch the base files from:
 
 ``iocage fetch ftpdir=/dir/``
 


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ x ] Supply documentation according to [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
- [ x ] Explain the feature

This is just a very minor patch to the documentation to say that HTTP mirrors are also supported for `iocage fetch`. I could not find a suitable place to make the same change to the manpage without a significant rewrite. Happy to take suggestions on this

- [ x ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
- [ x ] Only open the PR against the `develop` branch.

