### PR TITLE
Allow setting ip(4|6)_addr without an interface name

### DIFF
--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -794,10 +794,10 @@ class IOCJson(object):
             "host_domainname"      : ("string",),
             "host_hostname"        : ("string",),
             "exec_fib"             : ("string",),
-            "ip4_addr"             : ("|",),
+            "ip4_addr"             : ("string",),
             "ip4_saddrsel"         : ("0", "1",),
             "ip4"                  : ("new", "inherit", "none"),
-            "ip6_addr"             : ("|",),
+            "ip6_addr"             : ("string",),
             "ip6_saddrsel"         : ("0", "1"),
             "ip6"                  : ("new", "inherit", "none"),
             "defaultrouter"        : ("string",),
@@ -932,27 +932,11 @@ class IOCJson(object):
             if props[key][0] == "string":
                 return
             else:
-                if key == "ip4_addr" or key == "ip6_addr" and value == "none":
-                    err = ""
-                else:
-                    err = f"{value} is not a valid value for {key}.\n"
+                err = f"{value} is not a valid value for {key}.\n"
 
-                if key not in ("interfaces", "ip4_addr", "ip6_addr",
-                               "memoryuse"):
+                if key not in ("interfaces", "memoryuse"):
                     msg = f"Value must be {' or '.join(props[key])}"
 
-                elif key == "ip4_addr":
-                    msg = "IP address must contain both an interface and IP " \
-                          "address.\nEXAMPLE: em0|192.168.1.10"
-
-                    if value == "none":
-                        return
-                elif key == "ip6_addr":
-                    msg = "IP address must contain both an interface and IP " \
-                          "address.\nEXAMPLE: em0|fe80::5400:ff:fe54:1"
-
-                    if value == "none":
-                        return
                 elif key == "interfaces":
                     msg = "Interfaces must be specified as a pair.\n" \
                           "EXAMPLE: vnet0:bridge0, vnet1:bridge1"

--- a/iocage/lib/ioc_stop.py
+++ b/iocage/lib/ioc_stop.py
@@ -211,6 +211,9 @@ class IOCStop(object):
             if ip4_addr != "inherit" and vnet == "off":
                 if ip4_addr != "none":
                     for ip4 in ip4_addr.split(","):
+                        # Don't try to remove an alias if there's no interface.
+                        if "|" not in ip4:
+                            continue
                         try:
                             iface, addr = ip4.split("/")[0].split("|")
                             addr = addr.split()
@@ -218,16 +221,6 @@ class IOCStop(object):
                                 ["ifconfig", iface] + addr +
                                 ["-alias"],
                                 stderr=su.STDOUT)
-                        except ValueError:
-                            # Likely a misconfigured ip_addr with no interface.
-                            msg = "  ! IP4 address is missing an interface," \
-                                  " set ip4_addr to \"INTERFACE|IPADDR\""
-                            iocage.lib.ioc_common.logit({
-                                "level"  : "INFO",
-                                "message": msg
-                            },
-                                _callback=self.callback,
-                                silent=self.silent)
                         except su.CalledProcessError as err:
                             if "Can't assign requested address" in \
                                     err.output.decode("utf-8"):
@@ -243,22 +236,15 @@ class IOCStop(object):
             if ip6_addr != "inherit" and vnet == "off":
                 if ip6_addr != "none":
                     for ip6 in ip6_addr.split(","):
+                        # Don't try to remove an alias if there's no interface.
+                        if "|" not in ip6:
+                            continue
                         try:
                             iface, addr = ip6.split("/")[0].split("|")
                             addr = addr.split()
                             iocage.lib.ioc_common.checkoutput(
                                 ["ifconfig", iface, "inet6"] + addr +
                                 ["-alias"], stderr=su.STDOUT)
-                        except ValueError:
-                            # Likely a misconfigured ip_addr with no interface.
-                            msg = "  ! IP6 address is missing an interface," \
-                                  " set ip6_addr to \"INTERFACE|IPADDR\""
-                            iocage.lib.ioc_common.logit({
-                                "level"  : "INFO",
-                                "message": msg
-                            },
-                                _callback=self.callback,
-                                silent=self.silent)
                         except su.CalledProcessError as err:
                             if "Can't assign requested address" in \
                                     err.output.decode("utf-8"):

--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -729,7 +729,7 @@ class IOCage(object):
                     "level"  : "EXCEPTION",
                     "message": "An IP address is needed to fetch a plugin!\n"
                                "Please specify ip(4|6)"
-                               "_addr=\"INTERFACE|IPADDRESS\"!"
+                               "_addr=\"[INTERFACE|]IPADDRESS\"!"
                 },
                     _callback=self.callback,
                     silent=self.silent)


### PR DESCRIPTION
Close #193.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
