### PR TITLE
Include jail hostname in output of "iocage list".

### DIFF
--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -102,8 +102,15 @@ __list_jails () {
     local all_jids=$(jls -N -h jid | grep -v -x jid )
     local ioc_jids=""
     local non_ioc_jids=""
+    local display_template=""
+    local display_full_uuid=""
+    local uuid_width=""
 
-    if [ ! -z ${switch} ] && [ $switch == "-r" ] ; then
+    if [ -z ${switch} ] ; then
+        switch=zero
+    fi
+
+    if [ $switch == "-r" ] ; then
         echo "Downloaded releases:"
         local releases="$(zfs list -o name -Hr $pool/iocage/releases \
                         | grep RELEASE$ | cut -d \/ -f 4)"
@@ -112,8 +119,22 @@ __list_jails () {
         done
         exit 0
     fi
+    
+    if [ $switch == "-t" ] || [ $switch == "-tu" ] || [ $switch == "-ut" ] ; then
+        display_template="yes"
+    fi
 
-    printf "%-4s  %-36s  %s  %s  %-20s  %-15s  %s\n" "JID" "UUID"  "BOOT"\
+    if [ $switch == "-u" ] || [ $switch == "-tu" ] || [ $switch == "-ut" ] ; then
+        display_full_uuid="yes"
+    fi
+
+    if [ -z ${display_full_uuid} ] ; then
+        uuid_width="-8s"
+    else
+        uuid_width="-36s"
+    fi
+
+    printf "%-4s  %uuid_width  %s  %s  %-20s  %-15s  %s\n" "JID" "UUID"  "BOOT"\
            "STATE" "TAG" "IP" "HOSTNAME"
     for jail in $jails ; do
         uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid $jail)
@@ -137,18 +158,18 @@ __list_jails () {
             state=up
         fi
 
-        if [ -z ${switch} ] ; then
-            switch=zero
+        if [ -z ${display_full_uuid} ]; then
+            uuid=$(echo $uuid | cut -d'-' -f1)
         fi
 
-        if [ $switch == "-t" ] ; then
+        if [ ! -z ${display_template} ] ; then
             if [ $template == "yes" ] ; then
-                printf "%-4s  %-+.36s  %-3s   %-4s   %-4s   %-15s  %s\n" "$jid" "$uuid" \
+                printf "%-4s  %$uuid_width  %-3s   %-4s   %-4s   %-15s  %s\n" "$jid" "$uuid" \
                 "$boot" "$state" "$tag" "$ip4_addr" "$hostname"
             fi
-        elif [ $switch != "-t" ] ; then
+        elif [ -z ${display_template} ] ; then
             if [ $template != "yes" ] ; then
-                printf "%-4s  %-+.36s  %-4s  %-4s   %-4s   %-15s  %s\n" "$jid" "$uuid"  \
+                printf "%-4s  %$uuid_width  %-4s  %-4s   %-4s   %-15s  %s\n" "$jid" "$uuid"  \
                 "$boot" "$state" "$tag" "$ip4_addr" "$hostname"
             fi
         fi

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -113,7 +113,7 @@ __list_jails () {
         exit 0
     fi
 
-    printf "%-4s  %-36s  %s  %s  %-20s  %-16s  %s\n" "JID" "UUID"  "BOOT"\
+    printf "%-4s  %-36s  %s  %s  %-20s  %-15s  %s\n" "JID" "UUID"  "BOOT"\
            "STATE" "TAG" "IP" "HOSTNAME"
     for jail in $jails ; do
         uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid $jail)
@@ -143,12 +143,12 @@ __list_jails () {
 
         if [ $switch == "-t" ] ; then
             if [ $template == "yes" ] ; then
-                printf "%-4s  %-+.36s  %-3s   %-4s   %-4s   %-16s  %s\n" "$jid" "$uuid" \
+                printf "%-4s  %-+.36s  %-3s   %-4s   %-4s   %-15s  %s\n" "$jid" "$uuid" \
                 "$boot" "$state" "$tag" "$ip4_addr" "$hostname"
             fi
         elif [ $switch != "-t" ] ; then
             if [ $template != "yes" ] ; then
-                printf "%-4s  %-+.36s  %-4s  %-4s   %-4s   %-16s  %s\n" "$jid" "$uuid"  \
+                printf "%-4s  %-+.36s  %-4s  %-4s   %-4s   %-15s  %s\n" "$jid" "$uuid"  \
                 "$boot" "$state" "$tag" "$ip4_addr" "$hostname"
             fi
         fi

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -134,7 +134,7 @@ __list_jails () {
         uuid_width="-36s"
     fi
 
-    printf "%-4s  %uuid_width  %s  %s  %-20s  %-15s  %s\n" "JID" "UUID"  "BOOT"\
+    printf "%-4s  %$uuid_width  %s  %s  %-20s  %-15s  %s\n" "JID" "UUID"  "BOOT"\
            "STATE" "TAG" "IP" "HOSTNAME"
     for jail in $jails ; do
         uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid $jail)

--- a/lib/ioc-info
+++ b/lib/ioc-info
@@ -113,8 +113,8 @@ __list_jails () {
         exit 0
     fi
 
-    printf "%-4s  %-36s  %s  %s  %-20s  %s\n" "JID" "UUID"  "BOOT"\
-           "STATE" "TAG" "IP"
+    printf "%-4s  %-36s  %s  %s  %-20s  %-16s  %s\n" "JID" "UUID"  "BOOT"\
+           "STATE" "TAG" "IP" "HOSTNAME"
     for jail in $jails ; do
         uuid=$(zfs get -H -o value org.freebsd.iocage:host_hostuuid $jail)
         boot=$(zfs get -H -o value org.freebsd.iocage:boot $jail)
@@ -122,6 +122,7 @@ __list_jails () {
         jail_path=$(zfs get -H -o value mountpoint $jail)
         state=$(jls | grep ${jail_path} | awk '{print$1}')
         ip4_addr=$(zfs get -H -o value org.freebsd.iocage:ip4_addr $jail | cut -d'|' -f2 | cut -d'/' -f1)
+        hostname=$(zfs get -H -o value org.freebsd.iocage:hostname $jail)
         template=$(zfs get -H -o value org.freebsd.iocage:template $jail)
         # get jid for iocage jails
         jid=$(jls -j "ioc-"$uuid  -h jid 2> /dev/null | grep -v -x "jid")
@@ -142,13 +143,13 @@ __list_jails () {
 
         if [ $switch == "-t" ] ; then
             if [ $template == "yes" ] ; then
-                printf "%-4s  %-+.36s  %-3s   %-4s   %-4s   %s\n" "$jid" "$uuid" \
-                "$boot" "$state" "$tag" "$ip4_addr"
+                printf "%-4s  %-+.36s  %-3s   %-4s   %-4s   %-16s  %s\n" "$jid" "$uuid" \
+                "$boot" "$state" "$tag" "$ip4_addr" "$hostname"
             fi
         elif [ $switch != "-t" ] ; then
             if [ $template != "yes" ] ; then
-                printf "%-4s  %-+.36s  %-4s  %-4s   %-4s   %s\n" "$jid" "$uuid"  \
-                "$boot" "$state" "$tag" "$ip4_addr"
+                printf "%-4s  %-+.36s  %-4s  %-4s   %-4s   %-16s  %s\n" "$jid" "$uuid"  \
+                "$boot" "$state" "$tag" "$ip4_addr" "$hostname"
             fi
         fi
     done


### PR DESCRIPTION
Feature:
This patch adds a new "HOSTNAME" column in the output of iocage list that displays the jail hostname.

With the inclusion of this patch and #360, I no longer have to use `jls` to quickly see hostnames and IP addresses.

Branch:
Patched against Master for inclusion with v1.7.5.
