### PR TITLE
Fixed iocage import

### DIFF
--- a/lib/ioc-image
+++ b/lib/ioc-image
@@ -111,10 +111,6 @@ __import () {
     _icount="$(echo $_image|wc -w)"
     _pcksum="$(find $iocroot/packages/ -name $_name\*.sha256)"
     _icksum="$(find $iocroot/images/ -name $_name\*.sha256)"
-    _new_cksum="$(sha256 -q $_package)"
-    _old_cksum="$(cat $_pcksum)"
-    _uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
-    _mountpoint="$(__get_jail_prop mountpoint $_uuid)"
 
     if [ -z $_name ] ; then
         echo "  ERROR: Missing package UUID!"
@@ -145,6 +141,10 @@ __import () {
             exit 1
         fi
 
+		_new_cksum="$(sha256 -q $_package)"
+		_old_cksum="$(cat $_pcksum)"
+		_uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
+		_mountpoint="$(__get_jail_prop mountpoint $_uuid)"
 
         if [ $_new_cksum != $_old_cksum ] ; then
             echo "  ERROR: Checksum mismatch. Exiting"

--- a/lib/ioc-image
+++ b/lib/ioc-image
@@ -141,10 +141,10 @@ __import () {
             exit 1
         fi
 
-		_new_cksum="$(sha256 -q $_package)"
-		_old_cksum="$(cat $_pcksum)"
-		_uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
-		_mountpoint="$(__get_jail_prop mountpoint $_uuid)"
+        _new_cksum="$(sha256 -q $_package)"
+        _old_cksum="$(cat $_pcksum)"
+        _uuid="$(__create_jail create | grep uuid | cut -f2 -d=)"
+        _mountpoint="$(__get_jail_prop mountpoint $_uuid)"
 
         if [ $_new_cksum != $_old_cksum ] ; then
             echo "  ERROR: Checksum mismatch. Exiting"


### PR DESCRIPTION
Whenever I would export a jail, then move the /iocage/images files to a new system, then run iocage import <UUID>, the system would just hang. I noticed that some things were happening for /iocage/package files even if they did not exist. Attempting to run a sha256 checksum against a package file that did not exist was causing the hang. This code pertaining to packages was moved to within an "if" condition specifically for the existence of package files.
