### PR TITLE
Improve the robustness of cli activate + unit tests

### DIFF
--- a/iocage/cli/activate.py
+++ b/iocage/cli/activate.py
@@ -1,11 +1,91 @@
 """activate module for the cli."""
 import logging
-from subprocess import CalledProcessError, PIPE, Popen, check_call
-
 import click
+from subprocess import CalledProcessError, PIPE, Popen, check_call
 
 __cmdname__ = "activate_cmd"
 __rootcmd__ = True
+
+IOCAGE_ZFS_ACTIVE_PROPERTY = "org.freebsd.ioc:active"
+
+lgr = logging.getLogger('ioc_cli_activate')
+
+
+def get_zfs_pools():
+    """
+    Returns all the ZFS pools available on the system
+    :rtype: list of strings
+    :raise RuntimeError: if the underlying zfs command returns errors
+    """
+    proc = Popen(["zpool", "list", "-H", "-o", "name"], stdout=PIPE, stderr=PIPE)
+    stdout_data, stderr_data = proc.communicate()
+    if stderr_data:
+        raise RuntimeError("Cannot get the list of available ZFS pools: {}"
+                           .format(stderr_data.decode('utf-8'))
+                           )
+    return stdout_data.decode('utf-8').split()
+
+
+def set_zfs_pool_active_property(zpool_name, activate=True):
+    """
+    Set or unset the IOCAGE_ACTIVE_PROPERTY property
+    on a ZFS pool for iocage usage
+    :param zpool_name: name of the ZFS pool
+    :param activate: if True set the property to "yes", to "no" otherwise
+    :type zpool_name: string
+    :type activate: bool
+    :raises RuntimeError: if the zfs command returns errors
+    :raises ValueError: if one parameter is incorrect
+    """
+
+    if not isinstance(zpool_name, str) or zpool_name == "":
+        raise ValueError("'zpool_name' must be a non-empty string")
+
+    if not isinstance(activate, bool):
+        raise ValueError("'activate' must be a boolean")
+
+    zfs_cmd = ["zfs", "set"]
+    if activate:
+        zfs_cmd.append("{}=yes".format(IOCAGE_ZFS_ACTIVE_PROPERTY))
+    else:
+        zfs_cmd.append("{}=no".format(IOCAGE_ZFS_ACTIVE_PROPERTY))
+
+    zfs_cmd.append(zpool_name)
+    proc = Popen(zfs_cmd, stdout=PIPE, stderr=PIPE)
+    stdout_data, stderr_data = proc.communicate()
+    if stderr_data:
+        if activate:
+            raise RuntimeError("Cannot activate ZFS pool '{}': {}"
+                               .format(zpool_name, stderr_data.decode('utf-8')))
+        else:
+            raise RuntimeError("Cannot deactivate ZFS pool '{}': {}"
+                               .format(zpool_name, stderr_data.decode('utf-8')))
+
+
+def set_zfs_pool_comment(zpool_name, comment):
+    """
+    Set the ZFS pool comment
+    :param zpool_name: name of ZFS pool name
+    :param comment: the comment to set
+    :type zpool_name: string
+    :type comment: string
+    :raises RuntimeError: if the zpool command returns an error
+    :raises ValueError: if parameters are incorrect
+    """
+
+    if not isinstance(zpool_name, str) or zpool_name == "":
+        raise ValueError("'zpool_name' must be a non-empty string")
+
+    if not isinstance(comment, str) or comment == "":
+        raise ValueError("'comment' must be a non-empty string")
+
+    zfs_cmd = ["zpool", "set", "comment={}".format(comment), zpool_name]
+    print(zfs_cmd)
+    proc = Popen(zfs_cmd, stdout=PIPE, stderr=PIPE)
+    stdout_data, stderr_data = proc.communicate()
+    if stderr_data:
+        raise RuntimeError("Cannot set zpool comment to '{}' on ZFS pool '{}': {}"
+                           .format(comment, zpool_name, stderr_data.decode('utf-8')))
 
 
 @click.command(name="activate", help="Set a zpool active for iocage usage.")
@@ -14,30 +94,27 @@ __rootcmd__ = True
               is_flag=True)
 def activate_cmd(zpool, force):
     """Calls ZFS set to change the property org.freebsd.ioc:active to yes."""
-    lgr = logging.getLogger('ioc_cli_activate')
 
-    try:
-        if force:
-            zpools = Popen(["zpool", "list", "-H", "-o", "name"],
-                           stdout=PIPE).communicate()[0].decode(
-                "utf-8").split()
+    if force:
+        lgr.info("'--force' specified, all other ZFS pools will be"
+                 " deactivated for iocage usage")
+        # Here we just want one active pool, so we 'deactivate' all
+        # the ZFS pools, to ensure only one stays 'activated'
+        zpools = get_zfs_pools()
+        for pool in zpools:
+            set_zfs_pool_active_property(pool, activate=False)
 
-            for zfs in zpools:
-                # If they specify force we just want one active pool.
-                check_call(["zfs", "set", "org.freebsd.ioc:active=no", zfs],
-                           stderr=PIPE, stdout=PIPE)
+            # Check and clean if necessary iocage_legacy way
+            # to mark a ZFS pool as usable (now replaced by ZFS property)
+            proc = Popen(["zpool", "get", "-H", "-o", "value", "comment", pool],
+                            stdout=PIPE, stderr=PIPE)
+            stdout_data, stderr_data = proc.communicate()
+            if stderr_data:
+                raise RuntimeError("Cannot retrieve comment for ZFS pool '{}': {}"
+                                   .format(zpool, stderr_data.decode('utf-8')))
+            comment = stdout_data.decode('utf-8').strip()
+            if comment == "iocage":
+                set_zfs_pool_comment(zpool, "-")
 
-                old_zfs = Popen(["zpool", "get", "-H", "-o", "value",
-                                 "comment", zfs],
-                                stdout=PIPE).communicate()[0].decode(
-                    "utf-8").strip()
-
-                if old_zfs == "iocage":
-                    check_call(["zpool", "set", "comment=-", zfs], stderr=PIPE,
-                               stdout=PIPE)
-
-        check_call(["zfs", "set", "org.freebsd.ioc:active=yes", zpool],
-                   stderr=PIPE, stdout=PIPE)
-        lgr.info("{} successfully activated.".format(zpool))
-    except CalledProcessError:
-        raise RuntimeError("Pool: {} does not exist!".format(zpool))
+    set_zfs_pool_active_property(zpool, activate=True)
+    lgr.info("ZFS pool '{}' successfully activated.".format(zpool))

--- a/iocage/tests/1000_cli_activate_test.py
+++ b/iocage/tests/1000_cli_activate_test.py
@@ -1,0 +1,121 @@
+import mock
+import pytest
+from iocage.cli.activate import\
+    (get_zfs_pools, set_zfs_pool_active_property, set_zfs_pool_comment)
+
+
+@mock.patch('iocage.cli.activate.Popen.communicate')
+def test_get_zfs_pools_multiple_pools(mock_communicate):
+    """ Fake the expected output from zpool list -H -o name
+        on a system with 3 ZFS pools
+    """
+    mock_communicate.return_value = (b'tank0\ntank1\ntank2\n', None)
+
+    zpools = get_zfs_pools()
+    mock_communicate.assert_called()
+
+    assert zpools == ['tank0', 'tank1', 'tank2']
+
+
+@mock.patch('iocage.cli.activate.Popen.communicate')
+def test_get_zfs_pools_one_pool(mock_communicate):
+    """ Fake the expected output from zpool list -H -o name
+        on a system with 1 ZFS pool
+     """
+    mock_communicate.return_value = (b'tank0\n', None)
+
+    zpools = get_zfs_pools()
+    mock_communicate.assert_called()
+
+    assert zpools == ['tank0']
+
+
+@mock.patch('iocage.cli.activate.Popen.communicate')
+def test_get_zfs_pools_no_pool(mock_communicate):
+    """ Fake the expected output from zpool list -H -o name
+        on a system with zero ZFS pool
+     """
+    mock_communicate.return_value = (b'', None)
+
+    zpools = get_zfs_pools()
+    mock_communicate.assert_called()
+
+    assert zpools == []
+
+
+@mock.patch('iocage.cli.activate.Popen.communicate')
+def test_get_zfs_pools_bad_parameter(mock_communicate):
+    """ Fake zpool called with an incorrect parameter
+    (there is something in stderr), can save us when
+    updating the code
+     """
+    mock_communicate.return_value = (b'',
+                                     b"""cannot open 'nope-parameter': no such pool\ncannot open '-o':
+                                     name must begin with a letter\ncannot open 'name': no such pool\n""")
+
+    with pytest.raises(RuntimeError):
+        zpools = get_zfs_pools()
+        mock_communicate.assert_called()
+
+
+def test_set_zfs_pool_active_property_bad_param_zpool_name():
+    with pytest.raises(ValueError):
+        set_zfs_pool_active_property(None, True)
+
+    with pytest.raises(ValueError):
+        set_zfs_pool_active_property("", True)
+
+    with pytest.raises(ValueError):
+        set_zfs_pool_active_property(1, True)
+
+    with pytest.raises(ValueError):
+        set_zfs_pool_active_property([], True)
+
+
+def test_set_zfs_pool_active_property_bad_param_activate():
+    with pytest.raises(ValueError):
+        set_zfs_pool_active_property("pool_name", None)
+
+    with pytest.raises(ValueError):
+        set_zfs_pool_active_property("pool_name", [])
+
+    with pytest.raises(ValueError):
+        set_zfs_pool_active_property("pool_name", 1)
+
+
+@mock.patch('iocage.cli.activate.Popen.communicate')
+def test_set_zfs_pool_active_property_ok(mock_communicate):
+    mock_communicate.return_value = (b'', b'')
+    set_zfs_pool_active_property("pool_name", True)
+    assert mock_communicate.called
+
+
+@mock.patch('iocage.cli.activate.Popen.communicate')
+def test_set_zfs_pool_active_property_fail(mock_communicate):
+    mock_communicate.return_value = (b'', b"cannot set property for 'tank0': invalid property 'foo'\n")
+    with pytest.raises(RuntimeError):
+        set_zfs_pool_active_property("pool_name", True)
+
+    with pytest.raises(RuntimeError):
+        set_zfs_pool_active_property("pool_name", False)
+
+
+def test_set_zfs_pool_comment_bad_param ():
+    with pytest.raises(ValueError):
+        set_zfs_pool_comment(None, "comment")
+
+    with pytest.raises(ValueError):
+        set_zfs_pool_comment("", "comment")
+
+    with pytest.raises(ValueError):
+        set_zfs_pool_comment("pool", None)
+
+    with pytest.raises(ValueError):
+        set_zfs_pool_comment("pool", "")
+
+
+@mock.patch('iocage.cli.activate.Popen.communicate')
+def test_set_zfs_pool_comment_fail(mock_communicate):
+    mock_communicate.return_value = (b'', b"cannot set property for 'tank0': permission denied\n")
+    with pytest.raises(RuntimeError):
+        set_zfs_pool_comment("pool", "comment")


### PR DESCRIPTION
Hello,

This PR is not meant to be merged as is, just to serve as a starting point for discussion  :)

The overall idea is to split the code into small functions that can be unit-tested. 

Since iocage is going to run as root for almost every operation, one typo or one overlooked ```zfs``` output parsing error can have huge impact on the system.

What I would like to achieve:
  * Split  the code in small functions
  * For every ```zfs``` command started, check ```stderr``` to be sure we don't miss something
  * Improve the output for the user (see below)
  * Add unit tests that do not require to be running as root (in addition to the already existing functional tests)
  * In these unit tests, mock the output of ```zfs``` to test as many situations as possible (1 pool, many pools, no pools, ...)

This is still WIP (I have to deal with the yesterday ```check_call()``` update here)

User experience before the patch (tank0 exists, tankxx not)
```
$ sudo iocage activate tank0
tank0 successfully activated.

$ sudo iocage activate -f tank0
tank0 successfully activated.

$ sudo iocage activate -f tankxx
Pool: tankxx does not exist!

$ sudo iocage activate tankxx
Pool: tankxx does not exist!
```

After:
```
$ sudo iocage activate tank0
ZFS pool 'tank0' successfully activated.

$ sudo iocage activate -f tank0
'--force' specified, all other ZFS pools will be deactivated for iocage usage
ZFS pool 'tank0' successfully activated.

$ sudo iocage activate tankxx
Cannot activate ZFS pool 'tankxx': cannot open 'tankxx': dataset does not exist

$ sudo iocage activate -f tankxx
'--force' specified, all other ZFS pools will be deactivated for iocage usage
Cannot activate ZFS pool 'tankxx': cannot open 'tankxx': dataset does not exist
```

If you agree on the direction, I will add more tests to have a 100% coverage on this file.
```
$ pytest iocage/tests/1000_cli_activate_test.py -v
================================================================ test session starts ================================================================
platform freebsd11 -- Python 3.6.0, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /usr/home/loic/iocage/bin/python3.6
cachedir: .cache
rootdir: /usr/home/loic/iocage.git, inifile:
collected 4 items

iocage/tests/1000_cli_activate_test.py::test_get_zfs_pools_multiple_pools PASSED
iocage/tests/1000_cli_activate_test.py::test_get_zfs_pools_one_pool PASSED
iocage/tests/1000_cli_activate_test.py::test_get_zfs_pools_no_pool PASSED
iocage/tests/1000_cli_activate_test.py::test_get_zfs_pools_bad_parameter PASSED
```
Any thoughts?
Cheers