### PR TITLE
Use libzfs in ioc_fetch.py

### DIFF
--- a/iocage/lib/ioc_fetch.py
+++ b/iocage/lib/ioc_fetch.py
@@ -61,6 +61,9 @@ class IOCFetch(object):
         self.silent = silent
         self.callback = callback
 
+        self.zfs = libzfs.ZFS(history=True, history_prefix="<iocage>")
+        self.zpool = self.zfs.get(self.pool)
+
         if hardened:
             self.http = True
 
@@ -171,7 +174,9 @@ class IOCFetch(object):
             except OSError as err:
                 raise RuntimeError(f"{err}")
 
-            if os.path.isdir(f"{self.iocroot}/download/{self.release}"):
+            dataset = f"{self.iocroot}/download/{self.release}"
+
+            if os.path.isdir(dataset):
                 pass
             else:
                 su.Popen(["zfs", "create", "-o", "compression=lz4",

--- a/iocage/lib/ioc_fetch.py
+++ b/iocage/lib/ioc_fetch.py
@@ -186,8 +186,12 @@ class IOCFetch(object):
 
             for f in self.files:
                 if not os.path.isfile(f):
-                    su.Popen(["zfs", "destroy", "-r", "-f",
-                              f"{self.pool}{dataset}"])
+
+                    dataset = self.zfs.get_dataset(f"{self.pool}{dataset}")
+
+                    dataset.unmount()
+                    dataset.delete(recursive=True)
+
                     if f == "MANIFEST":
                         error = f"{f} is a required file!" \
                                 f"\nPlease place it in {self.root_dir}/" \

--- a/iocage/lib/ioc_fetch.py
+++ b/iocage/lib/ioc_fetch.py
@@ -180,8 +180,7 @@ class IOCFetch(object):
                 pass
             else:
                 self.zpool.create(f"{self.pool}/iocage/download/{self.release}", {
-                        "compression": "lz4",
-                        "mountpoint": dataset
+                        "compression": "lz4"
                     })
 
             for f in self.files:


### PR DESCRIPTION
blocked by https://github.com/jceel/py-libzfs/pull/19 (creation of ancestor datasets)

Utilizes libzfs instead of forking processes to create and destroy datasets.