### PR TITLE
Initial review of iocage.8

### DIFF
--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -45,6 +45,7 @@
 .Op Fl b | -basejail
 .Op Fl c | -count
 .Op Fl e | -empty
+.Op Fl f | -force
 .Op Fl n | -name
 .Op Fl p | -pkglist
 .Op Fl r | -release
@@ -321,6 +322,8 @@ Clone the jail from the current host's release, as determined by the
 command.
 .It Op Fl e | -empty
 Create an empty jail, which is used for unsupported or custom jails.
+.It Op Fl f | -force
+Skip prompts, auto-confirming them with yes.
 .It Op Fl p | -pkglist
 .It Op Fl r | -release
 Specify which release to use for the new jail.

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -550,6 +550,8 @@ Enable verifying the SSL cert for HTTP fetching.
 Specifies the authentication method for HTTP fetching.
 Current values are basic and digest.
 .It Op Fl c | -count Ar TEXT
+Used when fetching a plugin. This option creates the designated
+number of plugin type jails.
 .It Op Fl d | -root-dir Ar TEXT
 Specify the root directory containing all RELEASE files.
 .It Op Fl f | -file

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -132,6 +132,7 @@
 .Op Fl R | -remote
 .Op Fl b | r | -base | -release | Cm dataset_type
 .Op Fl l | -long | Cm _long
+.Op Fl q | -quick
 .Op Fl s | -sort | Cm _sort
 .Op Fl t | -template | Cm dataset_type
 .\" == MIGRATE ==
@@ -687,6 +688,8 @@ Shows available RELEASE options for remote.
 List all bases.
 .It Op Fl l | -long | Cm _long
 Shows the full UUID and ip4 address.
+.It Op Fl q | -quick
+Lists all jails with less processing and fields.
 .It Op Fl s | -sort | Cm _sort Ar TEXT
 Sorts the list by the given type.
 .It Op Fl t | -template | Cm dataset_type

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -1544,10 +1544,10 @@ Default: UUID
 .Pp
 Source:
 .Xr jail 8
-.It tag="any string"
+.It name="any string"
 Custom string for aliasing jails.
 .Pp
-Default: date@time
+Default: UUID
 .Pp
 Source: local
 .It Pf template= Op yes | no
@@ -1739,7 +1739,7 @@ iocage fetch
 .Pp
 Create first jail:
 .Bd -literal -offset indent
-iocage create -r 11.0-RELEASE tag=myjail
+iocage create -r 11.0-RELEASE -n myjail
 .Ed
 .Pp
 List jails:

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -24,35 +24,34 @@
 .\" == CLEAN ==
 .Nm
 .Cm clean
-.Op Fl a | -all
-.Op Fl b | r | -base
+.Op Fl a | -all | Cm dataset_type
+.Op Fl b | r | -base | Cm dataset_type
 .Op Fl f | -force
-.Op Fl j | -jails
-.Op Fl t | -template
+.Op Fl j | -jails |  Cm dataset_type
+.Op Fl t | -template | Cm dataset_type
+.\"== CLONE ==
+.Nm
+.Cm clone
+.Ar UUID | TAG
+.Ar PROPERTIES
+.Op Fl c | -count
 .\" == CONSOLE ==
 .Nm
 .Cm console
-.Op Fl f | -force
 .Ar UUID | TAG
 .\" == CREATE ==
 .Nm
 .Cm create
 .Op Fl b | -basejail
 .Op Fl c | -count
-.Ar TEXT
 .Op Fl e | -empty
+.Op Fl n | -name
 .Op Fl p | -pkglist
-.Ar TEXT
 .Op Fl r | -release
-.Ar TEXT
 .Op Fl s | -short
 .Op Fl t | -template
-.Ar TEXT
-.Op Fl u | -uuid
-.Ar TEXT
-.Op Cm release Ns = Ns Ar RELEASE
-.Op Cm pkglist Ns = Ns Ar FILE
-.Op Cm property Ns = Ns Ar VALUE
+.Op Fl u | -uuid | Cm _uuid
+.Ar PROPERTIES
 .\" == DESTROY ==
 .Nm
 .Cm destroy
@@ -64,15 +63,14 @@
 .Nm
 .Cm df
 .Op Fl H | h | -header
-.Op Fl l | -long
+.Op Fl l | -long | Cm _long
+.Op Fl s | -sort | Cm _sort
 .\" == EXEC ==
 .Nm
 .Cm exec
-.Op Fl U | -jail_user
-.Ar NAME
-.Op Fl u | -host_user
-.Ar NAME
-.Ar ALL | TAG | UUID
+.Op Fl U | -jail_user Ar NAME
+.Op Fl u | -host_user Ar NAME
+.Ar TAG | UUID
 .Cm COMMAND Op Ar ARGS
 .\" == EXPORT ==
 .Nm
@@ -81,70 +79,60 @@
 .\" == FETCH ==
 .Nm
 .Cm fetch
-.Op Fl -plugins
+.Op Fl -accept
+.Op Fl -noaccept
+.Op Fl -plugins Ar PROPERTIES
 .Op Fl E | -eol
 .Op Fl F | -files
-.Ar TEXT
 .Op Fl NE | -noeol
 .Op Fl NU | -noupdate
 .Op Fl NV | -noverify
 .Op Fl P | -plugin-file
-.Ar TEXT
 .Op Fl U | -update
 .Op Fl V | -verify
 .Op Fl a | -auth
-.Ar TEXT
 .Op Fl c | -count
-.Ar TEXT
 .Op Fl d | -root-dir
-.Ar TEXT
-.Op Fl f | -file
+.Op Fl f | -file | Cm _file
 .Op Fl h | -http
+.Op Fl n | -name
 .Op Fl p | -password
-.Ar TEXT
 .Op Fl r | -release
-.Ar TEXT
 .Op Fl s | -server
-.Ar TEXT
 .Op Fl u | -user
-.Ar TEXT
-.Op Cm release Ns = Ns Ar RELEASE
-.Op Cm ftphost Ns = Ns Ar ftp.hostname.org
-.Op Cm ftpdir Ns = Ns Ar /dir/
-.Op Cm ftpfiles Ns = Ns Ar "base.txz doc.txz lib32.txz src.txz"
 .\" == FSTAB ==
 .Nm
 .Cm fstab
-.Op Fl a | -add
-.Op Fl e | -edit
-.Op Fl r | -remove
 .Ar JAIL
-.Op Ar FSTAB_STRING
+.Ar FSTAB_STRING
+.Op Fl a | -add | Cm action
+.Op Fl e | -edit | Cm action
+.Op Fl r | -remove | Cm action
 .\" == GET ==
 .Nm
 .Cm get
+.Ar PROPERTY
+.Ar UUID | TAG
 .Op Fl H | h | -header
 .Op Fl P | -plugin
-.Op Fl a | -all
-.Op Fl p | -pool
+.Op Fl a | -all | Cm _all
+.Op Fl p | -pool | Cm _pool
 .Op Fl r | -recursive
-.Ar PROPERTY
-.Op Ar all | UUID | TAG
 .\" == IMPORT ==
 .Nm
 .Cm import
-.Ar JAIL
-.Op Ar Jail_value
+.Ar UUID | TAG
 .\" == LIST ==
 .Nm
 .Cm list
+.Op Fl -http
 .Op Fl H | h | -header
 .Op Fl P | -plugins
 .Op Fl R | -remote
-.Op Fl b | r | -base | -release
-.Op Fl h | -http
-.Op Fl l | -long
-.Op Fl t | -template
+.Op Fl b | r | -base | -release | Cm dataset_type
+.Op Fl l | -long | Cm _long
+.Op Fl s | -sort | Cm _sort
+.Op Fl t | -template | Cm dataset_type
 .\" == MIGRATE ==
 .Nm
 .Cm migrate
@@ -153,27 +141,25 @@
 .\" == PKG ==
 .Nm
 .Cm pkg
-.Ar JAIL
+.Ar UUID | TAG
 .Ar COMMAND
 .\" == RESTART ==
 .Nm
 .Cm restart
 .Op Fl s | -soft
-.Op Ar UUID | TAG
+.Ar UUID | TAG
 .\" == ROLLBACK ==
 .Nm
 .Cm rollback
+.Ar UUID | TAG
 .Op Fl f | -force
 .Op Fl n | -name
-.Ar SNAPSHOT
-.Op Ar UUID | TAG@snapshotname
 .\" == SET ==
 .Nm
 .Cm set
-.Op Fl P | -plugin
-.Ar KEY
-.Ar property_value
-.Op Ar UUID | TAG
+.Ar PROPERTY
+.Ar UUID | TAG
+.Op Fl P | -plugin Ar KEY
 .\" == SNAPLIST ==
 .Nm
 .Cm snaplist
@@ -182,33 +168,32 @@
 .\" == SNAPREMOVE ==
 .Nm
 .Cm snapremove
+.Ar UUID | TAG
 .Op Fl n | -name
-.Op Ar UUID | TAG@snapshotname | ALL
 .\" == SNAPSHOT ==
 .Nm
 .Cm snapshot
+.Ar UUID | TAG
 .Op Fl n | -name
-.Op Ar UUID | TAG | TAG@snapshotname
 .\" == START ==
 .Nm
 .Cm start
 .Op Fl -rc
-.Op Ar UUID | TAG
+.Ar UUID | TAG
 .\" == STOP ==
 .Nm
 .Cm stop
 .Op Fl -rc
-.Op Ar UUID | TAG
+.Ar UUID | TAG
 .\" == UPDATE ==
 .Nm
 .Cm update
-.Op Ar UUID | TAG
+.Ar UUID | TAG
 .\" == UPGRADE ==
 .Nm
 .Cm upgrade
-.Op Fl r | -release
-.Ar RELEASE
-.Op Ar UUID | TAG
+.Ar UUID | TAG
+.Fl r | -release Ar RELEASE
 .Sh DESCRIPTION
 .Nm
 is a system administration tool designed to simplify jail management
@@ -1606,6 +1591,8 @@ For more information, please see
 Please report bugs, issues, and feature requests at
 .Lk https://github.com/iocage/iocage/issues
 .Sh AUTHORS
+.An Warren Block
+.An Tim Moore Jr
 .An Peter Toth
 .An Brandon Schneider
 .Sh SPECIAL THANKS

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -19,7 +19,7 @@
 .\" == CHROOT ==
 .Nm
 .Cm chroot
-.Ar UUID | TAG
+.Ar UUID | NAME
 .Op Ar COMMAND
 .\" == CLEAN ==
 .Nm
@@ -32,13 +32,13 @@
 .\"== CLONE ==
 .Nm
 .Cm clone
-.Ar UUID | TAG
+.Ar UUID | NAME
 .Ar PROPERTIES
 .Op Fl c | -count
 .\" == CONSOLE ==
 .Nm
 .Cm console
-.Ar UUID | TAG
+.Ar UUID | NAME
 .\" == CREATE ==
 .Nm
 .Cm create
@@ -59,7 +59,7 @@
 .Op Fl d | -download
 .Op Fl f | -force
 .Op Fl r | -release
-.Ar UUID | TAG
+.Ar UUID | NAME
 .\" == DF ==
 .Nm
 .Cm df
@@ -71,12 +71,12 @@
 .Cm exec
 .Op Fl U | -jail_user Ar NAME
 .Op Fl u | -host_user Ar NAME
-.Ar TAG | UUID
+.Ar UUID | NAME
 .Cm COMMAND Op Ar ARGS
 .\" == EXPORT ==
 .Nm
 .Cm export
-.Ar UUID | TAG
+.Ar UUID | NAME
 .\" == FETCH ==
 .Nm
 .Cm fetch
@@ -115,7 +115,7 @@
 .Nm
 .Cm get
 .Ar PROPERTY
-.Ar UUID | TAG
+.Ar UUID | NAME
 .Op Fl H | h | -header
 .Op Fl P | -plugin
 .Op Fl a | -all | Cm _all
@@ -124,7 +124,7 @@
 .\" == IMPORT ==
 .Nm
 .Cm import
-.Ar UUID | TAG
+.Ar UUID | NAME
 .\" == LIST ==
 .Nm
 .Cm list
@@ -145,59 +145,59 @@
 .\" == PKG ==
 .Nm
 .Cm pkg
-.Ar UUID | TAG
+.Ar UUID | NAME
 .Ar COMMAND
 .\" == RESTART ==
 .Nm
 .Cm restart
 .Op Fl s | -soft
-.Ar UUID | TAG
+.Ar UUID | NAME
 .\" == ROLLBACK ==
 .Nm
 .Cm rollback
 .Op Fl f | -force
 .Fl n | -name Ar TEXT
-.Ar UUID | TAG
+.Ar UUID | NAME
 .\" == SET ==
 .Nm
 .Cm set
 .Ar PROPERTY
-.Ar UUID | TAG
+.Ar UUID | NAME
 .Op Fl P | -plugin Ar KEY
 .\" == SNAPLIST ==
 .Nm
 .Cm snaplist
 .Op Fl H | h | -header
 .Op Fl l | -long | Cm _long
-.Op Ar UUID | TAG
+.Op Ar UUID | NAME
 .\" == SNAPREMOVE ==
 .Nm
 .Cm snapremove
 .Op Fl n | -name Ar TEXT
-.Ar UUID | TAG | ALL
+.Ar UUID | NAME | ALL
 .\" == SNAPSHOT ==
 .Nm
 .Cm snapshot
 .Op Fl n | -name Ar TEXT
-.Ar UUID | TAG
+.Ar UUID | NAME
 .\" == START ==
 .Nm
 .Cm start
 .Op Fl -rc
-.Op Ar UUID | TAG | ALL
+.Op Ar UUID | NAME | ALL
 .\" == STOP ==
 .Nm
 .Cm stop
 .Op Fl -rc
-.Op Ar UUID | TAG | ALL
+.Op Ar UUID | NAME | ALL
 .\" == UPDATE ==
 .Nm
 .Cm update
-.Ar UUID | TAG
+.Ar UUID | NAME
 .\" == UPGRADE ==
 .Nm
 .Cm upgrade
-.Ar UUID | TAG
+.Ar UUID | NAME
 .Fl r | -release Ar RELEASE
 .Sh DESCRIPTION
 .Nm
@@ -222,13 +222,7 @@ can be used in the form of
 .Ar adae47cb
 or just
 .Ar adae .
-In addition to partial UUID calling, jail TAGs can be used
-interchangeably.
-.Pp
-To ease jail identification, a TAG field is included in list mode
-which can be set to any string (hostname, label, note, etc.).
-If unset, the TAG field contains the creation date and time stamp by
-default.
+In addition to partial UUID calling, jail NAMEs can also be used.
 .Pp
 Jails can be easily moved with ZFS
 .Cm send
@@ -333,9 +327,9 @@ is named.
 .Pp
 Example:
 .Pp
-.Dl # iocage clone 38114a58 tag=cloneexample1
+.Dl # iocage clone 38114a58 --name cloneexample1
 .Pp
-Clone jail 38114a58 and add the tag property cloneexample1.
+Clone jail 38114a58 and add the name cloneexample1 to the new jail.
 .Pp
 .\" == CONSOLE ==
 .It Cm console
@@ -366,7 +360,7 @@ Create an empty jail for unsupported or custom jails.
 .It Op Fl f | -force
 Skip prompts, auto-confirming them with yes.
 .It Op Fl n | -name
-Provide a name and tag instead of a UUID for the new jail.
+Provide a NAME instead of a UUID for the new jail.
 .It Op Fl p | -pkglist Ar TEXT
 Specify a JSON file which manages the installation of each
 package in the newly created jail.
@@ -392,12 +386,12 @@ Create a FreeBSD 11.0 jail with a shortened UUID.
 .Pp
 Create a FreeBSD 11.0 jail with the custom UUID 12345678.
 .Pp
-.Dl # iocage create -c 3 -r 11.0-RELEASE tag=examplejail
+.Dl # iocage create -c 3 -r 11.0-RELEASE -n examplejail
 .Pp
 This command creates three identical jails based off the
 FreeBSD 11.0 RELEASE.
-These jails are sequentially tagged based on the
-custom tag property.
+These jails are sequentially numbered  based on the
+custom NAME.
 .\" == DESTROY ==
 .It Cm destroy
 Destroy the specified jail.
@@ -445,7 +439,7 @@ disk quota
 used space
 .It AVA
 available space
-.It TAG
+.It NAME
 jail name
 .El
 .Pp
@@ -470,7 +464,7 @@ Displays the usage table with the full UUID of each jail.
 Execute a command inside the specified jail.
 This is an
 .Nm
-UUID/tag wrapper for
+UUID/NAME wrapper for
 .Xr jexec 8 .
 After invoking
 .Cm exec ,
@@ -630,7 +624,7 @@ Example:
 .\" == GET ==
 .It Cm get
 Display the specified property.
-List the property, then the UUID or TAG of the jail to search.
+List the property, then the UUID or NAME of the jail to search.
 .Pp
 Options:
 .Bl -tag -width "[-H | -h | --header]"
@@ -662,7 +656,7 @@ through
 .Pp
 .Dl # iocage get -r dhcp
 .Pp
-Displays a table with each jail's UUID, TAG, and the
+Displays a table with each jail's UUID or NAME and the
 status of the requested property.
 .Pp
 .\" == IMPORT ==
@@ -719,8 +713,8 @@ Unique identifcation number.
 .It STATE
 Displays the active state of the jail.
 Can be up or down.
-.It TAG
-The user added tag value.
+.It NAME
+The user assigned NAME.
 .It RELEASE
 The jail's FreeBSD RELEASE.
 .It IP4
@@ -752,7 +746,7 @@ no further user interaction.
 Run desired
 .Cm pkg
 commands in the specified jail.
-List the jail's UUID or TAG, then any desired commands.
+List the jail's UUID or NAME, then any desired commands.
 .Pp
 .\" == RESTART ==
 .It Cm restart
@@ -804,8 +798,6 @@ If accessing a nested key, use "." as a separator.
 Examples:
 .Pp
 .Dl # iocage set -P foo.bar.baz=VALUE PLUGIN
-.Pp
-.Dl # iocage set tag=examplejail1 b1ebda86
 .Pp
 .\" == SNAPLIST ==
 .It Cm snaplist
@@ -874,7 +866,7 @@ Example:
 Start a jail identified by
 .Ar UUID
 or
-.Ar TAG .
+.Ar NAME .
 Use
 .Op Ar ALL
 to start all installed jails instead.
@@ -895,7 +887,7 @@ Example:
 Stop a jail identified by
 .Ar UUID
 or
-.Ar TAG .
+.Ar NAME .
 Use
 .Op Ar ALL
 to stop all active jails instead.

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -1600,8 +1600,10 @@ and
 .An Brandon Schneider .
 .Pp
 This manual page was written by
-.An Warren Block
+.An Warren Block,
+.An Tim Moore,
+.An Peter Toth,
 and
-.An Tim Moore .
+.An Brandon Schneider .
 .Sh SPECIAL THANKS
 Sichendra Bista - for his ever willing attitude and ideas.

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -487,29 +487,27 @@ Define the user.
 .El
 .Pp
 Examples:
-.Bl -item
-.It
-.Nm
-fetch release=10.1-RELEASE
-.El
 .Pp
-.Cm fetch
-is also used to update already downloaded releases.
-To update a local release already present in
-.Nm
-.Po
-.Cm iocage list -r
-.Pc ,
-run:
-.Bl -item
-.It
-.Nm
-fetch release=10.1-RELEASE
-.El
+.Dl # iocage fetch
 .Pp
-This example applies the latest patches to 10.1-RELEASE base.
-Newly created jails or basejails will automatically have the latest
-updates applied.
+.Nm
+lists available FreeBSD releases and asks which to download.
+Enter the numeric option for the desired release, or type EXIT
+to quit without downloading.
+.Pp
+.Dl # iocage fetch --release 10.3-RELEASE
+.Pp
+This tells
+.Nm
+to download and automatically update the FreeBSD 10.3 RELEASE.
+This can also be used to apply the latest patches to an already
+downloaded release.
+Newly created jails or basejails are automatically updated.
+.Pp
+.Dl # iocage fetch -NE -r 11.0-RELEASE
+.Pp
+This disables the end of life check, then fetches the FreeBSD 11.0
+release and updates with the latest patches.
 .\" == FSTAB ==
 .It Cm fstab
 Manipulates the fstab settings of a specific jail.

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -344,18 +344,20 @@ Example:
 .Pp
 .\" == CREATE ==
 .It Cm create
-Deploy a new jail based on the host operating system's release.
-The default can be overridden by specifying the release option.
+Deploy a new jail based on the host operating system's RELEASE.
+The default can be overridden by specifying the RELEASE option.
 A fully independent jail set is created by default.
 .Pp
 Options:
 .Bl -tag -width "[-b | --basejail]"
 .It Op Fl b | -basejail
-Create a new "basejail" with a common shared base.
+Create a new "basejail".
+This basejail mounts the designated RELEASE directory as a
+nullfs mount over the jail's directories.
 .It Op Fl c | -count Ar TEXT
-Clone the jail from the current host's release, as determined by the
-.Fl r
-option.
+Designate the number of jails to create, all cloned from
+the desired
+.Op Fl r Ar RELEASE . 
 .It Op Fl e | -empty
 Create an empty jail for unsupported or custom jails.
 .It Op Fl f | -force
@@ -363,8 +365,10 @@ Skip prompts, auto-confirming them with yes.
 .It Op Fl n | -name
 Provide a name and tag instead of a UUID for the new jail.
 .It Op Fl p | -pkglist Ar TEXT
+Specify a JSON file which manages the installation of each
+package in the newly created jail.
 .It Op Fl r | -release Ar TEXT
-Specify which release to use for the new jail.
+Specify which RELEASE to use for the new jail.
 .It Op Fl f | -force
 Skip prompts, auto-confirming them with yes.
 .It Op Fl s | -short
@@ -385,6 +389,12 @@ Create a FreeBSD 11.0 jail with a shortened UUID.
 .Pp
 Create a FreeBSD 11.0 jail with the custom UUID 12345678.
 .Pp
+.Dl # iocage create -c 3 -r 11.0-RELEASE tag=examplejail
+.Pp
+This command creates three identical jails based off the
+FreeBSD 11.0 RELEASE.
+These jails are sequentially tagged based on the
+custom tag property.
 .\" == DESTROY ==
 .It Cm destroy
 Destroy the specified jail.

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -291,8 +291,11 @@ A command can be specified as with the normal system, see
 .Pp
 Example:
 .Pp
-.Dl # iocage chroot examplejail ls /home
+.Dl # iocage chroot 6ffe99a9 ls
 .Pp
+Run
+.Cm ls
+in the jail identified by the shortened UUID.
 .\" == CLEAN ==
 .It Cm clean
 Destroy ZFS datasets.
@@ -310,15 +313,35 @@ Destroys all created jails.
 .It Op Fl t | -template | Cm dataset_type
 Destroys all templates.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage clean -j
+.Pp
+Destroys all created jails on the system, after a prompt ensures this
+is the desired action.
+.Pp
 .\"== CLONE ==
 .It Cm clone
 Clone a jail.
 Properties can be configured for the clone by listing them after the
 .Ar SOURCE
 is named.
+.Pp
+Example:
+.Pp
+.Dl # iocage clone 38114a58 tag=cloneexample1
+.Pp
+Clone jail 38114a58 and add the tag property cloneexample1.
+.Pp
 .\" == CONSOLE ==
 .It Cm console
 Execute login to open a shell inside the jail.
+.Pp
+Example:
+.Pp
+.Dl # iocage console cloneexample1
+.Pp
 .\" == CREATE ==
 .It Cm create
 Deploy a new jail based on the host operating system's release.
@@ -353,14 +376,15 @@ Specify a desired UUID for the new jail.
 .El
 .Pp
 Examples:
-.Bl -item
-.It
-.Nm
-create tag=www01 pkglist=$HOME/my-pkgs.txt
-.It
-.Nm
-create -b tag=mybasejail
-.El
+.Pp
+.Dl # iocage create -s -r 11.0-RELEASE
+.Pp
+Create a FreeBSD 11.0 jail with a shortened UUID.
+.Pp
+.Dl # iocage create -r 11.0-RELEASE -u 12345678
+.Pp
+Create a FreeBSD 11.0 jail with the custom UUID 12345678.
+.Pp
 .\" == DESTROY ==
 .It Cm destroy
 Destroy the specified jail.
@@ -377,6 +401,15 @@ Destroy the jail with no further warnings or user input.
 .It Op Fl r | -release
 Destroy a specified RELEASE dataset.
 .El
+.Pp
+Examples:
+.Pp
+.Dl # iocage destroy 12345678
+.Pp
+.Dl # iocage destroy -r 10.1-RELEASE
+.Pp
+Destroy the downloaded FreeBSD 10.1 release.
+.Pp
 .\" == DF ==
 .It Cm df
 Show resource usage of all jails.
@@ -726,6 +759,13 @@ Options:
 Stop all jails with boot=on in a specific order.
 Jails with higher priority values stop first.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage stop 6ffe99a9
+.Pp
+Stop the jail identified by the shortened UUID.
+.Pp
 .\" == UPDATE ==
 .It Cm update
 Runs

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -1591,9 +1591,16 @@ For more information, please see
 Please report bugs, issues, and feature requests at
 .Lk https://github.com/iocage/iocage/issues
 .Sh AUTHORS
-.An Warren Block
-.An Tim Moore Jr
+.Nm
+was developed by
+.An -nosplit
 .An Peter Toth
-.An Brandon Schneider
+and
+.An Brandon Schneider .
+.Pp
+This manual page was written by
+.An Warren Block
+and
+.An Tim Moore .
 .Sh SPECIAL THANKS
 Sichendra Bista - for his ever willing attitude and ideas.

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -152,9 +152,9 @@
 .\" == ROLLBACK ==
 .Nm
 .Cm rollback
-.Ar UUID | TAG
 .Op Fl f | -force
-.Op Fl n | -name
+.Fl n | -name Ar TEXT
+.Ar UUID | TAG
 .\" == SET ==
 .Nm
 .Cm set
@@ -170,23 +170,23 @@
 .\" == SNAPREMOVE ==
 .Nm
 .Cm snapremove
-.Ar UUID | TAG
-.Op Fl n | -name
+.Op Fl n | -name Ar TEXT
+.Ar UUID | TAG | ALL
 .\" == SNAPSHOT ==
 .Nm
 .Cm snapshot
+.Op Fl n | -name Ar TEXT
 .Ar UUID | TAG
-.Op Fl n | -name
 .\" == START ==
 .Nm
 .Cm start
 .Op Fl -rc
-.Ar UUID | TAG
+.Op Ar UUID | TAG | ALL
 .\" == STOP ==
 .Nm
 .Cm stop
 .Op Fl -rc
-.Ar UUID | TAG
+.Op Ar UUID | TAG | ALL
 .\" == UPDATE ==
 .Nm
 .Cm update
@@ -209,8 +209,8 @@ Each jail has a unique ID (UUID) which is automatically generated at
 creation time.
 Using the UUID as a jail identifier makes it possible to replicate a
 jail in a distributed environment with greater flexibility.
-This also eliminates potential naming clashes on large scale deployments
-and helps reduce operator error.
+This also eliminates potential naming clashes on large scale
+deployments and helps reduce operator error.
 .Pp
 Partial UUID calling is supported with every operation.
 For example,
@@ -222,8 +222,8 @@ or just
 In addition to partial UUID calling, jail TAGs can be used
 interchangeably.
 .Pp
-To ease jail identification, a TAG field is included in list mode which
-can be set to any string (hostname, label, note, etc.).
+To ease jail identification, a TAG field is included in list mode
+which can be set to any string (hostname, label, note, etc.).
 If unset, the TAG field contains the creation date and time stamp by
 default.
 .Pp
@@ -281,31 +281,34 @@ By default, all other pools are deactivated.
 Chroot into a jail without actually starting the jail itself.
 Useful for initial setup like setting a root password or configuring
 networking.
-A command can be specified as with the normal system
+A command can be specified as with the normal system, see
 .Xr chroot 8 .
 .\" == CLEAN ==
 .It Cm clean
 Destroy ZFS datasets.
 .Pp
 Options:
-.Bl -tag -width "[-b | --base | -r]"
-.It Op Fl a | -all
+.Bl -tag -width "[-b | --base | -r | dataset_type]"
+.It Op Fl a | -all | Cm dataset_type
 Destroys all created iocage data.
-.It Op Fl b | r | -base
+.It Op Fl b | r | -base | Cm dataset_type
 Destroys all fetched RELEASE jails.
 .It Op Fl f | -force
 Runs the command without any further user interaction.
-.It Op Fl j | -jails
+.It Op Fl j | -jails | Cm dataset_type
 Destroys all created jails.
-.It Op Fl t | -template
+.It Op Fl t | -template | Cm dataset_type
 Destroys all templates.
 .El
+.\"== CLONE ==
+.It Cm clone
+Clone a jail.
+Properties can be configured for the clone by listing them after the
+.Ar SOURCE
+is named.
 .\" == CONSOLE ==
 .It Cm console
-Execute login to have a shell inside the jail.
-Use the
-.Op Fl f | -force
-option to run the command with no further user input.
+Execute login to open a shell inside the jail.
 .\" == CREATE ==
 .It Cm create
 Deploy a new jail based on the host operating system's release.
@@ -318,12 +321,14 @@ Options:
 Create a new "basejail" with a common shared base.
 .It Op Fl c | -count
 Clone the jail from the current host's release, as determined by the
-.Cm uname Fl r
-command.
+.Fl r
+option.
 .It Op Fl e | -empty
-Create an empty jail, which is used for unsupported or custom jails.
+Create an empty jail for unsupported or custom jails.
 .It Op Fl f | -force
 Skip prompts, auto-confirming them with yes.
+.It Op Fl n | -name
+Provide a name and tag instead of a UUID for the new jail.
 .It Op Fl p | -pkglist
 .It Op Fl r | -release
 Specify which release to use for the new jail.
@@ -331,9 +336,8 @@ Specify which release to use for the new jail.
 Use a short UUID of 8 characters instead of the default 36.
 .It Op Fl t | -template
 Create a template style jail.
-Use the
 .It Op Fl u | -uuid
-option to add a specific UUID to the new jail.
+Specify a desired UUID for the new jail.
 .El
 .Pp
 Examples:
@@ -348,13 +352,14 @@ create -b tag=mybasejail
 .\" == DESTROY ==
 .It Cm destroy
 Destroy the specified jail.
-This is not reversible, so use with caution.
-If the jail is running, the destroy action fails.
+Caution, this subcommand is irreversible.
+.Cm destroy
+only works with a stopped jail.
 .Pp
 Options:
 .Bl -tag -width "[-d | --download]"
 .It Op Fl d | -download
-Delete the download of the specified RELEASE as well.
+Also destroy the specified RELEASE download.
 .It Op Fl f | -force
 Destroy the jail with no further warnings or user input.
 .It Op Fl r | -release
@@ -388,8 +393,10 @@ Options:
 .Bl -tag -width "[-H | -h | --header]"
 .It Op Fl H | h | -header
 Use when scripting, using tabs for separators.
-.It Op Fl l | -long
+.It Op Fl l | -long | Cm _long
 Shows the full UUID.
+.It Op Fl s | -s | Cm _long Ar TEXT
+Sorts the list by the named type.
 .El
 .\" == EXEC ==
 .It Cm exec
@@ -398,12 +405,16 @@ This is an
 .Nm
 UUID/tag wrapper for
 .Xr jexec 8 .
+After invoking
+.Cm exec ,
+specify the jail, any commands to run inside that jail, and any
+arguments for those commands.
 .Pp
 Options:
-.Bl -tag -width "[-u | --host_user]"
-.It Op Fl U | -jail_user
+.Bl -tag -width "[-u | --host_user NAME]"
+.It Op Fl U | -jail_user Ar NAME
 Specifies which jail user runs the command.
-.It Op Fl u | -host_user
+.It Op Fl u | -host_user Ar NAME
 Specify which host user runs the command.
 .El
 .\" == EXPORT ==
@@ -411,26 +422,30 @@ Specify which host user runs the command.
 Exports the specified jail.
 An archive file is created in
 .Pa /iocage/images
-with a SHA256 checksum
+with an SHA256 checksum.
 The jail must be stopped before exporting.
 .\" == FETCH ==
 .It Cm fetch
-Download and updates/patches releases.
+Downloads and/or updates releases.
 .Pp
 .Cm fetch
 must be executed as the first command on a pristine system.
 The host node's RELEASE is downloaded for deployment.
 If other releases are required, this can be changed by supplying the
-required release property or just selecting the appropriate RELEASE from
+required release property or selecting the appropriate RELEASE from
 the menu list.
 .Pp
 Options:
 .Bl -tag -width "[-P | --plugin-file text]"
-.It Op Fl -plugins
+.It Op Fl -accept
+Accept the plugin's LICENSE agreement.
+.It Op Fl -noaccept
+Do not accept the plugin's LICENSE agreement.
+.It Op Fl -plugins Ar PROPERTIES
 List all available plugins for creation.
 .It Op Fl E | -eol
 Enable End Of Life (EOL) checking upstream.
-.It Op Fl F | -files
+.It Op Fl F | -files Ar TEXT
 Specify the files to fetch from the mirror.
 .It Op Fl NE | -noeol
 Disable EOL checking upstream.
@@ -438,33 +453,34 @@ Disable EOL checking upstream.
 Disable updating the fetch item to the latest patch level.
 .It Op Fl NV | -noverify
 Disable verifying the SSL cert for HTTP fetching.
-.It Op Fl P | -plugin-file
+.It Op Fl P | -plugin-file Ar TEXT
 Specify which plugin file to use.
 .It Op Fl U | -update
 Update the fetch to the latest patch level.
 .It Op Fl V | -verify
 Enable verifying the SSL cert for HTTP fetching.
-.It Op Fl a | -auth
+.It Op Fl a | -auth Ar TEXT
 Specifies the authentication method for HTTP fetching.
 Current values are basic and digest.
-.It Op Fl c | -count
-.It Op Fl d | -root-dir
+.It Op Fl c | -count Ar TEXT
+.It Op Fl d | -root-dir Ar TEXT
 Specify the root directory containing all RELEASE files.
 .It Op Fl f | -file
-Use a local file directory for the root directory instead of FTP or HTTP.
+Use a local file directory for the root directory instead of FTP or
+HTTP.
 .It Op Fl h | -http
 Change
 .Op Fl s | -server
 to define an HTTP server instead of the default FTP.
-.It Op Fl p | -password
+.It Op Fl p | -password Ar TEXT
 Add a password, if required.
-.It Op Fl r |-release
+.It Op Fl r |-release Ar TEXT
 Define the
 .Fx
 release to fetch.
-.It Op Fl s | -server
+.It Op Fl s | -server Ar TEXT
 Define which FTP server to log into.
-.It Op Fl u | -user
+.It Op Fl u | -user Ar TEXT
 Define the user.
 .El
 .Pp
@@ -495,23 +511,25 @@ updates applied.
 .\" == FSTAB ==
 .It Cm fstab
 Manipulates the fstab settings of a specific jail.
+Name any options, then the jail, and finally all needed fstab strings.
 .Pp
 Options:
-.Bl -tag -width "[-r | --remove]"
-.It Op Fl a | -add
-Adds an entry to the specific jail
+.Bl -tag -width "[-r | --remove | action]"
+.It Op Fl a | -add | Cm action
+Adds an entry to the specific jail's
 .Pa fstab
-and mount it.
-.It Op Fl e | -edit
-Open the
+and mounts it.
+.It Op Fl e | -edit | Cm action
+Opens the
 .Pa fstab
 file in the default editor.
-.It Op Fl r | -remove
-Remove an entry from a specific jail fstab and unmount it.
+.It Op Fl r | -remove | Cm action
+Remove an entry from a specific jail's fstab and unmounts it.
 .El
 .\" == GET ==
 .It Cm get
 Display the specified property.
+List the property, then the UUID or TAG of the jail to search.
 .Pp
 Options:
 .Bl -tag -width "[-H | -h | --header]"
@@ -520,10 +538,10 @@ Used in scripting.
 Use tabs for separators.
 .It Op Fl P | -plugin
 Get the specified key for a plugin jail.
-.It Op Fl a | -all
+.It Op Fl a | -all | Cm _all
 Get all properties for the specified jail.
 If accessing a nested key, use "." as a separator.
-.It Op Fl p | -pool
+.It Op Fl p | -pool | Cm _pool
 Get the currently activated zpool.
 .It Op Fl r | -recursive
 Get the specified property for all jails.
@@ -531,15 +549,19 @@ Get the specified property for all jails.
 .\" == IMPORT ==
 .It Cm import
 Import a specific jail image.
-Short UUIDs can be used, but do not specify the full filename, only the
-UUID.
+Short UUIDs can be used, but do not specify the full filename, only
+the UUID.
 .\" == LIST ==
 .It Cm list
-List a specified dataset type.
+List the specified dataset type.
 By default, all jails are listed.
 .Pp
 Options:
 .Bl -tag -width "[-H | -h | --header]"
+.It Op Fl -http
+Changes
+.Op Fl R | -remote
+to use HTTP.
 .It Op Fl H | h | -header
 Used in scripting.
 Use tabs for separators.
@@ -547,20 +569,19 @@ Use tabs for separators.
 Shows available plugins.
 .It Op Fl R | -remote
 Shows available RELEASE options for remote.
-.It Op Fl b | r | -base | -release
+.It Op Fl b | r | -base | -release | Cm dataset_type
 List all bases.
-.It Op Fl h | -http
-Changes
-.Op Fl R | -remote
-to use HTTP.
-.It Op Fl l | -long
+.It Op Fl l | -long | Cm _long
 Shows the full UUID and ip4 address.
-.It Op Fl t | -template
+.It Op Fl s | -sort | Cm _sort Ar TEXT
+Sorts the list by the given type.
+.It Op Fl t | -template | Cm dataset_type
 Lists all templates.
 .El
 .\" == MIGRATE ==
 .It Cm migrate
-Migrate from the development version of iocage-legacy to the current jail format.
+Migrate from the development version of iocage-legacy to the current
+jail format.
 .Pp
 Options:
 .Bl -tag -width "[-d | --delete]"
@@ -574,10 +595,10 @@ Bypass any further warning or required user interaction.
 Run desired
 .Cm pkg
 commands in the specified jail.
+List the jail's UUID or TAG, then any desired commands.
 .\" == RESTART ==
 .It Cm restart
-Restart the specified jail.
-Use ALL to restart all jails.
+Restart the specified jail, OR use ALL to restart all jails.
 .Pp
 Options:
 .Bl -tag -width "[-s | --soft]"
@@ -595,16 +616,17 @@ Options:
 .Bl -tag -width "[-f | --force]"
 .It Op Fl f | -force
 Run the command, skipping any warnings or further user interaction.
-.It Op Fl n | -name
+.It Fl n | -name
 [Required] Used to specify the snapshot name.
 .El
 .\" == SET ==
 .It Cm set
 Set the specified property in the desired jail.
+Type the desired property first, then the jail to which it applies.
 .Pp
 Options:
 .Bl -tag -width "[-P | --plugin]"
-.It Op Fl P | -plugin
+.It Op Fl P | -plugin Ar KEY
 Set the specified key for a plugin jail.
 If accessing a nested key, use "." as a separator.
 .El
@@ -636,17 +658,19 @@ Options:
 .It Op Fl H | h | -header
 Used for scripting.
 Tabs are used as separators.
+.It Op Fl l | -long | Cm _long
+Show the full dataset path for the snapshot.
 .El
 .\" == SNAPREMOVE ==
 .It Cm snapremove
 Delete snapshots of the specified jail.
 If the keyword
-.Ar ALL
+.Op Ar ALL
 is used, all snapshots the specified jail are deleted.
 .Pp
 Options:
 .Bl -tag -width "[-n | --name]"
-.It Op Fl n | -name
+.It Op Fl n | -name Ar TEXT
 [Required] The snapshot name.
 .El
 .\" == SNAPSHOT ==
@@ -656,8 +680,8 @@ If a snapshot name is not specified, a name based on the current
 date and time is generated.
 .Pp
 Options:
-.Bl -tag -width "[-n | --name]"
-.It Op Fl n | -name
+.Bl -tag -width "[-n | --name TEXT]"
+.It Op Fl n | -name Ar TEXT
 The user created snapshot name.
 .El
 .\" == START ==
@@ -665,8 +689,10 @@ The user created snapshot name.
 Start a jail identified by
 .Ar UUID
 or
-.Ar TAG
-.  Use ALL to start all installed jails.
+.Ar TAG .
+Use
+.Op Ar ALL
+to start all installed jails instead.
 .Pp
 Options:
 .Bl -tag -width "[--rc]"
@@ -679,8 +705,10 @@ Jails with lower priority start first.
 Stop a jail identified by
 .Ar UUID
 or
-.Ar TAG
-.  Use ALL to stop all active jails.
+.Ar TAG .
+Use
+.Op Ar ALL
+to stop all active jails instead.
 .Pp
 Options:
 .Bl -tag -width "[--rc]"
@@ -690,17 +718,24 @@ Jails with higher priority values stop first.
 .El
 .\" == UPDATE ==
 .It Cm update
-Run
+Runs
 .Cm freebsd-update
 to update the specified jail to the latest patch level.
 A backup snapshot is automatically created to provide a rollback
 option.
 .\" == UPGRADE ==
 .It Cm upgrade
-Run
-.Cm freebsd-update to upgrade a jail RELEASE to the specified
-RELEASE.
+Runs
+.Cm freebsd-update
+to upgrade a jail RELEASE to the specified RELEASE.
 .Pp
+Options:
+.Bl -tag -width "[-r | --release RELEASE]"
+.It Op Fl r | -release Ar RELEASE
+[Required] RELEASE the jail uses for upgrading.
+.El
+.Pp
+Example:
 .Bl -item
 .It
 .Nm
@@ -708,12 +743,6 @@ set release=10.1-RELEASE UUID|TAG
 .El
 .Pp
 For this, the release must be locally available.
-.Pp
-Options:
-.Bl -tag -width "[-r | --release TEXT]"
-.It Op Fl r | -release
-[Required] RELEASE the jail uses for upgrading.
-.El
 .El
 .Sh PROPERTIES
 The Source listed with each property shows whether it is a local
@@ -760,8 +789,9 @@ interface.
 A netmask in either dotted-quad or CIDR form given after the IP
 address is used when adding the IP alias.
 .Pp
-The IP address is automatically assigned at the first start of the jail.
-This requires that the
+The IP address is automatically assigned at the first start of the
+jail.
+This requires the
 .Dv ip4_autostart
 and
 .Dv ip4_autoend
@@ -784,10 +814,11 @@ set ip4_autosubnet="24" default
 .Pp
 This results in the automatic IPv4 address being assigned in the base
 range of the default network interface.
-That is, if the local default NIC is set to 192.168.0.XXX, then the new
-address will be 192.168.0.[100-150]/24.
+That is, if the local default NIC is set to 192.168.0.XXX, then the
+new address will be 192.168.0.[100-150]/24.
 .Pp
-In VNET jails, the interface is configured with the IP addresses listed.
+In VNET jails, the interface is configured with the IP addresses
+listed.
 .Pp
 Example:
 .Bd -literal -offset indent
@@ -1142,11 +1173,12 @@ Default: 1
 Source:
 .Xr jail 8
 .It allow_sysvipc=0 | 1
-Set whether a process in the jail has access to System V IPC primitives.
+Set whether a process in the jail has access to System V IPC
+primitives.
 Prior to FreeBSD 11.0, System V primitives share a single namespace
 across the host and jail environments, meaning that processes within a
-jail would be able to communicate with, and potentially interfere with,
-processes outside of the jail, or in other jails.
+jail would be able to communicate with, and potentially interfere
+with, processes outside of the jail, or in other jails.
 In
 .Fx 11.0
 and later, this setting is deprecated.
@@ -1165,8 +1197,8 @@ When set to new, the jail has its own key namespace, and can only see
 the objects that it has created.
 The system or parent jail has access to the jail's objects, but not to
 its keys.
-When set to disable, the jail cannot perform any sysvmsg-related system
-calls.
+When set to disable, the jail cannot perform any sysvmsg-related
+system calls.
 Ignored in
 .Fx
 10.3 and earlier.
@@ -1405,10 +1437,11 @@ Currently, gzip is equivalent to gzip-6, which is also the default for
 .Pp
 The zle algorithm compresses runs of zeros.
 .Pp
-The lz4 algorithm is a high-performance replacement for the lzjb algorithm.
+The lz4 algorithm is a high-performance replacement for the lzjb
+algorithm.
 It features significantly faster compression and decompression, as well
-as a moderately higher compression ratio than lzjb, but can only be used
-on pools with the lz4_compress feature enabled.
+as a moderately higher compression ratio than lzjb, but can only be
+used on pools with the lz4_compress feature enabled.
 See
 .Xr zpool-features 7
 for details on ZFS feature flags and the lz4_compress feature.
@@ -1436,11 +1469,11 @@ Source:
 Quota for the jail.
 Limit the amount of space a dataset and its descendants can consume.
 This property enforces a hard limit on the amount of space used.
-This includes all space consumed by descendants, including file systems
-and snapshots.
+This includes all space consumed by descendants, including file
+systems and snapshots.
 Setting a quota on a descendent of a dataset that already has a quota
-does not override the ancestor's quota, but rather imposes an additional
-limit.
+does not override the ancestor's quota, but rather imposes an
+additional limit.
 .Pp
 Default: none
 .Pp
@@ -1459,8 +1492,8 @@ Compression ratio.
 Read-only.
 For non-snapshots, the compression ratio achieved for the used space
 of this dataset, expressed as a multiplier.
-The used property includes descendant datasets, and, for clones, does not
-include the space shared with the origin snapshot.
+The used property includes descendant datasets, and, for clones, does
+not include the space shared with the origin snapshot.
 .Pp
 Source:
 .Xr zfs 8
@@ -1468,9 +1501,9 @@ Source:
 Available space in the jail's dataset.
 The amount of space available to the dataset and all its children,
 assuming that there is no other activity in the pool.
-Because space is shared within a pool, availability can be limited by any
-number of factors, including physical pool size, quotas, reservations,
-or other datasets within the pool.
+Because space is shared within a pool, availability can be limited by
+any number of factors, including physical pool size, quotas,
+reservations, or other datasets within the pool.
 .Pp
 Source:
 .Xr zfs 8

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -106,8 +106,10 @@
 .Cm fstab
 .Ar JAIL
 .Ar FSTAB_STRING
+.Op Fl H | h | -header
 .Op Fl a | -add | Cm action
 .Op Fl e | -edit | Cm action
+.Op Fl l | -list
 .Op Fl r | -remove | Cm action
 .\" == GET ==
 .Nm
@@ -602,6 +604,9 @@ Name any options, then the jail, and finally all needed fstab strings.
 .Pp
 Options:
 .Bl -tag -width "[-r | --remove | action]"
+.It Op Fl H | h | -header
+For scripting.
+Use tabs for separators.
 .It Op Fl a | -add | Cm action
 Adds an entry to the specific jail's
 .Pa fstab
@@ -610,6 +615,8 @@ and mounts it.
 Opens the
 .Pa fstab
 file in the default editor.
+.It Op Fl l | -list
+List the jail's fstab.
 .It Op Fl r | -remove | Cm action
 Remove an entry from a specific jail's
 .Pa fstab

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -939,7 +939,7 @@ The Source listed with each property shows whether it is a local
 .Nm
 property or where more information can be located.
 .Bl -tag -width "pkglist=none"
-.It pkglist=none | path-to-file
+.It Pf pkglist= Op none | path-to-file
 A json file listing one package per entry.
 Packages are automatically installed when a jail is created.
 Works only in combination with the
@@ -949,10 +949,10 @@ subcommand.
 Default: none
 .Pp
 Source: local
-.It vnet=on | off
+.It Pf vnet= Op on | off
 Controls whether the jail is started with a VNET or a shared IP
 configuration.
-Set "on" if a fully virtualized per-jail network stack is required.
+Set to on if a fully virtualized per-jail network stack is required.
 .Pp
 Default: off
 .Pp
@@ -1022,7 +1022,7 @@ Default: none
 .Pp
 Source:
 .Xr jail 8
-.It ip4_saddrsel=1 | 0
+.It Pf ip4_saddrsel= Op 1 | 0
 Only applies when vnet=off.
 A boolean option to change the formerly mentioned behavior and
 disable IPv4 source address selection for the prison in favor of
@@ -1035,7 +1035,7 @@ Default: 1
 .Pp
 Source:
 .Xr jail 8
-.It ip4=new | disable | inherit
+.It Pf ip4= Op new | disable | inherit
 Only applies when vnet=off.
 Control the availability of IPv4 addresses.
 Possible values are "inherit" to allow unrestricted access to all
@@ -1047,13 +1047,13 @@ Default: new
 .Pp
 Source:
 .Xr jail 8
-.It defaultrouter=none | ipaddress
+.It Pf defaultrouter= Op none | ipaddress
 Setting this property to anything other than none configures a
 default route inside a VNET jail.
-.It defaultrouter6=none | ip6address
+.It Pf defaultrouter6= Op none | ip6address
 Setting this property to anything other than none configures a
 default IPv6 route inside a VNET jail.
-.It resolver=none | nameserver IP;nameserver IP;search domain.local
+.It Pf resolver= Op none | nameserver IP;nameserver IP;search domain.local
 Set the jail's resolver
 .Pq resolv.conf .
 Fields must be delimited with a semicolon.
@@ -1066,7 +1066,7 @@ file from the host.
 .It ip6.addr, ip6.saddrsel, ip6
 A set of IPv6 options for the prison, the counterparts to ip4.addr,
 ip4.saddrsel and ip4 above.
-.It interfaces=vnet0:bridge0,vnet1:bridge1 | vnet0:bridge0
+.It Pf interfaces= Op vnet0:bridge0,vnet1:bridge1 | vnet0:bridge0
 By default, there are two interfaces specified with their bridge
 association.
 Up to four interfaces are supported.
@@ -1092,14 +1092,14 @@ Default: UUID
 .Pp
 Source:
 .Xr jail 8
-.It exec_fib=0 | 1 ..
+.It Pf exec_fib= Op 0 | 1 ..
 The FIB (routing table) to set when running commands inside the jail.
 .Pp
 Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It devfs_ruleset=4 | 0 ..
+.It Pf devfs_ruleset= Op 4 | 0 ..
 The number of the devfs ruleset that is enforced for mounting
 devfs in this jail.
 A value of zero (default) means no ruleset is enforced.
@@ -1125,7 +1125,7 @@ Default: 4
 .Pp
 Source:
 .Xr jail 8
-.It mount_devfs=1 | 0
+.It Pf mount_devfs= Op 1 | 0
 Mount a
 .Xr devfs 5
 filesystem on the chrooted
@@ -1185,7 +1185,7 @@ and after any exec_start commands have completed.
 Default: /usr/bin/true
 .Pp
 Source: jail 8
-.It exec_clean=1 | 0
+.It Pf exec_clean= Op 1 | 0
 Run commands in a clean environment.
 The environment is discarded except for HOME, SHELL, TERM and USER.
 HOME and SHELL are set to the target login's default values.
@@ -1198,7 +1198,7 @@ Default: 1
 .Pp
 Source:
 .Xr jail 8
-.It exec_timeout=60 | 30 ..
+.It Pf exec_timeout= Op 60 | 30 ..
 The maximum amount of time to wait for a command to complete.
 If a command is still running after this many seconds have passed,
 the jail will be terminated.
@@ -1207,7 +1207,7 @@ Default: 60
 .Pp
 Source:
 .Xr jail 8
-.It stop_timeout=30 | 60 ..
+.It Pf stop_timeout= Op 30 | 60 ..
 The maximum amount of time to wait for a jail's processes to
 exit after sending them a SIGTERM signal.
 This happens after the exec_stop commands have completed.
@@ -1220,14 +1220,14 @@ Default: 30
 .Pp
 Source:
 .Xr jail 8
-.It exec_jail_user=root
+.It Pf exec_jail_user= Op root | username
 In the jail environment, commands are run as this user.
 .Pp
 Default: root
 .Pp
 Source:
 .Xr jail 8
-.It exec_system_jail_user=0 | 1
+.It Pf exec_system_jail_user= Op 0 | 1
 This boolean option looks for the
 .Dv exec_jail_user
 in the system
@@ -1238,7 +1238,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It exec_system_user=root
+.It Pf exec_system_user= Op root | username
 Run commands as this user in the system environment.
 The default is to run commands as the current user.
 .Pp
@@ -1246,7 +1246,7 @@ Default: root
 .Pp
 Source:
 .Xr jail 8
-.It mount_fdescfs=1 | 0
+.It Pf mount_fdescfs= Op 1 | 0
 Mount a
 .Xr fdescfs 5
 filesystem in the jail's
@@ -1259,7 +1259,7 @@ Default: 1
 .Pp
 Source:
 .Xr jail 8
-.It mount_procfs=0 | 1
+.It Pf mount_procfs= Op 0 | 1
 Mount a
 .Xr procfs 5
 filesystem in the jail's
@@ -1269,7 +1269,7 @@ directory.
 Default: 0
 .Pp
 Source: local
-.It enforce_statfs=2 | 1 | 0
+.It Pf enforce_statfs= Op 2 | 1 | 0
 Determine which information processes in a jail are able to obtain
 about mount points.
 The behavior of these syscalls is affected:
@@ -1291,7 +1291,7 @@ mountpoint where the jail's chroot directory is located.
 Default: 2
 Source:
 .Xr jail 8
-.It children_max=0 | ..
+.It Pf children_max= Op 0 | ..
 The number of child jails allowed to be created by this jail (or
 by other jails under this jail).
 This limit is zero by default, indicating the jail is not allowed to
@@ -1312,7 +1312,7 @@ Default: -f root
 .Pp
 Source:
 .Xr login 1
-.It jail_zfs=on | off
+.It Pf jail_zfs= Op on | off
 Enable automatic ZFS jailing inside the jail.
 The assigned ZFS dataset is fully controlled by the jail.
 .Pp
@@ -1323,7 +1323,7 @@ These are dependent options required for ZFS management inside a jail.
 Default: off
 .Pp
 Source: local
-.It jail_zfs_dataset=iocage/jails/UUID/root/data | zfs_filesystem
+.It Pf jail_zfs_dataset= Op iocage/jails/UUID/root/data | zfs_filesystem
 The dataset to be jailed and fully handed over to a jail.
 Takes the ZFS filesystem name without pool name.
 .Pp
@@ -1339,7 +1339,7 @@ mount -a
 Default: iocage/jails/UUID/root/data
 .Pp
 Source: local
-.It securelevel=3 | 2 | 1 | 0 | -1
+.It Pf securelevel= Op 3 | 2 | 1 | 0 | -1
 The value of the jail's kern.securelevel sysctl.
 A jail never has a lower securelevel than the default system, but by
 setting this parameter it is allowed to have a higher one.
@@ -1350,7 +1350,7 @@ Default: 2
 .Pp
 Source:
 .Xr jail 8
-.It allow_set_hostname=1 | 0
+.It Pf allow_set_hostname= Op 1 | 0
 Allow the jail's hostname to be changed with
 .Xr hostname 1
 or
@@ -1360,7 +1360,7 @@ Default: 1
 .Pp
 Source:
 .Xr jail 8
-.It allow_sysvipc=0 | 1
+.It Pf allow_sysvipc= Op 0 | 1
 Set whether a process in the jail has access to System V IPC
 primitives.
 Prior to FreeBSD 11.0, System V primitives share a single namespace
@@ -1376,7 +1376,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It sysvmsg=disable | inherit | new
+.It Pf sysvmsg= Op disable | inherit | new
 Allow access to SYSV IPC message primitives.
 When set to inherit, all IPC objects on the system are visible to this
 jail, whether they were created by the jail itself, the base system,
@@ -1395,7 +1395,7 @@ Default: disable
 .Pp
 Source:
 .Xr jail 8
-.It sysvsem=disable | inherit | new
+.It Pf sysvsem= Op disable | inherit | new
 Allow access to SYSV IPC semaphore primitives in the same manner as
 sysvmsg.
 Ignored in
@@ -1406,7 +1406,7 @@ Default: disable
 .Pp
 Source:
 .Xr jail 8
-.It sysvshm=disable | inherit | new
+.It Pf sysvshm= Op disable | inherit | new
 Allow access to SYSV IPC shared memory primitives in the same manner
 as sysvmsg.
 Ignored in
@@ -1416,7 +1416,7 @@ and earlier.
 Default: disable
 Source:
 .Xr jail 8
-.It allow_raw_sockets=0 | 1
+.It Pf allow_raw_sockets= Op 0 | 1
 The prison root is allowed to create raw sockets.
 Setting this parameter allows utilities like
 .Xr ping 8
@@ -1434,7 +1434,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_chflags=0 | 1
+.It Pf allow_chflags= Op 0 | 1
 Normally, privileged users inside a jail are treated as unprivileged
 by
 .Xr chflags 2 .
@@ -1446,7 +1446,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_mount=0 | 1
+.It Pf allow_mount= Op 0 | 1
 Allow privileged users inside the jail to mount and unmount filesystem
 types marked as jail-friendly.
 The
@@ -1460,7 +1460,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_mount_devfs=0 | 1
+.It Pf allow_mount_devfs= Op 0 | 1
 Allow privileged users inside the jail to mount and unmount the devfs
 file system.
 This permission is effective only together with allow.mount and if
@@ -1472,7 +1472,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_mount_nullfs=0 | 1
+.It Pf allow_mount_nullfs= Op 0 | 1
 Allow privileged users inside the jail to mount and unmount the nullfs
 file system.
 This permission is effective only together with allow_mount and if
@@ -1482,7 +1482,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_mount_procfs=0 | 1
+.It Pf allow_mount_procfs= Op 0 | 1
 Allow privileged users inside the jail to mount and unmount the procfs
 file system.
 This permission is effective only together with allow.mount and if
@@ -1492,7 +1492,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_mount_tmpfs=0 | 1
+.It Pf allow_mount_tmpfs= Op 0 | 1
 Allow privileged users inside the jail to mount and unmount the tmpfs
 file system.
 This permission is effective only together with allow.mount and if
@@ -1504,7 +1504,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_mount_zfs=0 | 1
+.It Pf allow_mount_zfs= Op 0 | 1
 Allow privileged users inside the jail to mount and unmount the ZFS
 filesystem.
 This permission is effective only together with allow.mount and if
@@ -1519,7 +1519,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_quotas=0 | 1
+.It Pf allow_quotas= Op 0 | 1
 The jail root can administer quotas on the jail's filesystems.
 This includes filesystems that the jail might share with other jails
 or with non-jailed parts of the system.
@@ -1528,7 +1528,7 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
-.It allow_socket_af=0 | 1
+.It Pf allow_socket_af= Op 0 | 1
 Sockets within a jail are normally restricted to IPv4, IPv6, local
 (UNIX), and route.
 This setting allows access to other protocol stacks that have not had
@@ -1549,7 +1549,7 @@ Custom string for aliasing jails.
 Default: date@time
 .Pp
 Source: local
-.It template=yes | no
+.It Pf template= Op yes | no
 This property controls whether the jail is a template.
 Templates are not started by iocage.
 Set to yes if this jail will be converted into a template.
@@ -1558,7 +1558,7 @@ See the EXAMPLES section below.
 Default: no
 .Pp
 Source: local
-.It boot=on | off
+.It Pf boot= Op on | off
 If set to "on", the jail is auto-started at boot time with
 .Cm start --rc
 and stopped at shutdown time with
@@ -1581,7 +1581,7 @@ Can be any string.
 Default: root
 .Pp
 Source: local
-.It priority=99 | 50 ..
+.It Pf priority= Op 99 | 50 ..
 Start priority at boot time.
 Smaller values mean higher priority.
 For shutdown, the order is reversed.
@@ -1596,20 +1596,20 @@ Automatically set every time the jail starts.
 Default: timestamp
 .Pp
 Source: local
-.It type=basejail,empty,normal
+.It Pf type= Op basejail | empty | normal
 Set the jail type to basejail, empty or normal.
 .Pp
 Default: normal
 .Pp
 Source: local
-.It release=10.0-RELEASE | 9.2-RELEASE
+.It Pf release= Op 11.0-RELEASE | 10.3-RELEASE
 The release used at creation time.
 Can be set to any string if needed.
 .Pp
 Default: the host's release
 .Pp
 Source: local
-.It compression=on | off | lzjb | gzip | gzip-N | zle | lz4
+.It Pf compression= Op on | off | lzjb | gzip | gzip-N | zle | lz4
 Controls the compression algorithm used for this dataset.
 The lzjb compression algorithm is optimized for performance while
 providing decent data compression.
@@ -1627,9 +1627,9 @@ The zle algorithm compresses runs of zeros.
 .Pp
 The lz4 algorithm is a high-performance replacement for the lzjb
 algorithm.
-It features significantly faster compression and decompression, as well
-as a moderately higher compression ratio than lzjb, but can only be
-used on pools with the lz4_compress feature enabled.
+It features significantly faster compression and decompression and a
+moderately higher compression ratio than lzjb, but can only be used on
+pools with the lz4_compress feature enabled.
 See
 .Xr zpool-features 7
 for details on ZFS feature flags and the lz4_compress feature.
@@ -1653,7 +1653,7 @@ Default: -
 .Pp
 Source:
 .Xr zfs 8
-.It quota=15G | 50G | ..
+.It Pf quota= Op 15G | 50G | ..
 Quota for the jail.
 Limit the amount of space a dataset and its descendants can consume.
 This property enforces a hard limit on the amount of space used.
@@ -1701,14 +1701,14 @@ Read-only.
 .Pp
 Source:
 .Xr zfs 8
-.It dedup=on | off | verify | sha256[,verify]
+.It Pf dedup= Op on | off | verify | sha256[,verify]
 Deduplication for jail.
 .Pp
 Default: off
 .Pp
 Source:
 .Xr zfs 8
-.It reservation=size | none
+.It Pf reservation= Op size | none
 Reserved space for jail.
 .Pp
 Default: none
@@ -1719,7 +1719,7 @@ Source:
 This is for future use, currently not supported.
 .It sync_tgt_zpool
 For future use, currently not supported.
-.It cpuset=1 | 1,2,3,4 | 1-2 | off
+.It Pf cpuset= Op 1 | 1,2,3,4 | 1-2 | off
 .Pp
 Control the jail's CPU affinity.
 .Pp

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -65,7 +65,7 @@
 .Cm df
 .Op Fl H | h | -header
 .Op Fl l | -long | Cm _long
-.Op Fl s | -sort | Cm _sort
+.Op Fl s | -sort | Cm _sort Ar TEXT
 .\" == EXEC ==
 .Nm
 .Cm exec

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -164,6 +164,7 @@
 .Nm
 .Cm snaplist
 .Op Fl H | h | -header
+.Op Fl l | -long | Cm _long
 .Op Ar UUID | TAG
 .\" == SNAPREMOVE ==
 .Nm

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -952,11 +952,9 @@ Source: local
 .It vnet=on | off
 Controls whether the jail is started with a VNET or a shared IP
 configuration.
-The default is to auto-guess from a sysctl.
-If a fully virtualized per-jail network stack is not needed, set this
-to off.
+Set "on" if a fully virtualized per-jail network stack is required.
 .Pp
-Default: auto-guess
+Default: off
 .Pp
 Source: local
 .It ip4_addr="interface|ip-address/netmask"

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -43,16 +43,16 @@
 .Nm
 .Cm create
 .Op Fl b | -basejail
-.Op Fl c | -count
+.Op Fl c | -count Ar TEXT
 .Op Fl e | -empty
 .Op Fl f | -force
 .Op Fl n | -name
-.Op Fl p | -pkglist
-.Op Fl r | -release
+.Op Fl p | -pkglist Ar TEXT
+.Op Fl r | -release Ar TEXT
 .Op Fl s | -short
-.Op Fl t | -template
-.Op Fl u | -uuid | Cm _uuid
-.Ar PROPERTIES
+.Op Fl t | -template Ar TEXT
+.Op Fl u | -uuid | Cm _uuid Ar TEXT
+.Op Ar PROPERTIES
 .\" == DESTROY ==
 .Nm
 .Cm destroy
@@ -319,7 +319,7 @@ Options:
 .Bl -tag -width "[-b | --basejail]"
 .It Op Fl b | -basejail
 Create a new "basejail" with a common shared base.
-.It Op Fl c | -count
+.It Op Fl c | -count Ar TEXT
 Clone the jail from the current host's release, as determined by the
 .Fl r
 option.
@@ -329,14 +329,14 @@ Create an empty jail for unsupported or custom jails.
 Skip prompts, auto-confirming them with yes.
 .It Op Fl n | -name
 Provide a name and tag instead of a UUID for the new jail.
-.It Op Fl p | -pkglist
-.It Op Fl r | -release
+.It Op Fl p | -pkglist Ar TEXT
+.It Op Fl r | -release Ar TEXT
 Specify which release to use for the new jail.
 .It Op Fl s | -short
 Use a short UUID of 8 characters instead of the default 36.
-.It Op Fl t | -template
+.It Op Fl t | -template Ar TEXT
 Create a template style jail.
-.It Op Fl u | -uuid
+.It Op Fl u | -uuid Ar TEXT
 Specify a desired UUID for the new jail.
 .El
 .Pp

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -979,34 +979,6 @@ interface.
 A netmask in either dotted-quad or CIDR form given after the IP
 address is used when adding the IP alias.
 .Pp
-The IP address is automatically assigned at the first start of the
-jail.
-This requires the
-.Dv ip4_autostart
-and
-.Dv ip4_autoend
-variables are set on the "default" property source.
-If used, the IP4 address is set to the first available based upon the
-given range and existing jails.
-.Pp
-Example:
-.Bd -literal -offset indent
-.Pp
-.Nm
-set ip4_autostart="100" default
-.Pp
-.Nm
-set ip4_autoend="150" default
-.Pp
-.Nm
-set ip4_autosubnet="24" default
-.Ed
-.Pp
-This results in the automatic IPv4 address being assigned in the base
-range of the default network interface.
-That is, if the local default NIC is set to 192.168.0.XXX, then the
-new address will be 192.168.0.[100-150]/24.
-.Pp
 In VNET jails, the interface is configured with the IP addresses
 listed.
 .Pp

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -161,7 +161,7 @@
 .\" == SET ==
 .Nm
 .Cm set
-.Ar PROPERTY
+.Ar PROPERTY Op ...
 .Ar UUID | NAME
 .Op Fl P | -plugin Ar KEY
 .\" == SNAPLIST ==
@@ -785,8 +785,9 @@ Example:
 .Pp
 .\" == SET ==
 .It Cm set
-Set the specified property in the desired jail.
-Type the desired property first, then the jail to which it applies.
+Set the specified properties in the desired jail.
+Type the desired properties separated by a space, then the jail
+UUID or NAME to apply the changes.
 .Pp
 Options:
 .Bl -tag -width "[-P | --plugin]"
@@ -797,7 +798,7 @@ If accessing a nested key, use "." as a separator.
 .Pp
 Examples:
 .Pp
-.Dl # iocage set -P foo.bar.baz=VALUE PLUGIN
+.Dl # iocage set boot=on notes="Example note." testjail -P foo.bar.baz=VALUE PLUGIN
 .Pp
 .\" == SNAPLIST ==
 .It Cm snaplist

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -375,7 +375,7 @@ Skip prompts, auto-confirming them with yes.
 .It Op Fl s | -short
 Use a short UUID of 8 characters instead of the default 36.
 .It Op Fl t | -template Ar TEXT
-Create a template style jail.
+Create a jail from the specified template.
 .It Op Fl u | -uuid Ar TEXT
 Specify a desired UUID for the new jail.
 .El

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -1041,9 +1041,9 @@ Source:
 Only applies when vnet=off.
 Control the availability of IPv4 addresses.
 Possible values are "inherit" to allow unrestricted access to all
-system addresses, "new" to restrict addresses via ip4.addr above,
+system addresses, "new" to restrict addresses via ip4_addr above,
 and "disable" to stop the jail from using IPv4 entirely.
-Setting the ip4.addr parameter implies a value of "new".
+Setting the ip4_addr parameter implies a value of "new".
 .Pp
 Default: new
 .Pp
@@ -1065,9 +1065,9 @@ Semicolons are translated to newlines in
 If the resolver is set to none (default) the jail inherits the
 .Pa resolv.conf
 file from the host.
-.It ip6.addr, ip6.saddrsel, ip6
-A set of IPv6 options for the prison, the counterparts to ip4.addr,
-ip4.saddrsel and ip4 above.
+.It ip6_addr, ip6_saddrsel, ip6
+A set of IPv6 options for the prison, the counterparts to ip4_addr,
+ip4_saddrsel and ip4 above.
 .It Pf interfaces= Op vnet0:bridge0,vnet1:bridge1 | vnet0:bridge0
 By default, there are two interfaces specified with their bridge
 association.

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -208,8 +208,8 @@ Both shared IP jails and VNET jails are supported.
 .Pp
 Each jail has a unique ID (UUID) which is automatically generated at
 creation time.
-Using the UUID as a jail identifier makes it possible to replicate a
-jail in a distributed environment with greater flexibility.
+Using the UUID as a jail identifier is more flexible when replicating
+a jail in a distributed environment.
 This also eliminates potential naming clashes on large scale
 deployments and helps reduce operator error.
 .Pp
@@ -358,7 +358,7 @@ nullfs mount over the jail's directories.
 .It Op Fl c | -count Ar TEXT
 Designate the number of jails to create, all cloned from
 the desired
-.Op Fl r Ar RELEASE . 
+.Op Fl r Ar RELEASE .
 .It Op Fl e | -empty
 Create an empty jail for unsupported or custom jails.
 .It Op Fl f | -force
@@ -790,6 +790,7 @@ Options:
 .It Op Fl P | -plugin Ar KEY
 Set the specified key for a plugin jail.
 If accessing a nested key, use "." as a separator.
+.El
 .Pp
 Examples:
 .Pp
@@ -1762,17 +1763,17 @@ List templates:
 iocage list -t
 .Ed
 .Pp
-Import package on another host
+Import package on another host:
 .Bd -literal -offset indent
 iocage import UUID
 .Ed
 .Sh HINTS
-When using VNET, remember to add the node's physical NIC into one
-of the bridges if an outside connection is needed.
+When using VNET and an outside connection is needed, add the node's
+physical NIC into one of the bridges.
 Also see
 .Xr bridge 4
 for how traffic is handled.
-In a nutshell: bridges behave like a network switch.
+Basically, bridges behave like a network switch.
 .Pp
 The PF firewall is not supported inside VNET jails as of July 2014.
 PF can be enabled for the host.
@@ -1799,8 +1800,9 @@ net.link.bridge.pfil_bridge=0
 net.link.bridge.pfil_member=0
 .Ed
 .Pp
-For more information, please see
+See
 .Lk https://github.com/iocage/iocage
+for more information.
 .Sh SEE ALSO
 .Xr cpuset 1 ,
 .Xr bridge 4 ,
@@ -1812,9 +1814,10 @@ For more information, please see
 .Xr rctl 8 ,
 .Xr sysctl 8 ,
 .Xr zfs 8 ,
-.Xr zpool 8
+.Xr zpool 8 ,
+.Xr VNET 9
 .Sh BUGS
-Please report bugs, issues, and feature requests at
+Please report bugs, issues, and feature requests to
 .Lk https://github.com/iocage/iocage/issues
 .Sh AUTHORS
 .Nm

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -414,7 +414,9 @@ Destroy a specified RELEASE dataset.
 .Pp
 Examples:
 .Pp
-.Dl # iocage destroy 12345678
+.Dl # iocage destroy 12345678 -f
+.Pp
+Destroy the identified jail with no further input.
 .Pp
 .Dl # iocage destroy -r 10.1-RELEASE
 .Pp
@@ -450,9 +452,16 @@ Options:
 Use when scripting, using tabs for separators.
 .It Op Fl l | -long | Cm _long
 Shows the full UUID.
-.It Op Fl s | -s | Cm _long Ar TEXT
+.It Op Fl s | -sort | Cm _sort Ar TEXT
 Sorts the list by the named type.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage df -l
+.Pp
+Displays the usage table with the full UUID of each jail.
+.Pp
 .\" == EXEC ==
 .It Cm exec
 Execute a command inside the specified jail.
@@ -472,6 +481,23 @@ Specifies which jail user runs the command.
 .It Op Fl u | -host_user Ar NAME
 Specify which host user runs the command.
 .El
+.Pp
+Examples:
+.Pp
+.Dl # iocage exec examplejail_1 ls /tmp
+.Pp
+Lists the contents of the examplejail_1's
+.Pa /tmp
+directory.
+.Pp
+.Dl # iocage exec examplejail_1 "cat COPYRIGHT" | less
+.Pp
+In this example, examplejail_1 executes
+.Cm cat COPYRIGHT ,
+while the output is run with
+.Cm less
+outside the jail on the primary system.
+.Pp
 .\" == EXPORT ==
 .It Cm export
 Exports the specified jail.
@@ -479,6 +505,11 @@ An archive file is created in
 .Pa /iocage/images
 with an SHA256 checksum.
 The jail must be stopped before exporting.
+.Pp
+Example:
+.Pp
+.Dl # iocage export examplejail_2
+.Pp
 .\" == FETCH ==
 .It Cm fetch
 Downloads and/or updates releases.
@@ -577,8 +608,15 @@ Opens the
 .Pa fstab
 file in the default editor.
 .It Op Fl r | -remove | Cm action
-Remove an entry from a specific jail's fstab and unmounts it.
+Remove an entry from a specific jail's
+.Pa fstab
+and unmounts it.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage fstab -e examplejail_1
+.Pp
 .\" == GET ==
 .It Cm get
 Display the specified property.
@@ -599,11 +637,34 @@ Get the currently activated zpool.
 .It Op Fl r | -recursive
 Get the specified property for all jails.
 .El
+.Pp
+Examples:
+.Pp
+.Dl # iocage get -p
+.Pp
+Outputs the name of the activated zpool.
+.Pp
+.Dl # iocage get -a examplejail_1 | less
+.Pp
+List all properties of examplejail_1 and send the output
+through
+.Cm less .
+.Pp
+.Dl # iocage get -r dhcp
+.Pp
+Displays a table with each jail's UUID, TAG, and the
+status of the requested property.
+.Pp
 .\" == IMPORT ==
 .It Cm import
 Import a specific jail image.
 Short UUIDs can be used, but do not specify the full filename, only
 the UUID.
+.Pp
+Example:
+.Pp
+.Dl # iocage import 064c247
+.Pp
 .\" == LIST ==
 .It Cm list
 List the specified dataset type.
@@ -631,6 +692,29 @@ Sorts the list by the given type.
 .It Op Fl t | -template | Cm dataset_type
 Lists all templates.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage list
+.Pp
+Displays a table containing several elements for
+each installed jail:
+.Bl -tag -width "release"
+.It JID
+Jail identifier
+.It UUID
+Unique identifcation number.
+.It STATE
+Displays the active state of the jail.
+Can be up or down.
+.It TAG
+The user added tag value.
+.It RELEASE
+The jail's FreeBSD RELEASE.
+.It IP4
+Shows the availability of IP4 addresses.
+.El
+.Pp
 .\" == MIGRATE ==
 .It Cm migrate
 Migrate from the development version of iocage-legacy to the current
@@ -643,12 +727,21 @@ Destroy the old dataset after migration.
 .It Op Fl f | -force
 Bypass any further warning or required user interaction.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage migrate -d -f
+.Pp
+Migrates to the new jail format and deletes the old dataset with
+no further user interaction.
+.Pp
 .\" == PKG ==
 .It Cm pkg
 Run desired
 .Cm pkg
 commands in the specified jail.
 List the jail's UUID or TAG, then any desired commands.
+.Pp
 .\" == RESTART ==
 .It Cm restart
 Restart the specified jail, OR use ALL to restart all jails.
@@ -658,6 +751,13 @@ Options:
 .It Op Fl s | -soft
 Restart the jail, but do not tear down the network stack.
 .El
+.Pp
+Examples:
+.Pp
+.Dl # iocage restart ALL
+.Pp
+.Dl # iocage restart --soft examplejail1
+.Pp
 .\" == ROLLBACK ==
 .It Cm rollback
 Roll back a jail to an existing snapshot.
@@ -672,6 +772,11 @@ Run the command, skipping any warnings or further user interaction.
 .It Fl n | -name
 [Required] Used to specify the snapshot name.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage rollback -n snapshottest2 examplejail1
+.Pp
 .\" == SET ==
 .It Cm set
 Set the specified property in the desired jail.
@@ -682,14 +787,13 @@ Options:
 .It Op Fl P | -plugin Ar KEY
 Set the specified key for a plugin jail.
 If accessing a nested key, use "." as a separator.
-.El
 .Pp
-Example:
-.Bl -item
-.It
-.Nm
-set -P foo.bar.baz=VALUE PLUGIN
-.El
+Examples:
+.Pp
+.Dl # iocage set -P foo.bar.baz=VALUE PLUGIN
+.Pp
+.Dl # iocage set tag=examplejail1 b1ebda86
+.Pp
 .\" == SNAPLIST ==
 .It Cm snaplist
 List snapshots of a jail.
@@ -714,6 +818,11 @@ Tabs are used as separators.
 .It Op Fl l | -long | Cm _long
 Show the full dataset path for the snapshot.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage snaplist examplejail1
+.Pp
 .\" == SNAPREMOVE ==
 .It Cm snapremove
 Delete snapshots of the specified jail.
@@ -726,6 +835,11 @@ Options:
 .It Op Fl n | -name Ar TEXT
 [Required] The snapshot name.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage snapremove -n snapshottest1 examplejail1
+.Pp
 .\" == SNAPSHOT ==
 .It Cm snapshot
 Create a ZFS snapshot of the specified jail.
@@ -737,6 +851,11 @@ Options:
 .It Op Fl n | -name Ar TEXT
 The user created snapshot name.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage snapshot examplejail1 -n snapshottest1
+.Pp
 .\" == START ==
 .It Cm start
 Start a jail identified by
@@ -753,6 +872,11 @@ Options:
 Start all jails with boot=on in a specific order.
 Jails with lower priority start first.
 .El
+.Pp
+Example:
+.Pp
+.Dl # iocage start examplejail1
+.Pp
 .\" == STOP ==
 .It Cm stop
 Stop a jail identified by
@@ -783,6 +907,11 @@ Runs
 to update the specified jail to the latest patch level.
 A backup snapshot is automatically created to provide a rollback
 option.
+.Pp
+Example:
+.Pp
+.Dl # iocage update examplejail1
+.Pp
 .\" == UPGRADE ==
 .It Cm upgrade
 Runs
@@ -796,14 +925,11 @@ Options:
 .El
 .Pp
 Example:
-.Bl -item
-.It
-.Nm
-set release=10.1-RELEASE UUID|TAG
-.El
 .Pp
-For this, the release must be locally available.
-.El
+.Dl # iocage upgrade examplejail2 -r 11.0-RELEASE
+.Pp
+To upgrade, the release must be locally available.
+.Pp
 .Sh PROPERTIES
 The Source listed with each property shows whether it is a local
 .Nm

--- a/iocage/iocage.8
+++ b/iocage/iocage.8
@@ -276,6 +276,11 @@ The pool can be activated for
 .Nm
 jails without requiring user input.
 By default, all other pools are deactivated.
+.Pp
+Example:
+.Pp
+.Dl # iocage activate examplezpool
+.Pp
 .\" == CHROOT ==
 .It Cm chroot
 Chroot into a jail without actually starting the jail itself.
@@ -283,6 +288,11 @@ Useful for initial setup like setting a root password or configuring
 networking.
 A command can be specified as with the normal system, see
 .Xr chroot 8 .
+.Pp
+Example:
+.Pp
+.Dl # iocage chroot examplejail ls /home
+.Pp
 .\" == CLEAN ==
 .It Cm clean
 Destroy ZFS datasets.


### PR DESCRIPTION
- Added Warren Block and Tim Moore to the author list.
First pass SYNOPSIS review
- Added missing "clone" command.
- "console": remove --force flag.
- "create": add --name flag, remove obsolete commands.
- "df": Add _long, add --sort flags.
- "exec": remove ALL  argument.
- "fetch": add _file, --name, --accept, --noaccept, remove obsolete optional commands.
- "fstab": add ACTION arguments to flags, rework lines.
- "get": rework lines, add _all, add _pool
- "import": remove Jail_value line
- "list": add dataset_type arguments, add --sort flags, add _long flag
- "pkg": remove JAIL arg, replace with UUID | TAG
- "rollback": move jail argument, remove obsolete argument.
- "set": rework  arguments
- "snapremove": rework arguments
- "snapshot": rework argument
- General reworks are based on the .py files.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
