### PR TITLE
Fix typo (iocate -> iocage).

### DIFF
--- a/doc/build/html/_sources/jailtypes.txt
+++ b/doc/build/html/_sources/jailtypes.txt
@@ -53,7 +53,7 @@ Template is just another jail where the "template" property is set to "yes".
 
 To turn a jail into a template simply execute:
 
-``iocate set template=yes UUID|TAG``
+``iocage set template=yes UUID|TAG``
 
 After this operation the jail can be listed with:
 

--- a/doc/build/html/jailtypes.html
+++ b/doc/build/html/jailtypes.html
@@ -79,7 +79,7 @@ environments where patching or upgrades are required at once to multiple jails.<
 <h2>Template<a class="headerlink" href="#template" title="Permalink to this headline">¶</a></h2>
 <p>Template is just another jail where the &#8220;template&#8221; property is set to &#8220;yes&#8221;.</p>
 <p>To turn a jail into a template simply execute:</p>
-<p><code class="docutils literal"><span class="pre">iocate</span> <span class="pre">set</span> <span class="pre">template=yes</span> <span class="pre">UUID|TAG</span></code></p>
+<p><code class="docutils literal"><span class="pre">iocage</span> <span class="pre">set</span> <span class="pre">template=yes</span> <span class="pre">UUID|TAG</span></code></p>
 <p>After this operation the jail can be listed with:</p>
 <p><code class="docutils literal"><span class="pre">iocage</span> <span class="pre">list</span> <span class="pre">-t</span></code></p>
 <p>To deploy a jail from this template, execute:</p>

--- a/doc/source/jailtypes.rst
+++ b/doc/source/jailtypes.rst
@@ -53,7 +53,7 @@ Template is just another jail where the "template" property is set to "yes".
 
 To turn a jail into a template simply execute:
 
-``iocate set template=yes UUID|TAG``
+``iocage set template=yes UUID|TAG``
 
 After this operation the jail can be listed with:
 


### PR DESCRIPTION
Just a few typo fixes in the docs.