### PR TITLE
Don't use ifconfig -f inet:cidr to extract IP/Mask...

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -442,9 +442,9 @@ class IOCStart(object):
 
                     # ...so we extract the ip4 address and mask,
                     # and calculate cidr manually
-                    addr_split = out.splitlines()
-                    ip4_addr = addr_split[2].split()[1].decode()
-                    hexmask = addr_split[2].split()[3].decode()
+                    addr_split = out.splitlines()[2]
+                    ip4_addr = addr_split.split()[1].decode()
+                    hexmask = addr_split.split()[3].decode()
                     maskcidr = sum([bin(int(hexmask, 16)).count("1")])
 
                     addr = f"{ip4_addr}/{maskcidr}"

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -434,13 +434,18 @@ class IOCStart(object):
                         # Jails default is epairNb
                         interface = f"{interface.replace('vnet', 'epair')}b"
 
+                    # We'd like to use ifconfig -f inet:cidr here,
+                    # but only FreeBSD 11.0 and newer support it...
                     cmd = ["jexec", f"ioc-{self.uuid}", "ifconfig",
                            interface, "inet"]
                     out = su.check_output(cmd)
 
-                    hexmask = out.splitlines()[2].split()[3].decode()
+                    # ...so we extract the ip4 address and mask,
+                    # and calculate cidr manually
+                    addr_split = out.splitlines()
+                    ip4_addr = addr_split[2].split()[1].decode()
+                    hexmask = addr_split[2].split()[3].decode()
                     maskcidr = sum([bin(int(hexmask, 16)).count("1")])
-                    ip4_addr = out.splitlines()[2].split()[1].decode()
 
                     addr = f"{ip4_addr}/{maskcidr}"
                 except su.CalledProcessError:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -434,12 +434,17 @@ class IOCStart(object):
                         # Jails default is epairNb
                         interface = f"{interface.replace('vnet', 'epair')}b"
 
-                    cmd = ["jexec", f"ioc-{self.uuid}", "ifconfig", "-f",
-                           "inet:cidr",
+                    cmd = ["jexec", f"ioc-{self.uuid}", "ifconfig",
                            interface, "inet"]
                     out = su.check_output(cmd)
 
-                    addr = f"{out.splitlines()[2].split()[1].decode()}"
+                    hexmask = out.splitlines()[2].split()[3].decode()
+                    maskcidr = sum([bin(int(hexmask, 16)).count("1")])
+                    ip4_addr = out.splitlines()[2].split()[1].decode()
+
+                    addr = f"{ip4_addr}/{maskcidr}"
+                except su.CalledProcessError:
+                    addr = "ERROR, check jail logs"
 
                     if "0.0.0.0" in addr:
                         failed_dhcp = True


### PR DESCRIPTION
... this is only supported by FreeBSD 11 and newer

Make sure to follow and check these boxes before submitting a PR! Thank you.

*My first pull request - please be gentle!*

- [x] Explain the feature

Nice feature added at commit 6556e18 shows IP address / mask at jail startup, but unfortunately only works on FreeBSD 11 and newer.

Rather than using `ifconfig -f inet:cidr`, just get the netmask in hex format from the standard `ifconfig` output, and convert it to cidr (number of bits).

- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)