### PR TITLE
Custom uuid

### DIFF
--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -43,8 +43,8 @@ def create_cmd(release, template, count, props, pkglist, basejail, empty,
 
     if short and uuid:
         raise RuntimeError(
-            "Can't use --short (-s) and --uuid (-u) at the same time!!")
-    
+            "Can't use --short (-s) and --uuid (-u) at the same time!")
+
     if not template and not release and not empty:
         raise RuntimeError(
             "Must supply either --template (-t) or --release (-r)!")

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -29,6 +29,7 @@ def validate_count(ctx, param, value):
 @click.option("--release", "-r", required=False)
 @click.option("--template", "-t", required=False)
 @click.option("--pkglist", "-p", default=None)
+@click.option("--uuid", "-u", default=None)
 @click.option("--basejail", "-b", is_flag=True, default=False)
 @click.option("--empty", "-e", is_flag=True, default=False)
 @click.option("--short", "-s", is_flag=True, default=False,
@@ -36,7 +37,7 @@ def validate_count(ctx, param, value):
                    "36")
 @click.argument("props", nargs=-1)
 def create_cmd(release, template, count, props, pkglist, basejail, empty,
-               short):
+               short, uuid):
     lgr = logging.getLogger('ioc_cli_create')
 
     if not template and not release and not empty:
@@ -85,7 +86,7 @@ def create_cmd(release, template, count, props, pkglist, basejail, empty,
     if count == 1:
         try:
             IOCCreate(release, props, 0, pkglist,
-                      template=template, short=short,
+                      template=template, short=short, uuid=uuid
                       basejail=basejail, empty=empty).create_jail()
         except RuntimeError as err:
             lgr.error(err)

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -29,7 +29,8 @@ def validate_count(ctx, param, value):
 @click.option("--release", "-r", required=False)
 @click.option("--template", "-t", required=False)
 @click.option("--pkglist", "-p", default=None)
-@click.option("--uuid", "-u", default=None)
+@click.option("--uuid", "-u", default=None,
+              help="Provide a specific UUID for this jail")
 @click.option("--basejail", "-b", is_flag=True, default=False)
 @click.option("--empty", "-e", is_flag=True, default=False)
 @click.option("--short", "-s", is_flag=True, default=False,
@@ -40,6 +41,10 @@ def create_cmd(release, template, count, props, pkglist, basejail, empty,
                short, uuid):
     lgr = logging.getLogger('ioc_cli_create')
 
+    if short and uuid:
+        raise RuntimeError(
+            "Can't use --short (-s) and --uuid (-u) at the same time!!")
+    
     if not template and not release and not empty:
         raise RuntimeError(
             "Must supply either --template (-t) or --release (-r)!")

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -86,7 +86,7 @@ def create_cmd(release, template, count, props, pkglist, basejail, empty,
     if count == 1:
         try:
             IOCCreate(release, props, 0, pkglist,
-                      template=template, short=short, uuid=uuid
+                      template=template, short=short, uuid=uuid,
                       basejail=basejail, empty=empty).create_jail()
         except RuntimeError as err:
             lgr.error(err)

--- a/iocage/lib/ioc_create.py
+++ b/iocage/lib/ioc_create.py
@@ -56,6 +56,9 @@ class IOCCreate(object):
 
         location = "{}/jails/{}".format(self.iocroot, jail_uuid)
 
+        if os.path.isdir(location):
+            raise RuntimeError("The UUID is already in use by another jail.")
+
         if self.migrate:
             config = self.config
         else:

--- a/iocage/lib/ioc_create.py
+++ b/iocage/lib/ioc_create.py
@@ -20,7 +20,7 @@ class IOCCreate(object):
 
     def __init__(self, release, props, num, pkglist=None, plugin=False,
                  migrate=False, config=None, silent=False, template=False,
-                 short=False, basejail=False, empty=False):
+                 short=False, basejail=False, empty=False, uuid=None):
         self.pool = IOCJson().json_get_value("pool")
         self.iocroot = IOCJson(self.pool).json_get_value("iocroot")
         self.release = release
@@ -34,6 +34,7 @@ class IOCCreate(object):
         self.short = short
         self.basejail = basejail
         self.empty = empty
+        self.uuid = uuid
         self.lgr = logging.getLogger('ioc_create')
 
         if silent:
@@ -45,7 +46,10 @@ class IOCCreate(object):
         jail from that. The user can also specify properties to override the
         defaults.
         """
-        jail_uuid = str(uuid.uuid4())
+        if self.uuid:
+            jail_uuid = self.uuid
+        else:
+            jail_uuid = str(uuid.uuid4())
 
         if self.short:
             jail_uuid = jail_uuid[:8]


### PR DESCRIPTION
This PR adds a `--uuid (-u)` option to the `iocage create` command that allows specifying the uuid used for the jail. This is related to #65 .