### PR TITLE
fix iocage on 10.3; can't pass empty args (fails w/ "jail: unknown pa…

### DIFF
--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -149,7 +149,7 @@ class IOCStart(object):
 
             self.lgr.info("* Starting {} ({})".format(self.uuid, self.conf[
                 "tag"]))
-            start = Popen(["jail", "-c"] + net +
+            start = Popen([x for x in ["jail", "-c"] + net +
                           ["name=ioc-{}".format(self.uuid),
                            "host.domainname={}".format(host_domainname),
                            "host.hostname={}".format(host_hostname),
@@ -187,7 +187,7 @@ class IOCStart(object):
                            "allow.dying",
                            "exec.consolelog={}/log/ioc-{}-console.log".format(
                                self.iocroot, self.uuid),
-                           "persist"])
+                           "persist"] if x != ''])
             start.communicate()
 
             if start.returncode:


### PR DESCRIPTION
Hi. The new set of parameters _sysvmsg, _sysvsem and _sysvshm break iocage on 10.3. They are passed as empty arguments if userland version <= 10.3 and "jail" can't handle arguments with no value.

[vanderva@xeon ~/iocage/testlan]$ sudo iocage start dog.testlan.wenglab.org
\* Starting 375cad35-df69-4fd0-b4df-2148cc627b58 (dog.testlan.wenglab.org)
jail: unknown parameter:
  \+ Start FAILED
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 11, in <module>
    load_entry_point('iocage==0.9.3', 'console_scripts', 'iocage')()
  File "/usr/local/lib/python2.7/site-packages/iocage/main.py", line 89, in main