### PR TITLE
Make heuristic for finding bridge mtu a little more robust

### DIFF
--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -337,7 +337,7 @@ class IOCStart(object):
                                                     iface, ip, gw, jid)
 
         except CalledProcessError as err:
-            return f"ERROR: {err.output.decode('utf-8')}".rstrip()
+            self.lgr.warning(f"Network failed to start: {err.output.decode('utf-8')}".rstrip())
 
     def start_network_vnet(self, nic, bridge, mtu, iface, ip, defaultgw, jid):
         """

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -322,12 +322,7 @@ class IOCStart(object):
         nic, bridge = nic.split(":")
 
         try:
-            memberif = Popen(["ifconfig", bridge],
-                             stdout=PIPE).communicate()[0].decode(
-                                 "utf-8").split()[40]
-            membermtu = Popen(["ifconfig", memberif],
-                              stdout=PIPE).communicate()[0].decode(
-                                  "utf-8").split()[5]
+            membermtu = find_bridge_mtu(bridge)
 
             for addrs, gw in net_configs:
                 if addrs != 'none':
@@ -341,8 +336,8 @@ class IOCStart(object):
                             self.start_network_vnet(nic, bridge, membermtu,
                                                     iface, ip, gw, jid)
 
-        except:
-            pass
+        except CalledProcessError as err:
+            return f"ERROR: {err.output.decode('utf-8')}".rstrip()
 
     def start_network_vnet(self, nic, bridge, mtu, iface, ip, defaultgw, jid):
         """
@@ -458,3 +453,14 @@ class IOCStart(object):
         else:
             mac_a, mac_b = mac.split(",")
             return mac_a, mac_b
+
+def find_bridge_mtu(bridge):
+    memberif = [x for x in
+                    checkoutput(["ifconfig", bridge]).splitlines()
+                    if x.strip().startswith("member")]
+    if not memberif:
+        return '1500'
+
+    membermtu = checkoutput(["ifconfig", memberif[0].split()[1]]).split()
+    return membermtu[5]
+

--- a/iocage/tests/unit_tests/1001_lib_start_test.py
+++ b/iocage/tests/unit_tests/1001_lib_start_test.py
@@ -1,0 +1,74 @@
+import unittest.mock as mock
+import pytest
+from iocage.lib.ioc_start import find_bridge_mtu
+
+@mock.patch('iocage.lib.ioc_start.checkoutput')
+def test_should_return_mtu_of_first_member(mock_checkoutput):
+    mock_checkoutput.side_effect = [bridge_if_config, member_if_config]
+
+    mtu = find_bridge_mtu('bridge0')
+    assert mtu == '1500'
+    mock_checkoutput.assert_has_calls([mock.call(["ifconfig", "bridge0"]),
+                                       mock.call(["ifconfig", "bge0"])])
+
+@mock.patch('iocage.lib.ioc_start.checkoutput')
+def test_should_return_mtu_of_first_member_with_description(mock_checkoutput):
+    mock_checkoutput.side_effect = [bridge_with_description_if_config,
+                                    member_if_config]
+
+    mtu = find_bridge_mtu('bridge0')
+    assert mtu == '1500'
+    mock_checkoutput.assert_has_calls([mock.call(["ifconfig", "bridge0"]),
+                                       mock.call(["ifconfig", "bge0"])])
+
+@mock.patch('iocage.lib.ioc_start.checkoutput')
+def test_should_return_default_mtu_if_no_members(mock_checkoutput):
+    mock_checkoutput.side_effect = [bridge_with_no_members_if_config,
+                                    member_if_config]
+
+    mtu = find_bridge_mtu('bridge0')
+    assert mtu == '1500'
+    mock_checkoutput.called_with(["ifconfig", "bridge0"])
+
+bridge_if_config = """bridge0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+        ether 00:00:00:00:00:00
+        nd6 options=1<PERFORMNUD>
+        groups: bridge
+        id 00:00:00:00:00:00 priority 32768 hellotime 2 fwddelay 15
+        maxage 20 holdcnt 6 proto rstp maxaddr 2000 timeout 1200
+        root id 00:00:00:00:00:00 priority 32768 ifcost 0 port 0
+            member: bge0 flags=143<LEARNING,DISCOVER,AUTOEDGE,AUTOPTP>
+            ifmaxaddr 0 port 1 priority 128 path cost 20000
+"""
+
+bridge_with_description_if_config = """bridge0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+        description: first-bridge
+        ether 00:00:00:00:00:00
+        nd6 options=1<PERFORMNUD>
+        groups: bridge
+        id 00:00:00:00:00:00 priority 32768 hellotime 2 fwddelay 15
+        maxage 20 holdcnt 6 proto rstp maxaddr 2000 timeout 1200
+        root id 00:00:00:00:00:00 priority 32768 ifcost 0 port 0
+            member: bge0 flags=143<LEARNING,DISCOVER,AUTOEDGE,AUTOPTP>
+            ifmaxaddr 0 port 1 priority 128 path cost 20000
+"""
+
+bridge_with_no_members_if_config = """bridge0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+        description: first-bridge
+        ether 00:00:00:00:00:00
+        nd6 options=1<PERFORMNUD>
+        groups: bridge
+        id 00:00:00:00:00:00 priority 32768 hellotime 2 fwddelay 15
+        maxage 20 holdcnt 6 proto rstp maxaddr 2000 timeout 1200
+        root id 00:00:00:00:00:00 priority 32768 ifcost 0 port 0
+"""
+
+member_if_config = """bge0: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> metric 0 mtu 1500
+        options=c019b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,VLAN_HWCSUM,TSO4,VLAN_HWTSO,LINKSTATE>
+        ether 00:00:00:00:00:00
+        inet6 fe80::0000:0000:0000:0000%bge0 prefixlen 64 scopeid 0x1
+        inet 10.2.3.4 netmask 0xffffff00 broadcast 10.2.3.255
+        nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
+        media: Ethernet autoselect (1000baseT <full-duplex>)
+        status: active
+"""

--- a/iocage/tests/unit_tests/1001_lib_start_test.py
+++ b/iocage/tests/unit_tests/1001_lib_start_test.py
@@ -1,4 +1,4 @@
-import unittest.mock as mock
+import mock
 import pytest
 from iocage.lib.ioc_start import find_bridge_mtu
 


### PR DESCRIPTION
I was unable to create a VNET jail, and traced it to the fact that the bridge I was using had a description field. I've changed the parsing logic which determines the interface MTU to handle this case, and the case that the bridge has no members. 

NB: I've also changed the behaviour to fail if any of the networking setup calls fail, rather than silently continuing. Happy to make this just log a message and continue if that's closer to what you intend.  

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)