### PR TITLE
Allow hyphens in jail names

### DIFF
--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -82,7 +82,7 @@ def validate_count(ctx, param, value):
 def cli(release, template, count, props, pkglist, basejail, empty, short,
         name, _uuid, force):
     if name:
-        valid = True if re.match("^[a-zA-Z0-9_]*$", name) else False
+        valid = True if re.match("^[a-zA-Z0-9_-]*$", name) else False
         if not valid:
             ioc_common.logit({
                 "level"  : "EXCEPTION",


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
This allows jail names like `my-jail`.  Preventing this was an oversight from preventing errors with weird characters.
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
