### PR TITLE
Fix mac_b address construction

### DIFF
--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -580,7 +580,7 @@ class IOCStart(object):
 
     def __generate_mac_address_pair(self, nic):
         mac_a = self.__generate_mac_bytes(nic)
-        mac_b = hex(int(mac_a, 16) + 1)[2:]
+        mac_b = hex(int(mac_a, 16) + 1)[2:].zfill(12)
         return mac_a, mac_b
 
     def __start_generate_vnet_mac__(self, nic):


### PR DESCRIPTION
mac_b seems to be invalid as its prefix is `2f:f6`. Due to a missing leading zero it's not a valid _invidiual_ and _local_ MAC. Don't know if `zfill` is a python best practice. I looked it up in former iocage code. :smile: