### PR TITLE
extract configuration in external functions

### DIFF
--- a/iocage/lib/ioc_common.py
+++ b/iocage/lib/ioc_common.py
@@ -429,8 +429,8 @@ def checkoutput(*args, **kwargs):
         out = su.check_output(*args, **kwargs)
 
         out = out.decode("utf-8")
-    except su.CalledProcessError:
-        raise
+    except su.CalledProcessError as err:
+        raise RuntimeError(err.output.decode("utf-8").rstrip())
 
     return out
 


### PR DESCRIPTION
as a continuation to #293, we use try to extract some infrastructure
setup code from the error handling.

For now, this is happening at the expense of mild duplication, but that
too might be fixed in future patches