### PR TITLE
remove 0x prefix from second mac address

### DIFF
--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -580,7 +580,7 @@ class IOCStart(object):
 
     def __generate_mac_address_pair(self, nic):
         mac_a = self.__generate_mac_bytes(nic)
-        mac_b = hex(int(mac_a, 16) + 1)
+        mac_b = hex(int(mac_a, 16) + 1)[2:]
         return mac_a, mac_b
 
     def __start_generate_vnet_mac__(self, nic):


### PR DESCRIPTION
Fixes a bug introduced with https://github.com/iocage/iocage/pull/199

The second mac address was calculated from the first one. The output string was then prefixed with `0x` which prevented the jail from obtaining the right mac address.