### PR TITLE
ensure templates have correct type on creation

### DIFF
--- a/iocage/lib/ioc_create.py
+++ b/iocage/lib/ioc_create.py
@@ -287,6 +287,7 @@ class IOCCreate(object):
                     iocjson.json_write(config)  # Set counts on this.
                     location = location.replace("/jails/", "/templates/")
 
+                    iocjson.json_set_value("type=template")
                     iocjson.json_set_value("template=yes")
 
                 try:


### PR DESCRIPTION
when creating templates directly with

    iocage create --name foo template=yes

we also need to ensure that the `type` property is set correctly