### PR TITLE
Support for template state

### DIFF
--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -458,8 +458,8 @@ __get_jail_prop () {
             fi
         fi
     else
-        _template=="$(__get_jail_prop istemplate $_name $_dataset)"
-        if [ "${_template}" != "=yes" ]; then
+        _template="$(__get_jail_prop istemplate $_name $_dataset)"
+        if [ "${_template}" != "yes" ]; then
             _fulluuid="$(uclcmd get -qf ${_mountpoint}/config host_hostuuid 2> \
                 /dev/null)"
             _state="$(__is_running ${_fulluuid})"

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -458,9 +458,14 @@ __get_jail_prop () {
             fi
         fi
     else
-        _fulluuid="$(uclcmd get -qf ${_mountpoint}/config host_hostuuid 2> \
-            /dev/null)"
-        _state="$(__is_running ${_fulluuid})"
+        _template=="$(__get_jail_prop istemplate $_name $_dataset)"
+        if [ "${_template}" != "=yes" ]; then
+            _fulluuid="$(uclcmd get -qf ${_mountpoint}/config host_hostuuid 2> \
+                /dev/null)"
+            _state="$(__is_running ${_fulluuid})"
+        else
+            _state="$(__is_running ${_name})"
+        fi
 
         if [ "${_state}" ] ; then
             echo "up"

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -3,7 +3,7 @@
 # Print supported releases----------------------------------
 __print_release () {
     supported="11.0-CURRENT
-               10.3-PRERELEASE
+               10.3-RELEASE
                10.2-RELEASE
                9.3-RELEASE"
 


### PR DESCRIPTION
- templates can have states `up` and `down`
- currently, because of rewrites to the way properties are handled,
  templates are always marked `down`
- add this functionality (again) through a conditional on whether a jail is a template,
- do the right thing if it is.

- while there, sneak in support for `10.3-RELEASE`