### PR TITLE
use fast returns for less indentation and easier readability

### DIFF
--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -57,7 +57,6 @@ def get_args(cls, dist, header=None):
     """
     if header is None:
         header = cls.get_header()
-    spec = str(dist.as_requirement())
     for type_ in 'console', 'gui':
         group = type_ + '_scripts'
         for name, ep in dist.get_entry_map(group).items():

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -99,9 +99,10 @@ def main():
         with open(setup_path, 'a+') as setup:
             setup.seek(0)
             setup_content = setup.read()
-            if not 'import fastentrypoints' in setup_content:
+            if 'import fastentrypoints' not in setup_content:
                 setup.seek(0)
                 setup.truncate()
                 setup.write('import fastentrypoints\n' + setup_content)
+
 
 print(__name__)

--- a/iocage/lib/ioc_check.py
+++ b/iocage/lib/ioc_check.py
@@ -101,24 +101,27 @@ class IOCCheck(object):
         Checks if /dev/fd is mounted, and if not, give the user a
         warning.
         """
-        if not os.path.ismount("/dev/fd"):
-            messages = collections.OrderedDict([
-                ("1-NOTICE", "*" * 80),
-                ("2-WARNING", "fdescfs(5) is not mounted, performance "
-                              " may suffer. Please run:"),
-                ("3-INFO", "mount -t fdescfs fdesc /dev/fd"),
-                ("4-WARNING", "You can also permanently mount it in "
-                              "/etc/fstab with the following entry:"),
-                ("5-INFO", "fdesc /dev/fd  fdescfs  rw  0  0"),
-                ("6-NOTICE", f"{'*' * 80}\n")
-            ])
+        if os.path.ismount("/dev/fd"):
+            # all good!
+            return
 
-            for level, msg in messages.items():
-                level = level.partition("-")[2]
+        messages = collections.OrderedDict([
+            ("1-NOTICE", "*" * 80),
+            ("2-WARNING", "fdescfs(5) is not mounted, performance "
+                            " may suffer. Please run:"),
+            ("3-INFO", "mount -t fdescfs fdesc /dev/fd"),
+            ("4-WARNING", "You can also permanently mount it in "
+                            "/etc/fstab with the following entry:"),
+            ("5-INFO", "fdesc /dev/fd  fdescfs  rw  0  0"),
+            ("6-NOTICE", f"{'*' * 80}\n")
+        ])
 
-                iocage.lib.ioc_common.logit({
-                    "level"  : level,
-                    "message": msg
-                },
-                    _callback=self.callback,
-                    silent=self.silent)
+        for level, msg in messages.items():
+            level = level.partition("-")[2]
+
+            iocage.lib.ioc_common.logit({
+                "level"  : level,
+                "message": msg
+            },
+                _callback=self.callback,
+                silent=self.silent)

--- a/iocage/lib/ioc_common.py
+++ b/iocage/lib/ioc_common.py
@@ -439,43 +439,44 @@ def git_pull(repo, remote_name="origin", branch="master"):
     # https://raw.githubusercontent.com/MichaelBoselowitz/pygit2-examples/master/examples.py
     # @formatter:on
     for remote in repo.remotes:
-        if remote.name == remote_name:
-            remote.fetch()
-            remote_master_id = repo.lookup_reference(
-                f"refs/remotes/origin/{branch}").target
-            merge_result, _ = repo.merge_analysis(remote_master_id)
-            # Up to date, do nothing
-            if merge_result & pygit2.GIT_MERGE_ANALYSIS_UP_TO_DATE:
-                return
-            # We can just fastforward
-            elif merge_result & pygit2.GIT_MERGE_ANALYSIS_FASTFORWARD:
-                repo.checkout_tree(repo.get(remote_master_id))
-                try:
-                    master_ref = repo.lookup_reference(f'refs/heads/{branch}')
-                    master_ref.set_target(remote_master_id)
-                except KeyError:
-                    repo.create_branch(branch, repo.get(remote_master_id))
-                repo.head.set_target(remote_master_id)
-            elif merge_result & pygit2.GIT_MERGE_ANALYSIS_NORMAL:
-                repo.merge(remote_master_id)
+        if remote.name != remote_name:
+            continue
 
-                if repo.index.conflicts is not None:
-                    for conflict in repo.index.conflicts:
-                        logit({
-                            "level"  : "EXCEPTION",
-                            "message": "Conflicts found in:"
-                                       f" {conflict[0].path}"
-                        })
+        remote.fetch()
+        remote_master_id = repo.lookup_reference(
+            f"refs/remotes/origin/{branch}").target
+        merge_result, _ = repo.merge_analysis(remote_master_id)
+        # Up to date, do nothing
+        if merge_result & pygit2.GIT_MERGE_ANALYSIS_UP_TO_DATE:
+            return
+        # We can just fastforward
+        elif merge_result & pygit2.GIT_MERGE_ANALYSIS_FASTFORWARD:
+            repo.checkout_tree(repo.get(remote_master_id))
+            try:
+                master_ref = repo.lookup_reference(f'refs/heads/{branch}')
+                master_ref.set_target(remote_master_id)
+            except KeyError:
+                repo.create_branch(branch, repo.get(remote_master_id))
+            repo.head.set_target(remote_master_id)
+        elif merge_result & pygit2.GIT_MERGE_ANALYSIS_NORMAL:
+            repo.merge(remote_master_id)
 
-                user = repo.default_signature
-                tree = repo.index.write_tree()
-                repo.create_commit('HEAD', user, user, "merged by iocage",
-                                   tree, [repo.head.target, remote_master_id])
-                # We need to do this or git CLI will think we are still
-                # merging.
-                repo.state_cleanup()
-            else:
-                raise AssertionError("Unknown merge analysis result")
+            if repo.index.conflicts is not None:
+                for conflict in repo.index.conflicts:
+                    logit({
+                        "level"  : "EXCEPTION",
+                        "message": "Conflicts found in: {conflict[0].path}"
+                    })
+
+            user = repo.default_signature
+            tree = repo.index.write_tree()
+            repo.create_commit('HEAD', user, user, "merged by iocage",
+                                tree, [repo.head.target, remote_master_id])
+            # We need to do this or git CLI will think we are still
+            # merging.
+            repo.state_cleanup()
+        else:
+            raise AssertionError("Unknown merge analysis result")
 
 
 def set_rcconf(jail_path, key, value):

--- a/iocage/lib/ioc_common.py
+++ b/iocage/lib/ioc_common.py
@@ -85,11 +85,9 @@ def raise_sort_error(sort_list):
         msg += f"  {s}\n"
 
     logit({
-        "level"  : "ERROR",
+        "level"  : "EXCEPTION",
         "message": msg.rstrip()
     })
-
-    raise RuntimeError()
 
 
 def ioc_sort(caller, s_type, data=None):

--- a/iocage/lib/ioc_common.py
+++ b/iocage/lib/ioc_common.py
@@ -69,16 +69,13 @@ def logit(content, _callback=None, silent=False):
     level = content["level"]
     msg = content["message"]
 
-    if silent:
-        if level != "EXCEPTION":
-            # They need to see these errors, too bad!
-            return
+    if silent and level != "EXCEPTION":
+        # They need to see these errors, too bad!
+        return
 
-    if callable(_callback):
-        _callback({"level": level, "message": msg})
-    else:
-        # This will log with our callback method if they didn't supply one.
-        callback(content)
+    # This will log with our callback method if they didn't supply one.
+    _callback = _callback if callable(_callback) else callback
+    _callback({"level": level, "message": msg})
 
 
 def raise_sort_error(sort_list):

--- a/iocage/lib/ioc_destroy.py
+++ b/iocage/lib/ioc_destroy.py
@@ -102,21 +102,21 @@ class IOCDestroy(object):
             su.Popen(["umount", "-f", f"{umount_path}/root/compat/linux/proc"],
                      stderr=su.PIPE).communicate()
 
-        if not snapshot:
-            if any(_type in dataset.name for _type in ("jails", "templates",
-                                                       "releases")):
-                # The jails parent won't show in the list.
-                j_parent = self.ds(f"{dataset.name.replace('/root','')}")
-                j_dependents = j_parent.dependents
+        if not snapshot and \
+           any(_type in dataset.name for _type
+               in ("jails", "templates", "releases")):
+            # The jails parent won't show in the list.
+            j_parent = self.ds(f"{dataset.name.replace('/root','')}")
+            j_dependents = j_parent.dependents
 
-                for j_dependent in j_dependents:
-                    if j_dependent.type == libzfs.DatasetType.FILESYSTEM:
-                        j_dependent.umount(force=True)
+            for j_dependent in j_dependents:
+                if j_dependent.type == libzfs.DatasetType.FILESYSTEM:
+                    j_dependent.umount(force=True)
 
-                    j_dependent.delete()
+                j_dependent.delete()
 
-                j_parent.umount(force=True)
-                j_parent.delete()
+            j_parent.umount(force=True)
+            j_parent.delete()
 
     def __destroy_dataset__(self, dataset):
         """Destroys the given datasets and snapshots."""

--- a/iocage/lib/ioc_fetch.py
+++ b/iocage/lib/ioc_fetch.py
@@ -155,32 +155,32 @@ class IOCFetch(object):
         if self.release.lower() == "exit":
             exit()
 
-        if len(self.release) <= 2:
-            try:
-                self.release = releases[int(self.release)]
-            except IndexError:
-                raise RuntimeError(f"[{self.release}] is not in the list!")
-            except ValueError:
-                # We want to use their host as RELEASE, but it may
-                # not be on the mirrors anymore.
-                try:
-                    self.release = self.__fetch_host_release__()
-
-                    if "-STABLE" in self.release:
-                        # Custom HardenedBSD server
-                        self.hardened = True
-                        return self.release
-
-                    releases.index(self.release)
-                except ValueError:
-                    raise RuntimeError("Please select an item!")
-        else:
+        if len(self.release) > 2:
             # Quick list validation
             try:
                 releases.index(self.release)
             except ValueError as err:
                 raise RuntimeError(err)
+            return self.release
 
+        try:
+            self.release = releases[int(self.release)]
+        except IndexError:
+            raise RuntimeError(f"[{self.release}] is not in the list!")
+        except ValueError:
+            # We want to use their host as RELEASE, but it may
+            # not be on the mirrors anymore.
+            try:
+                self.release = self.__fetch_host_release__()
+
+                if "-STABLE" in self.release:
+                    # Custom HardenedBSD server
+                    self.hardened = True
+                    return self.release
+
+                releases.index(self.release)
+            except ValueError:
+                raise RuntimeError("Please select an item!")
         return self.release
 
     def fetch_release(self, _list=False):

--- a/iocage/lib/ioc_fstab.py
+++ b/iocage/lib/ioc_fstab.py
@@ -118,9 +118,8 @@ class IOCFstab(object):
                         removed = True
                         dest = line.split()[1]
                         continue
-                    else:
-                        _fstab.write(line)
 
+                    _fstab.write(line)
                     index += 1
         if removed:
             iocage.lib.ioc_common.logit({
@@ -131,14 +130,14 @@ class IOCFstab(object):
                 _callback=self.callback,
                 silent=self.silent)
             return dest  # Needed for umounting, otherwise we lack context.
-        else:
-            iocage.lib.ioc_common.logit({
-                "level"  : "INFO",
-                "message": "No matching fstab entry."
-            },
-                _callback=self.callback,
-                silent=self.silent)
-            exit()
+
+        iocage.lib.ioc_common.logit({
+            "level"  : "INFO",
+            "message": "No matching fstab entry."
+        },
+            _callback=self.callback,
+            silent=self.silent)
+        exit()
 
     def __fstab_mount__(self):
         """Mounts the users mount if the jail is running."""

--- a/iocage/lib/ioc_image.py
+++ b/iocage/lib/ioc_image.py
@@ -162,13 +162,8 @@ class IOCImage(object):
         exports = os.listdir(image_dir)
         matches = fnmatch.filter(exports, f"{jail}*.zip")
 
-        if len(matches) == 1:
-            image_target = f"{image_dir}/{matches[0]}"
-            uuid = matches[0].rsplit("_")[0]
-            date = matches[0].rsplit("_")[1].strip(".zip")
-        elif len(matches) > 1:
+        if len(matches) > 1:
             msg = f"Multiple images found for {jail}:"
-
             for j in sorted(matches):
                 msg += f"\n  {j}"
 
@@ -178,13 +173,17 @@ class IOCImage(object):
             },
                 self.callback,
                 silent=self.silent)
-        else:
+        elif len(matches) < 1:
             iocage.lib.ioc_common.logit({
                 "level"  : "EXCEPTION",
                 "message": f"{jail} not found!"
             },
                 self.callback,
                 silent=self.silent)
+
+        image_target = f"{image_dir}/{matches[0]}"
+        uuid = matches[0].rsplit("_")[0]
+        date = matches[0].rsplit("_")[1].strip(".zip")
 
         with zipfile.ZipFile(image_target, "r") as _import:
             for z in _import.namelist():

--- a/iocage/lib/ioc_list.py
+++ b/iocage/lib/ioc_list.py
@@ -123,21 +123,22 @@ class IOCList(object):
 
             jail_list.append([uuid, ip4])
 
-        # Prints the table
-        if self.header:
-            table = texttable.Texttable(max_width=0)
-
-            # We get an infinite float otherwise.
-            table.set_cols_dtype(["t", "t"])
-            jail_list.insert(0, ["NAME", "IP4"])
-
-            table.add_rows(jail_list)
-
-            return table.draw()
-        else:
+        # return the list
+        if not self.header:
             flat_jail = [j for j in jail_list]
 
             return flat_jail
+
+        # Prints the table
+        table = texttable.Texttable(max_width=0)
+
+        # We get an infinite float otherwise.
+        table.set_cols_dtype(["t", "t"])
+        jail_list.insert(0, ["NAME", "IP4"])
+
+        table.add_rows(jail_list)
+
+        return table.draw()
 
     def list_all(self, jails):
         """List all jails."""
@@ -216,28 +217,28 @@ class IOCList(object):
                                               data=jail_list)
         jail_list.sort(key=sort)
 
-        # Prints the table
-        if self.header:
-            table = texttable.Texttable(max_width=0)
-
-            if self.full:
-                # We get an infinite float otherwise.
-                table.set_cols_dtype(["t", "t", "t", "t", "t", "t", "t", "t",
-                                      "t"])
-                jail_list.insert(0, ["JID", "NAME", "BOOT", "STATE", "TYPE",
-                                     "RELEASE", "IP4", "IP6", "TEMPLATE"])
-            else:
-                # We get an infinite float otherwise.
-                table.set_cols_dtype(["t", "t", "t", "t", "t"])
-                jail_list.insert(0, ["JID", "NAME", "STATE", "RELEASE", "IP4"])
-
-            table.add_rows(jail_list)
-
-            return table.draw()
-        else:
+        # return the list...
+        if not self.header:
             flat_jail = [j for j in jail_list]
 
             return flat_jail
+
+        # Prints the table
+        table = texttable.Texttable(max_width=0)
+
+        if self.full:
+            # We get an infinite float otherwise.
+            table.set_cols_dtype(["t", "t", "t", "t", "t", "t", "t", "t", "t"])
+            jail_list.insert(0, ["JID", "NAME", "BOOT", "STATE", "TYPE",
+                                 "RELEASE", "IP4", "IP6", "TEMPLATE"])
+        else:
+            # We get an infinite float otherwise.
+            table.set_cols_dtype(["t", "t", "t", "t", "t"])
+            jail_list.insert(0, ["JID", "NAME", "STATE", "RELEASE", "IP4"])
+
+        table.add_rows(jail_list)
+
+        return table.draw()
 
     def list_bases(self, datasets):
         """Lists all bases."""
@@ -245,17 +246,17 @@ class IOCList(object):
                                                    data=datasets)
         table = texttable.Texttable(max_width=0)
 
-        if self.header:
-            base_list.insert(0, ["Bases fetched"])
-            table.add_rows(base_list)
-            # We get an infinite float otherwise.
-            table.set_cols_dtype(["t"])
-
-            return table.draw()
-        else:
+        if not self.header:
             flat_base = [b for b in base_list for b in b]
 
             return flat_base
+
+        base_list.insert(0, ["Bases fetched"])
+        table.add_rows(base_list)
+        # We get an infinite float otherwise.
+        table.set_cols_dtype(["t"])
+
+        return table.draw()
 
     @classmethod
     def list_get_jid(cls, uuid):

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -380,15 +380,17 @@ class IOCStart(object):
 
         :param vnet: Boolean
         """
-        if vnet:
-            _, jid = iocage.lib.ioc_list.IOCList().list_get_jid(self.uuid)
-            net_configs = (
-                (self.get("ip4_addr"), self.get("defaultrouter"), False),
-                (self.get("ip6_addr"), self.get("defaultrouter6"), True))
-            nics = self.get("interfaces").split(",")
+        if not vnet:
+            return
 
-            for nic in nics:
-                self.start_network_interface_vnet(nic, net_configs, jid)
+        _, jid = iocage.lib.ioc_list.IOCList().list_get_jid(self.uuid)
+        net_configs = (
+            (self.get("ip4_addr"), self.get("defaultrouter"), False),
+            (self.get("ip6_addr"), self.get("defaultrouter6"), True))
+        nics = self.get("interfaces").split(",")
+
+        for nic in nics:
+            self.start_network_interface_vnet(nic, net_configs, jid)
 
     def start_network_interface_vnet(self, nic_defs, net_configs, jid):
         """
@@ -536,12 +538,13 @@ class IOCStart(object):
 
     def start_copy_localtime(self):
         host_time = self.get("host_time")
-        if host_time == "yes":
-            try:
-                shutil.copy("/etc/localtime",
-                            f"{self.path}/root/etc/localtime")
-            except FileNotFoundError:
-                return
+        if host_time != "yes":
+            return
+
+        try:
+            shutil.copy("/etc/localtime", f"{self.path}/root/etc/localtime")
+        except FileNotFoundError:
+            return
 
     def start_generate_resolv(self):
         resolver = self.get("resolver")

--- a/iocage/lib/ioc_upgrade.py
+++ b/iocage/lib/ioc_upgrade.py
@@ -55,58 +55,61 @@ class IOCUpgrade(object):
     def upgrade_jail(self):
         if "HBSD" in self.freebsd_version:
             su.Popen(["hbsd-upgrade", "-j", self.jid]).communicate()
-        else:
-            os.environ["PAGER"] = "/bin/cat"
-            if os.path.isfile(f"{self.path}/etc/freebsd-update.conf"):
-                f = "https://raw.githubusercontent.com/freebsd/freebsd" \
-                    "/master/usr.sbin/freebsd-update/freebsd-update.sh"
+            return
 
-                tmp = None
-                try:
-                    tmp = tempfile.NamedTemporaryFile(delete=False)
-                    with urllib.request.urlopen(f) as fbsd_update:
-                        tmp.write(fbsd_update.read())
+        os.environ["PAGER"] = "/bin/cat"
+        if not os.path.isfile(f"{self.path}/etc/freebsd-update.conf"):
+            return
+
+        f = "https://raw.githubusercontent.com/freebsd/freebsd" \
+            "/master/usr.sbin/freebsd-update/freebsd-update.sh"
+
+        tmp = None
+        try:
+            tmp = tempfile.NamedTemporaryFile(delete=False)
+            with urllib.request.urlopen(f) as fbsd_update:
+                tmp.write(fbsd_update.read())
+            tmp.close()
+            os.chmod(tmp.name, 0o755)
+
+            fetch = su.Popen([tmp.name, "-b", self.path, "-d",
+                                f"{self.path}/var/db/freebsd-update/",
+                                "-f",
+                                f"{self.path}/etc/freebsd-update.conf",
+                                "--not-running-from-cron",
+                                "--currently-running "
+                                f"{self.jail_release}",
+                                "-r",
+                                self.new_release, "upgrade"],
+                                stdin=su.PIPE)
+            fetch.communicate(b"y")
+
+            if fetch.returncode:
+                raise RuntimeError("Error occured, jail not upgraded!")
+
+            while not self.__upgrade_install__(tmp.name):
+                pass
+
+            if self.new_release[:4].endswith("-"):
+                # 9.3-RELEASE and under don't actually have this binary
+                new_release = self.new_release
+            else:
+                with open(self._freebsd_version, "r") as r:
+                    for line in r:
+                        if line.startswith("USERLAND_VERSION"):
+                            new_release = line.rstrip().partition(
+                                "=")[2].strip('"')
+        finally:
+            if tmp:
+                if not tmp.closed:
                     tmp.close()
-                    os.chmod(tmp.name, 0o755)
+                os.remove(tmp.name)
 
-                    fetch = su.Popen([tmp.name, "-b", self.path, "-d",
-                                      f"{self.path}/var/db/freebsd-update/",
-                                      "-f",
-                                      f"{self.path}/etc/freebsd-update.conf",
-                                      "--not-running-from-cron",
-                                      "--currently-running "
-                                      f"{self.jail_release}",
-                                      "-r",
-                                      self.new_release, "upgrade"],
-                                     stdin=su.PIPE)
-                    fetch.communicate(b"y")
+        iocage.lib.ioc_json.IOCJson(
+            f"{self.path.replace('/root', '')}",
+            silent=True).json_set_value(f"release={new_release}")
 
-                    if fetch.returncode:
-                        raise RuntimeError("Error occured, jail not upgraded!")
-
-                    while not self.__upgrade_install__(tmp.name):
-                        pass
-
-                    if self.new_release[:4].endswith("-"):
-                        # 9.3-RELEASE and under don't actually have this binary
-                        new_release = self.new_release
-                    else:
-                        with open(self._freebsd_version, "r") as r:
-                            for line in r:
-                                if line.startswith("USERLAND_VERSION"):
-                                    new_release = line.rstrip().partition(
-                                        "=")[2].strip('"')
-                finally:
-                    if tmp:
-                        if not tmp.closed:
-                            tmp.close()
-                        os.remove(tmp.name)
-
-                iocage.lib.ioc_json.IOCJson(
-                    f"{self.path.replace('/root', '')}",
-                    silent=True).json_set_value(f"release={new_release}")
-
-                return new_release
+        return new_release
 
     def __upgrade_install__(self, name):
         """Installs the upgrade and returns the exit code."""


### PR DESCRIPTION
I've started cleaning up the code for readability by using the pattern
of fast-return, to jump out of the code (often on error), so we don't
have to indent the main logic into the else branch.