### PR TITLE
fix rstrip removing chars from command names

### DIFF
--- a/iocage/main.py
+++ b/iocage/main.py
@@ -4,6 +4,7 @@ import os
 import signal
 import subprocess as su
 import sys
+import re
 
 import click
 # This prevents it from getting in our way.
@@ -52,7 +53,7 @@ class IOCageCLI(click.MultiCommand):
         for filename in os.listdir(cmd_folder):
             if filename.endswith('.py') and \
                     not filename.startswith('__init__'):
-                rv.append(filename.rstrip(".py"))
+                rv.append(re.sub(".py$", "", filename))
         rv.sort()
 
         return rv


### PR DESCRIPTION
str.rstrip(".py") removes all trailing characters `.`, `p` or `y` from a string. In case of `stop.py` the result is `sto` instead of the expected `stop`. The regular expression ensures only the string `.py` gets removed.

In consequence the iocage commands ending with `p` or `y` did not get loaded and were not accessible.

```
>>> "destroy.py".rstrip(".py") 
'destro'
>>> "stop.py".rstrip(".py")                                                                                                                                               
'sto'
```