### PR TITLE
 Fix traceback for iocage update

### DIFF
--- a/iocage/cli/update.py
+++ b/iocage/cli/update.py
@@ -42,7 +42,7 @@ __rootcmd__ = True
 def cli(jail):
     """Runs update with the command given inside the specified jail."""
     # TODO: Move to API
-    jails, paths = ioc_list.IOCList("uuid").list_datasets()
+    jails = ioc_list.IOCList("uuid").list_datasets()
     _jail = {uuid: path for (uuid, path) in jails.items() if
              uuid.startswith(jail)}
 


### PR DESCRIPTION
Fix a traceback with iocage following tag removal. 

> root@vm1:/iocage/jails/ftpserv # iocage update ftpserv
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/iocage/cli/update.py", line 45, in cli
    jails, paths = ioc_list.IOCList("uuid").list_datasets()
ValueError: too many values to unpack (expected 2)