### PR TITLE
Update ip4_addr separator character in ioc_stop.py

### DIFF
--- a/iocage/lib/ioc_stop.py
+++ b/iocage/lib/ioc_stop.py
@@ -100,7 +100,7 @@ class IOCStop(object):
 
             if ip4_addr != "inherit" and vnet == "off":
                 if ip4_addr != "none":
-                    for ip4 in ip4_addr.split():
+                    for ip4 in ip4_addr.split(","):
                         try:
                             iface, addr = ip4.split("/")[0].split("|")
                             checkoutput(["ifconfig", iface, addr,


### PR DESCRIPTION
It needs to match the character used in ioc_start.py

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
