### PR TITLE
enable/disable rtsold when setting ip6_addr

### DIFF
--- a/iocage/lib/ioc_common.py
+++ b/iocage/lib/ioc_common.py
@@ -500,3 +500,44 @@ def git_pull(repo, remote_name="origin", branch="master"):
                 repo.state_cleanup()
             else:
                 raise AssertionError("Unknown merge analysis result")
+
+
+def set_rcconf(jail_path, key, value):
+
+    conf_file = f"{jail_path}/root/etc/rc.conf"
+
+    found = False
+    changed = False
+
+    with open(conf_file, "r+") as f:
+
+        output = []
+
+        lines = f.read().splitlines()
+        for line in lines:
+
+            try:
+                current_key, current_value = line.split("=", 1)
+                current_value = current_value.strip("\"")
+            except ValueError:
+                output.append(line)
+                continue
+
+            if current_key == key:
+                found = True
+
+                if current_value != value:
+                    changed = True
+                    output.append(f"{key}=\"{value}\"")
+                    continue
+
+            output.append(line)
+
+        if not found:
+            output.append(f"{key}=\"{value}\"")
+            changed = True
+
+        if changed:
+            f.seek(0)
+            f.write("\n".join(output) + "\n")
+            f.truncate()

--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -959,6 +959,47 @@ class IOCage(object):
             _callback=self.callback,
             silent=self.silent)
 
+    def __set_rcconf(self, key, value):
+
+        tag, uuid, path = self.__check_jail_existence__()
+        conf_file = f"{self.iocroot}/jails/{uuid}/root/etc/rc.conf"
+
+        found = False
+        changed = False
+
+        with open(conf_file, "r+") as f:
+
+            output = []
+
+            lines = f.read().splitlines()
+            for line in lines:
+
+                try:
+                    current_key, current_value = line.split("=", 1)
+                    current_value = current_value.strip("\"")
+                except ValueError:
+                    output.append(line)
+                    continue
+
+                if current_key == key:
+                    found = True
+
+                    if current_value != value:
+                        changed = True
+                        output.append(f"{key}=\"{value}\"")
+                        continue
+
+                output.append(line)
+
+            if not found:
+                output.append(f"{key}=\"{value}\"")
+                changed = True
+
+            if changed:
+                f.seek(0)
+                f.write("\n".join(output) + "\n")
+                f.truncate()
+
     def set(self, prop, plugin=False):
         """Sets a property for a jail or plugin"""
         prop = " ".join(prop)  # We don't want a tuple.
@@ -972,11 +1013,13 @@ class IOCage(object):
         if "template=no" in prop:
             self.jail = f"{self.jail} (template)"
 
+        key, value = prop.split("=", 1)
+
         if not default:
             tag, uuid, path = self.__check_jail_existence__()
             iocjson = ioc_json.IOCJson(path, cli=True)
 
-            if "template" in prop.split("=")[0]:
+            if "template" in key:
                 if "templates/" in path and prop != "template=no":
                     ioc_common.logit({
                         "level"  : "EXCEPTION",
@@ -1011,6 +1054,11 @@ class IOCage(object):
                     },
                         _callback=self.callback,
                         silent=self.silent)
+
+            if key == "ip6_addr":
+                rtsold_enable = "YES" if ("accept_rtadv" in value) else "NO"
+                self.__set_rcconf("rtsold_enable", rtsold_enable)
+
         else:
             ioc_json.IOCJson(self.iocroot).json_set_value(prop, default=True)
 

--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -959,47 +959,6 @@ class IOCage(object):
             _callback=self.callback,
             silent=self.silent)
 
-    def __set_rcconf(self, key, value):
-
-        tag, uuid, path = self.__check_jail_existence__()
-        conf_file = f"{self.iocroot}/jails/{uuid}/root/etc/rc.conf"
-
-        found = False
-        changed = False
-
-        with open(conf_file, "r+") as f:
-
-            output = []
-
-            lines = f.read().splitlines()
-            for line in lines:
-
-                try:
-                    current_key, current_value = line.split("=", 1)
-                    current_value = current_value.strip("\"")
-                except ValueError:
-                    output.append(line)
-                    continue
-
-                if current_key == key:
-                    found = True
-
-                    if current_value != value:
-                        changed = True
-                        output.append(f"{key}=\"{value}\"")
-                        continue
-
-                output.append(line)
-
-            if not found:
-                output.append(f"{key}=\"{value}\"")
-                changed = True
-
-            if changed:
-                f.seek(0)
-                f.write("\n".join(output) + "\n")
-                f.truncate()
-
     def set(self, prop, plugin=False):
         """Sets a property for a jail or plugin"""
         prop = " ".join(prop)  # We don't want a tuple.
@@ -1057,7 +1016,7 @@ class IOCage(object):
 
             if key == "ip6_addr":
                 rtsold_enable = "YES" if ("accept_rtadv" in value) else "NO"
-                self.__set_rcconf("rtsold_enable", rtsold_enable)
+                ioc_common.set_rcconf(path, "rtsold_enable", rtsold_enable)
 
         else:
             ioc_json.IOCJson(self.iocroot).json_set_value(prop, default=True)

--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -1015,7 +1015,7 @@ class IOCage(object):
                         silent=self.silent)
 
             if key == "ip6_addr":
-                rtsold_enable = "YES" if ("accept_rtadv" in value) else "NO"
+                rtsold_enable = "YES" if "accept_rtadv" in value else "NO"
                 ioc_common.set_rcconf(path, "rtsold_enable", rtsold_enable)
 
         else:


### PR DESCRIPTION
implements #236 

The jail's `/etc/rc.conf` is altered when the property `ip6_addr` is set (e.g. `iocage set ip6_addr=...`). 

- set `rtsold_enable="YES"` when the string `accept_rtadv` was found in the propery value
- set `rtsold_enable="NO"` when the string was not found