### PR TITLE
Only specify ip[46].addr on jail command line if set

### DIFF
--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -215,19 +215,18 @@ class IOCStart(object):
             ip6_addr = self.conf["ip6_addr"]
             ip6_saddrsel = self.conf["ip6_saddrsel"]
             ip6 = self.conf["ip6"]
+            net = []
 
-            if ip4_addr == "none":
-                ip4_addr = ""
+            if ip4_addr != "none":
+                net.append(f"ip4.addr={ip4_addr}")
 
-            if ip6_addr == "none":
-                ip6_addr = ""
+            if ip6_addr != "none":
+                net.append(f"ip6.addr={ip6_addr}")
 
-            net = [f"ip4.addr={ip4_addr}",
-                   f"ip4.saddrsel={ip4_saddrsel}",
-                   f"ip4={ip4}",
-                   f"ip6.addr={ip6_addr}",
-                   f"ip6.saddrsel={ip6_saddrsel}",
-                   f"ip6={ip6}"]
+            net += [f"ip4.saddrsel={ip4_saddrsel}",
+                    f"ip4={ip4}",
+                    f"ip6.saddrsel={ip6_saddrsel}",
+                    f"ip6={ip6}"]
 
             vnet = False
         else:


### PR DESCRIPTION
Previously we would send `jail -c ip4.addr=`, which disables ip4, breaking iocage's inherit option. Inherit works if ip4.addr is completely unspecified on the jail command line.
