### PR TITLE
optimize list command

### DIFF
--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -41,7 +41,7 @@ def cli(dataset_type, header, _long, remote, http, plugins, _sort):
     elif plugins:
         ioc_fetch.IOCFetch("").fetch_plugin_index("", _list=True)
     else:
-        _list = ioc.IOCage().list(dataset_type, header, _long, _sort)
+        _list = ioc.IOCage(skip_jails=True).list(dataset_type, header, _long, _sort)
 
         if not header:
             if dataset_type == "base":

--- a/iocage/lib/ioc_list.py
+++ b/iocage/lib/ioc_list.py
@@ -119,7 +119,6 @@ class IOCList(object):
             uuid = conf["host_hostuuid"]
             full_ip4 = conf["ip4_addr"]
             ip6 = conf["ip6_addr"]
-            jail_root = f"{self.pool}/iocage/jails/{uuid}/root"
 
             try:
                 short_ip4 = full_ip4.split("|")[1].split("/")[0]
@@ -152,7 +151,7 @@ class IOCList(object):
                 template = "-"
             else:
                 _origin_property = jail.properties["origin"]
-                if _origin_property and (_origin_property.value != ""):
+                if _origin_property and _origin_property.value != "":
                     template = jail.properties["origin"].value
                 else:
                     template = "-"

--- a/iocage/lib/ioc_list.py
+++ b/iocage/lib/ioc_list.py
@@ -113,8 +113,8 @@ class IOCList(object):
         jail_list = []
 
         for jail in jails:
-            jail = jail.properties["mountpoint"].value
-            conf = iocage.lib.ioc_json.IOCJson(jail).json_load()
+            mountpoint = jail.properties["mountpoint"].value
+            conf = iocage.lib.ioc_json.IOCJson(mountpoint).json_load()
 
             uuid = conf["host_hostuuid"]
             full_ip4 = conf["ip4_addr"]
@@ -151,11 +151,10 @@ class IOCList(object):
             if conf["type"] == "template":
                 template = "-"
             else:
-                try:
-                    template = iocage.lib.ioc_common.checkoutput(
-                        ["zfs", "get", "-H", "-o", "value", "origin",
-                         jail_root]).split("/")[3]
-                except IndexError:
+                _origin_property = jail.properties["origin"]
+                if _origin_property and (_origin_property.value != ""):
+                    template = jail.properties["origin"].value
+                else:
                     template = "-"
 
             if "release" in template.lower() or "stable" in template.lower():


### PR DESCRIPTION
- do not load jails twice to list them
- access zfs property `origin` directly from libzfs
