### PR TITLE
Alter docs style a little:

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -120,7 +120,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'agogo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -196,11 +196,11 @@ html_theme = 'alabaster'
 
 # If true, links to the reST sources are added to the pages.
 #
-# html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #
-# html_show_sphinx = True
+html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 #


### PR DESCRIPTION
- Adjust docs style to built-in "agogo" theme, as it is fairly customizable:
  - Agogo adds a few more color elements to the docs.
  - Fixes Table of Contents linking.
  - Basic search functionality is included.
  - Overall appears a little nicer/more professional.
- Remove footer link for sources.
- Remove footer "Built with Sphinx" addition.
- Local build test: no issues or errors detected/reported.
- If no one likes "agogo", the Sphinx website has a number of other built-in themes available: http://www.sphinx-doc.org/en/stable/theming.html . These all take one minor adjustment to set active, and some allow for simple customizations without creating new .css stylesheets.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
