### PR TITLE
prevents iocage from adding hostinterface to bridge

### DIFF
--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -28,7 +28,6 @@ import os
 import re
 import shutil
 import subprocess as su
-import netifaces
 
 import iocage.lib.ioc_common
 import iocage.lib.ioc_json

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -602,18 +602,6 @@ class IOCStart(object):
                 ["setfib", self.exec_fib, "jexec", f"ioc-{self.uuid}",
                  "ifconfig", jail_nic, "link", mac_b], stderr=su.STDOUT)
 
-            # Host
-            gws = netifaces.gateways()
-            def_iface = gws["default"][netifaces.AF_INET][1]
-
-            try:
-                # Host interface also needs to be on the bridge
-                iocage.lib.ioc_common.checkoutput(
-                    ["ifconfig", bridge, "addm", def_iface], stderr=su.STDOUT)
-            except su.CalledProcessError:
-                # Already exists
-                pass
-
             iocage.lib.ioc_common.checkoutput(
                 ["ifconfig", bridge, "addm", f"{nic}:{jid}", "up"],
                 stderr=su.STDOUT)

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -28,7 +28,6 @@ import os
 import re
 import shutil
 import subprocess as su
-import netifaces
 
 import iocage.lib.ioc_common
 import iocage.lib.ioc_json
@@ -601,18 +600,6 @@ class IOCStart(object):
             iocage.lib.ioc_common.checkoutput(
                 ["setfib", self.exec_fib, "jexec", f"ioc-{self.uuid}",
                  "ifconfig", jail_nic, "link", mac_b], stderr=su.STDOUT)
-
-            # Host
-            gws = netifaces.gateways()
-            def_iface = gws["default"][netifaces.AF_INET][1]
-
-            try:
-                # Host interface also needs to be on the bridge
-                iocage.lib.ioc_common.checkoutput(
-                    ["ifconfig", bridge, "addm", def_iface], stderr=su.STDOUT)
-            except su.CalledProcessError:
-                # Already exists
-                pass
 
             iocage.lib.ioc_common.checkoutput(
                 ["ifconfig", bridge, "addm", f"{nic}:{jid}", "up"],


### PR DESCRIPTION
This prevents iocage from adding a host interface to the bridge on jail startup. This was discussed in #521