### PR TITLE
Moved up logic for "empty jail" to fix issue 512

### DIFF
--- a/iocage/lib/ioc_create.py
+++ b/iocage/lib/ioc_create.py
@@ -371,7 +371,15 @@ class IOCCreate(object):
 
         final_line = f"{etc_hosts_ip_addr}\t{jail_hostname}\n"
 
-        if not self.clone:
+        if self.empty:
+            open(f"{location}/fstab", "wb").close()
+
+            config["release"] = "EMPTY"
+            config["cloned_release"] = "EMPTY"
+
+            iocjson.json_write(config)
+
+        elif not self.clone:
             open(f"{location}/fstab", "wb").close()
 
             with open(f"{location}/root/etc/hosts", "r") as _etc_hosts:
@@ -438,12 +446,6 @@ class IOCCreate(object):
                                               destination, "nullfs", "ro", "0",
                                               "0", silent=True)
                 config["basejail"] = "yes"
-
-            iocjson.json_write(config)
-
-        if self.empty:
-            config["release"] = "EMPTY"
-            config["cloned_release"] = "EMPTY"
 
             iocjson.json_write(config)
 


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
I moved up the logic/check for "empty jails" to fix issue #512
It will still create an fstab file, but not a hosts file.  
After the fix, I managed to create Debian Wheezy jail as per the original issue report.

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
