### PR TITLE
Fixed attribute error when no release is specified on the CLI

### DIFF
--- a/iocage/cli/fetch.py
+++ b/iocage/cli/fetch.py
@@ -140,10 +140,12 @@ def validate_count(ctx, param, value):
     help="Accept the plugin's LICENSE agreement.")
 def cli(**kwargs):
     """CLI command that calls fetch_release()"""
-    release = kwargs.get("release", None).rsplit("-", 1)[0].rsplit("-", 1)[0]
-    host_release = os.uname()[2].rsplit("-", 1)[0].rsplit("-", 1)[0]
+    release = kwargs.get("release", None)
 
     if release is not None:
+        release = release.rsplit("-", 1)[0].rsplit("-", 1)[0]
+        host_release = os.uname()[2].rsplit("-", 1)[0].rsplit("-", 1)[0]
+
         if host_release < release:
             ioc_common.logit({
                 "level":


### PR DESCRIPTION
The following error occurred:
```
  File "iocage/cli/fetch.py", line 143, in cli
    release = kwargs.get("release", None).rsplit("-", 1)[0].rsplit("-", 1)[0]
AttributeError: 'NoneType' object has no attribute 'rsplit'
```