### PR TITLE
better error message when jail is missing

### DIFF
--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -257,7 +257,7 @@ class IOCage(object):
                     _callback=self.callback,
                     silent=self.silent)
             else:
-                msg = f"{self.jail} not found!"
+                msg = f"jail '{self.jail}' not found!"
 
                 ioc_common.logit(
                     {


### PR DESCRIPTION
Hi there,

I rephrased the error message to indicate a missing jail slightly to make it more comprehensible. Now it makes clear that the given jail is missing, so you don't need to read the backtrace anymore to see what is going on.

Cheers,
tpltnt

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
