### PR TITLE
Allow destroying jails with legacy mounted root/root path

### DIFF
--- a/iocage/lib/ioc_destroy.py
+++ b/iocage/lib/ioc_destroy.py
@@ -52,6 +52,8 @@ class IOCDestroy(object):
                 continue
             if dataset.type != libzfs.DatasetType.FILESYSTEM:
                 continue
+            if dataset.properties["mountpoint"].value == 'legacy':
+                continue
 
             # This is just to setup a replacement.
             path = path.replace("templates", "jails")


### PR DESCRIPTION
It seems that my [comment](https://github.com/iocage/iocage/issues/251#issuecomment-316929836) in issue [251](https://github.com/iocage/iocage/issues/251) is based on our very special way to create jails. And this is the reason why we still have problems with destroying jails:
```
sudo iocage destroy -f <jail>
Destroying vprob001
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/iocage/cli/destroy.py", line 128, in cli
    skip_jails=True).destroy_jail()
  File "/usr/local/lib/python3.6/site-packages/iocage/lib/iocage.py", line 623, in destroy_jail
    exit_on_error=self.exit_on_error).destroy_jail(path)
  File "/usr/local/lib/python3.6/site-packages/iocage/lib/ioc_destroy.py", line 207, in destroy_jail
    f"{self.pool}/iocage/{dataset_type}/{uuid}")
  File "/usr/local/lib/python3.6/site-packages/iocage/lib/ioc_destroy.py", line 167, in __destroy_parse_datasets__
    self.__stop_jails__(datasets, path, root)
  File "/usr/local/lib/python3.6/site-packages/iocage/lib/ioc_destroy.py", line 68, in __stop_jails__
    conf = iocage.lib.ioc_json.IOCJson(_path).json_load()
  File "/usr/local/lib/python3.6/site-packages/iocage/lib/ioc_json.py", line 176, in json_load
    jail_type, jail_uuid = self.location.rsplit("/", 2)[-2:]
ValueError: not enough values to unpack (expected 2, got 1)
```

I dived into the code a little and found out that this error is a result of our ZFS dataset structure. We create empty jails and build the datasets ourselves. In particular there is a dataset `zroot/iocage/jails/<jail>/root/root` which is `legacy` mounted. So what happens is: Method [__stop_jails__](https://github.com/iocage/iocage/blob/master/iocage/lib/ioc_destroy.py#L67) realizes that dataset `zroot/iocage/jails/<jail>/root/root` endswith uuid `root` and trys to load the configuration, which will fail obviously.

Remark: The pull request will fix this for legacy mounted `zroot/iocage/jails/<jail>/root/root`, but will not work for not legacy mounted `zroot/iocage/jails/<jail>/root/root` datasets. So, it is basically a simple workaround not a sophisticated solution.
