### PR TITLE
Backport "Preserve IFS in __stop_legacy_networking"

### DIFF
--- a/lib/ioc-network
+++ b/lib/ioc-network
@@ -222,6 +222,7 @@ __stop_legacy_networking () {
     ip6_addr=$(echo $ip6_addr | sed "s/DEFAULT|/$default_iface|/g")
 
     if [ "$ip4_addr" != "none" ] ; then
+        local oIFS=$IFS
         local IFS=','
         for ip in $ip4_addr ; do
             local iface="$(echo $ip | \
@@ -232,9 +233,11 @@ __stop_legacy_networking () {
 
             ifconfig $iface $ip4 -alias
         done
+        local IFS=$oIFS
     fi
 
     if [ "$ip6_addr" != "none" ] ; then
+        local oIFS=$IFS
         local IFS=','
         for ip6 in $ip6_addr ; do
             local iface="$(echo $ip6 | \
@@ -244,5 +247,6 @@ __stop_legacy_networking () {
                        awk 'BEGIN { FS = "/" } ; { print $1 }')"
             ifconfig $iface inet6 $ip6 -alias
         done
+        local IFS=$oIFS
     fi
 }


### PR DESCRIPTION
This PR backports to master the fix for IFS clobbering in `__stop_legacy_networking` landed in 9cf580d on the develop branch.

At the time I didn't know that master was going to be frozen pending a full rewrite, so I never got around to submit a backport PR back then.