### PR TITLE
Fix iocage with non-vnet PPP network interfaces

### DIFF
--- a/lib/ioc-network
+++ b/lib/ioc-network
@@ -221,7 +221,7 @@ __stop_legacy_networking () {
     ip4_addr=$(echo $ip4_addr | sed "s/DEFAULT|/$default_iface|/g")
     ip6_addr=$(echo $ip6_addr | sed "s/DEFAULT|/$default_iface|/g")
 
-    if [ $ip4_addr != "none" ] ; then
+    if [ "$ip4_addr" != "none" ] ; then
         local IFS=','
         for ip in $ip4_addr ; do
             local iface="$(echo $ip | \
@@ -234,7 +234,7 @@ __stop_legacy_networking () {
         done
     fi
 
-    if [ $ip6_addr != "none" ] ; then
+    if [ "$ip6_addr" != "none" ] ; then
         local IFS=','
         for ip6 in $ip6_addr ; do
             local iface="$(echo $ip6 | \

--- a/lib/ioc-rc
+++ b/lib/ioc-rc
@@ -226,11 +226,11 @@ __legacy_start () {
       tmpfs=""
     fi
 
-    if [ $ip4_addr == "none" ] ; then
+    if [ "$ip4_addr" == "none" ] ; then
         ip4_addr=""
     fi
 
-    if [ $ip6_addr == "none" ] ; then
+    if [ "$ip6_addr" == "none" ] ; then
         ip6_addr=""
     fi
 
@@ -265,7 +265,7 @@ __legacy_start () {
 
     if [ $ipv6 == "on" ] ; then
         jail -c \
-        ${ip4_addr_propline} \
+        "${ip4_addr_propline}" \
         ip4.saddrsel="$(__get_jail_prop ip4_saddrsel $name)" \
         ip4="${ip4}" \
         ${ip6_addr_propline} \
@@ -306,7 +306,7 @@ __legacy_start () {
         persist
     else
         jail -c \
-        ${ip4_addr_propline} \
+        "${ip4_addr_propline}" \
         ip4.saddrsel="$(__get_jail_prop ip4_saddrsel $name)" \
         ip4="${ip4}" \
         name="ioc-$(__get_jail_prop host_hostuuid $name)" \


### PR DESCRIPTION
PPP-like interfaces, such as tun(4), have an additional dest parameter
in their config strings, separated from the first by a string.  ip4_addr
and ip6_addr must be quoted in several places to make such interfaces
work.

This PR is direct to the stable branch because the relevant code has been rewritten on the develop branch.