### PR TITLE
fixes #114

### DIFF
--- a/iocage/lib/ioc_common.py
+++ b/iocage/lib/ioc_common.py
@@ -236,6 +236,8 @@ def sort_release(releases, split=False):
             r_dict[rel] = r_type
     else:
         if list_sort:
+            if isinstance(releases, str):
+                releases = releases.split(".")
             if len(releases[0]) < 2:
                 releases = f"0{releases}"
 

--- a/iocage/lib/ioc_common.py
+++ b/iocage/lib/ioc_common.py
@@ -236,7 +236,7 @@ def sort_release(releases, split=False):
             r_dict[rel] = r_type
     else:
         if list_sort:
-            if len(releases.split(".")[0]) < 2:
+            if len(releases[0]) < 2:
                 releases = f"0{releases}"
 
             return releases


### PR DESCRIPTION
- [x] Explain the feature: fixes the issue described in #114
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

`releases` is a list and `.split(".")` is not needed; removing it resolves #114 and `iocage fetch` works as expected.
