### PR TITLE
Improve support for running under volatile mountpoints

### DIFF
--- a/lib/ioc-common
+++ b/lib/ioc-common
@@ -727,7 +727,7 @@ __fetch_release () {
 # reads tag property from given jail dataset
 # creates symlink from $iocroot/jails/<uuid> to $iocroot/tags/<tag>
 __link_tag () {
-    local _dataset _mountpoint _tag _readlink_tag _readlink_mount _tag_date
+    local _dataset _mountpoint _tag _readlink_tag _readlink_mount _tag_date _altroot
     _dataset=$1
     _tag="$2"
 
@@ -742,18 +742,31 @@ __link_tag () {
         _tag_date=$(date "+%F@%T")
         mkdir -p ${iocroot}/tags
         if [ ! -e ${iocroot}/tags/${_tag} ] ; then
-            ln -s ${_mountpoint} ${iocroot}/tags/${_tag}
+            _altroot="$(zpool get -H altroot "${pool}" | awk '{print $3}')"
+            if [ "${_altroot}" != "-" ]; then
+                _mountpoint=${_mountpoint#${iocroot}}
+                cd ${iocroot}/tags
+                ln -s ..${_mountpoint} ${_tag}
+            else
+                ln -s ${_mountpoint} ${iocroot}/tags/${_tag}
+            fi
         elif [ -e ${iocroot}/tags/${_tag} ] && [ "${_readlink_mount}" != "${_mountpoint}" ] ; then
             echo " "
             echo "  WARNING: Replacing tag ${_tag}!" >&2
             echo "  Renaming ${_readlink_tag}'s tag to ${_tag_date}." >&2
             echo " "
-
-
-            # Link new tag to jail, and relink old jail to new tag.
-            ln -shf ${_mountpoint} ${iocroot}/tags/${_tag}
-            ln -s ${_readlink_mount} ${iocroot}/tags/${_tag_date}
-            __ucl_set "${_readlink_mount}" "tag" "${_tag_date}"
+            if [ "${_altroot}" != "-" ]; then
+                _mountpoint=${_mountpoint#${iocroot}}
+                cd ${iocroot}/tags
+                ln -s ..${_mountpoint} ${_tag}
+                ln -s ${_readlink_mount} ${iocroot}/tags/${_tag_date}
+                __ucl_set "${_readlink_mount}" "tag" "${_tag_date}"
+            else
+                # Link new tag to jail, and relink old jail to new tag.
+                ln -shf ${_mountpoint} ${iocroot}/tags/${_tag}
+                ln -s ${_readlink_mount} ${iocroot}/tags/${_tag_date}
+                __ucl_set "${_readlink_mount}" "tag" "${_tag_date}"
+            fi
         fi
     else
         __die "no such dataset: ${_dataset}!"
@@ -766,6 +779,9 @@ __unlink_tag () {
     _dataset=$1
 
     if _mountpoint=$(zfs get -H -o value mountpoint ${_dataset}) ; then
+        find ${iocroot}/tags -type l -lname "${_mountpoint}*" \
+            -exec rm -f \{\} \; > /dev/null 2>&1
+        _mountpoint=..${_mountpoint#${iocroot}}
         find ${iocroot}/tags -type l -lname "${_mountpoint}*" \
             -exec rm -f \{\} \; > /dev/null 2>&1
     fi

--- a/lib/ioc-zfs
+++ b/lib/ioc-zfs
@@ -946,8 +946,13 @@ __check_filesystems () {
                         > /dev/null 2>&1
                 fi
 
-                if [ "${_altroot}" != "-" ] ; then
+                if [ "${_altroot}" != "-" -a ! -d "/iocage" ] ; then
                     sed -i '' s#.*iocroot.*#iocroot="${_altroot}/iocage"# \
+                        "${LIB}/ioc-globals"
+                    export iocroot="${_altroot}/iocage"
+                elif [ "${_altroot}" = "/mnt" -a -d "/iocage" ] ; then
+                    # we're in a chroot.
+                    sed -i '' s#.*iocroot.*#iocroot="/iocage"# \
                         "${LIB}/ioc-globals"
                     export iocroot="${_altroot}/iocage"
                 elif [ "${_altroot}" = "-" ] ; then
@@ -971,7 +976,7 @@ __check_filesystems () {
     # Checks to see if the user changed the altroot and modify ioc-globals
     # If the user decided to unset their altroot, they need to run again as
     # root to set it back to the default location
-    if [ "${_altroot}" != "-" ] && [ "$(id -un)" = "root" ] ; then
+    if [ "${_altroot}" != "-" ] && [ "$(id -un)" = "root" ] && [ ! -d "/iocage" ] ; then
         sed -i '' s#.*iocroot.*#iocroot="${_altroot}/iocage"# \
             "${LIB}/ioc-globals"
         export iocroot="${_altroot}/iocage"


### PR DESCRIPTION
- a zpool's altroot can change after setting up jails
- think having bsdinstall execute iocage in a chroot
- in that case, after a reboot altroot is reset an tags go towards a non-existent location
- to make life easier, use relative symlinks instead of absolute ones
- add (naive) chroot detection (e.g. in above bsdinstall case):
  if altroot is not "-" and /iocage exists, assume we're in one.