### PR TITLE
Fix Sphinx build error:

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -42,11 +42,12 @@ Documentation:
    best-practices
    advanced-use
    templates
-   automatic-package-installation
    jail-package
    debian
    known-issues
    faq
+
+.. Missing File: automatic-package-installation
 
 Indices and tables
 ==================


### PR DESCRIPTION
Sphinx reports missing document 'automatic-package-installation'.
Comment entry out in index to fix html build error and note the file is missing.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
