### PR TITLE
Don't process flags with `iocage pkg`

### DIFF
--- a/iocage/cli/pkg.py
+++ b/iocage/cli/pkg.py
@@ -29,7 +29,10 @@ import iocage.lib.iocage as ioc
 __rootcmd__ = True
 
 
-@click.command(name="pkg", help="Use pkg inside a specified jail.")
+@click.command(
+    name="pkg",
+    context_settings=dict(ignore_unknown_options=True),
+    help="Use pkg inside a specified jail.")
 @click.argument("jail", required=True, nargs=1)
 @click.argument("command", nargs=-1, type=click.UNPROCESSED)
 def cli(command, jail):


### PR DESCRIPTION
`pkg` has a bunch of flags for ease-of-use. Enable use of these flags
through iocage by having the pkg subcommand ignore these flags.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
