### PR TITLE
fix unsupported tqdm api call

### DIFF
--- a/iocage/lib/ioc_fetch.py
+++ b/iocage/lib/ioc_fetch.py
@@ -656,8 +656,7 @@ class IOCFetch(object):
                                        " {rate_fmt}"
                                        " Elapsed: {elapsed}"
                                        " Remaining: {remaining}",
-                            unit="bit",
-                            unit_scale="mega")
+                            unit="Mb")
                         pbar.set_description(f"Downloading: {f}")
 
                         for chunk in r.iter_content(chunk_size=1024):
@@ -697,8 +696,7 @@ class IOCFetch(object):
                                                             "elapsed}"
                                                             " Remaining: {"
                                                             "remaining}",
-                                                 unit="bit",
-                                                 unit_scale="mega")
+                                                 unit="Mb")
                                 pbar.set_description(
                                     f"Downloading: {f}")
 


### PR DESCRIPTION
This addresses #302, a supposed regression in our code, which turned out
to be a supposed regression in tqdm's code, which turned out to be an
unsupported use of the API: https://github.com/tqdm/tqdm/issues/415