### PR TITLE
Fix spelling error

### DIFF
--- a/iocage/tests/README.md
+++ b/iocage/tests/README.md
@@ -18,7 +18,7 @@ $ pytest
 
 ## Functional tests
 
-Located in the ``tests/functional_tests``, they need a root acces and the name of a ZFS pool
+Located in the ``tests/functional_tests``, they need a root access and the name of a ZFS pool
 
 **/!\ The contents of the specified ZFS pool will be destroyed**
 


### PR DESCRIPTION
The word access was misspelled.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
