### PR TITLE
Fix syntax error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,7 @@ SERVER=""
 
 install:
 	echo -e "import os\ntry:\n  if not os.listdir('/usr/src'): exit('/usr/src must be populated!')\nexcept FileNotFoundError:\n  exit('/usr/src must be populated!')" | python3.6
-
-	if [ -d "./.git" ]; then
-		git pull
-	fi
+        test -d .git && git pull || true
 
 	python3.6 -m ensurepip
 	pip3.6 install -U Cython


### PR DESCRIPTION
This caused a:
```
$ make install
echo -e "import os\ntry:\n  if not os.listdir('/usr/src'): exit('/usr/src must be populated!')\nexcept FileNotFoundError:\n  exit('/usr/src must be populated!')" | python3.6
if [ -d "./.git" ]; then
/bin/sh: Syntax error: end of file unexpected (expecting "fi")
```

If-statements like this don't work in Makefiles.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
