### PR TITLE
Don't explode listing jails without origin

### DIFF
--- a/iocage/lib/ioc_list.py
+++ b/iocage/lib/ioc_list.py
@@ -146,10 +146,14 @@ class IOCList(object):
             if conf["type"] == "template":
                 template = "-"
             else:
-                template = check_output(["zfs", "get", "-H", "-o", "value",
-                                         "origin",
-                                         "{}/iocage/jails/{}/root".format(
-                                             self.pool, uuid)]).split("/")[3]
+                origin = check_output(["zfs", "get", "-H", "-o", "value",
+                                       "origin",
+                                       "{}/iocage/jails/{}/root".format(
+                                           self.pool, uuid)])
+                if "/" in origin:
+                    template = origin.split("/")[3]
+                else:
+                    template = "-"
 
             if template == release:
                 # Then it does not have a template.


### PR DESCRIPTION
testing it: 
```
# iocage list
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 11, in <module>
    load_entry_point('iocage==0.9', 'console_scripts', 'iocage')()
  File "/usr/local/lib/python2.7/site-packages/iocage/main.py", line 78, in main
    cli(obj=MODULES)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/iocage/cli/list.py", line 24, in list_cmd
    IOCList(dataset_type, header, _long).get_datasets()
  File "/usr/local/lib/python2.7/site-packages/iocage/lib/ioc_list.py", line 62, in get_datasets
    self.list_all(datasets)
  File "/usr/local/lib/python2.7/site-packages/iocage/lib/ioc_list.py", line 152, in list_all
    self.pool, uuid)]).split("/")[3]
IndexError: list index out of range
```
The reason is that "origin" of the only iocage jail I have is set to '-' (jail is not cloned)

This PR allow `# iocage list` to work here. feel free to write it differently :)