### PR TITLE
use libzfs in ioc_json

### DIFF
--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -118,7 +118,7 @@ class IOCJson(object):
         try:
             return self._zfs_get_properties(identifier)[key].value
         except:
-            return ""
+            return "-"
 
     def zfs_set_property(self, identifier, key, value):
         if ":" in key:


### PR DESCRIPTION
Uses py-libzfs in ioc_json.py

- removes the need to parse command output strings
- does not fork a process for each ZFS operation
- some refactoring
