### PR TITLE
More helpful message when snapshot already exists

### DIFF
--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -1447,8 +1447,9 @@ class IOCJson(object):
                         if err.code == libzfs.Error.EXISTS:
                             iocage.lib.ioc_common.logit(
                                 {
-                                    "level": "EXCEPTION",
-                                    "message": 
+                                    "level": 
+                                    "EXCEPTION",
+                                    "message":
                                     f"Snapshot {jail_parent_ds}@{tag} already exists!",
                                 },
                                 exit_on_error=self.exit_on_error,

--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -1448,7 +1448,7 @@ class IOCJson(object):
                             iocage.lib.ioc_common.logit(
                                 {
                                     "level": "EXCEPTION",
-                                    "message": "Snapshot already exists!"
+                                    "message": f"Snapshot {jail_parent_ds}@{tag} already exists!",
                                 },
                                 exit_on_error=self.exit_on_error,
                                 _callback=self.callback,

--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -1450,7 +1450,8 @@ class IOCJson(object):
                                     "level": 
                                     "EXCEPTION",
                                     "message":
-                                    f"Snapshot {jail_parent_ds}@{tag} already exists!",
+                                    f"Snapshot {jail_parent_ds}@{tag} already\
+                                    exists!",
                                 },
                                 exit_on_error=self.exit_on_error,
                                 _callback=self.callback,

--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -1448,7 +1448,8 @@ class IOCJson(object):
                             iocage.lib.ioc_common.logit(
                                 {
                                     "level": "EXCEPTION",
-                                    "message": f"Snapshot {jail_parent_ds}@{tag} already exists!",
+                                    "message": 
+                                    f"Snapshot {jail_parent_ds}@{tag} already exists!",
                                 },
                                 exit_on_error=self.exit_on_error,
                                 _callback=self.callback,


### PR DESCRIPTION
When trying to` iocage -f list` to transition from an old non-python iocage installation, if the snapshot that is being created as part of the upgrade process already exists, a generic error will be printed and there is no way (that I know of) to get out of that situation by using iocage alone. By providing the exact snapshot that already exists, the user can e.g. choose to `zfs rename -r` said snapshot and thus overcome the impasse.
