### PR TITLE
fix name validation: names should be > 0 char

### DIFF
--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -82,7 +82,7 @@ def validate_count(ctx, param, value):
 def cli(release, template, count, props, pkglist, basejail, empty, short,
         name, _uuid, force):
     if name:
-        valid = True if re.match("^[a-zA-Z0-9_-]*$", name) else False
+        valid = True if re.match("^[a-zA-Z0-9_-]+$", name) else False
         if not valid:
             ioc_common.logit({
                 "level"  : "EXCEPTION",


### PR DESCRIPTION
previously, `name` was permitted to be empty (`*`), we now require at
least one character from the allowed set (`+`).