### PR TITLE
refactor fetch plugins

### DIFF
--- a/iocage/lib/ioc_fetch.py
+++ b/iocage/lib/ioc_fetch.py
@@ -21,6 +21,7 @@ import requests.auth
 import requests.packages.urllib3.exceptions
 import tqdm
 
+from git import Repo
 import iocage.lib.ioc_common
 import iocage.lib.ioc_create
 import iocage.lib.ioc_destroy
@@ -1070,9 +1071,8 @@ fingerprint: {fingerprint}
                 _callback=self.callback,
                 silent=self.silent)
 
-            su.Popen(["git", "clone", conf["artifact"],
-                      f"{jaildir}/plugin"], stdout=su.PIPE,
-                     stderr=su.PIPE).communicate()
+            Repo.clone_from(conf["artifact"], f"{jaildir}/plugin", branch='master')
+
             tar_in = su.Popen(["tar", "cvf", "-", "-C",
                                f"{jaildir}/plugin/overlay/", "."],
                               stdout=su.PIPE,

--- a/iocage/lib/ioc_fetch.py
+++ b/iocage/lib/ioc_fetch.py
@@ -22,6 +22,8 @@ import requests.packages.urllib3.exceptions
 import tqdm
 
 from git import Repo
+from distutils.dir_util import copy_tree
+
 import iocage.lib.ioc_common
 import iocage.lib.ioc_create
 import iocage.lib.ioc_destroy
@@ -1071,15 +1073,8 @@ fingerprint: {fingerprint}
                 _callback=self.callback,
                 silent=self.silent)
 
-            Repo.clone_from(conf["artifact"], f"{jaildir}/plugin", branch='master')
-
-            tar_in = su.Popen(["tar", "cvf", "-", "-C",
-                               f"{jaildir}/plugin/overlay/", "."],
-                              stdout=su.PIPE,
-                              stderr=su.PIPE).communicate()
-            su.Popen(["tar", "xf", "-", "-C", f"{jaildir}/root"],
-                     stdin=su.PIPE).communicate(
-                input=tar_in[0])
+            repo = Repo.clone_from(conf["artifact"], f"{jaildir}/plugin", branch='master')
+            copy_tree(f"{jaildir}/plugin/overlay/", f"{jaildir}/root", preserve_symlinks=True)
 
             try:
                 shutil.copy(f"{jaildir}/plugin/post_install.sh",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(name='iocage',
           'requests',
           'tqdm',
           'coloredlogs',
+          'GitPython',
           'libzfs'
       ],
       setup_requires=['pytest-runner'],


### PR DESCRIPTION
**Warning**: this code is untested yet. Would love to pick up this refactoring at a later time. ⚡️

- use GitPython library to clone plugins
- use [distutils.dir_util.copy_tree](https://docs.python.org/2/distutils/apiref.html#distutils.dir_util.copy_tree) instead of tar pipes
