### PR TITLE
add "hosid_strickt_check" as a new value

### DIFF
--- a/iocage/lib/ioc_create.py
+++ b/iocage/lib/ioc_create.py
@@ -498,6 +498,7 @@ class IOCCreate(object):
         # values.
         jail_props["host_hostname"] = jail_uuid
         jail_props["host_hostuuid"] = jail_uuid
+        jail_props["hostid_strict_check"] = "off"
         jail_props["release"] = release
         jail_props["cloned_release"] = self.release
         jail_props["jail_zfs_dataset"] = f"iocage/jails/{jail_uuid}/data"

--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -1003,12 +1003,12 @@ class IOCJson(object):
 
         # Version 11 keys
         try:
-           hostid_stict_check = conf["hostid_stict_check"]
+           hostid_strict_check = conf["hostid_strict_check"]
         except KeyError:
-            hostid_stict_check = "off"
+            hostid_strict_check = "off"
 
         # Set all keys, even if it's the same value.
-        conf["hostid_stict_check"] = hostid_stict_check
+        conf["hostid_strict_check"] = hostid_strict_check
         
         if not default:
             try:

--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -811,7 +811,7 @@ class IOCJson(object):
     @staticmethod
     def json_get_version():
         """Sets the iocage configuration version."""
-        version = "10"
+        version = "11"
 
         return version
 
@@ -1001,6 +1001,15 @@ class IOCJson(object):
         # Set all keys, even if it's the same value.
         conf["CONFIG_VERSION"] = self.json_get_version()
 
+        # Version 11 keys
+        try:
+           hostid_stict_check = conf["hostid_stict_check"]
+        except KeyError:
+            hostid_stict_check = "off"
+
+        # Set all keys, even if it's the same value.
+        conf["hostid_stict_check"] = hostid_stict_check
+        
         if not default:
             try:
                 if not renamed:
@@ -1151,6 +1160,7 @@ class IOCJson(object):
             "owner": ("string", ),
             "priority": str(tuple(range(1, 100))),
             "hostid": ("string", ),
+            "hostid_strict_check": ("no", "yes"),
             "jail_zfs": ("off", "on"),
             "jail_zfs_dataset": ("string", ),
             "jail_zfs_mountpoint": ("string", ),
@@ -1699,6 +1709,7 @@ class IOCJson(object):
                 "last_started": "none",
                 "template": "no",
                 "hostid": hostid,
+                "hostid_strict_check": "off",
                 "jail_zfs": "off",
                 "jail_zfs_mountpoint": "none",
                 "mount_procfs": "0",

--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -1003,13 +1003,13 @@ class IOCJson(object):
 
         # Version 11 keys
         try:
-           hostid_strict_check = conf["hostid_strict_check"]
+            hostid_strict_check = conf["hostid_strict_check"]
         except KeyError:
             hostid_strict_check = "off"
 
         # Set all keys, even if it's the same value.
         conf["hostid_strict_check"] = hostid_strict_check
-        
+
         if not default:
             try:
                 if not renamed:

--- a/iocage/lib/ioc_json.py
+++ b/iocage/lib/ioc_json.py
@@ -811,7 +811,7 @@ class IOCJson(object):
     @staticmethod
     def json_get_version():
         """Sets the iocage configuration version."""
-        version = "10"
+        version = "11"
 
         return version
 
@@ -1001,6 +1001,15 @@ class IOCJson(object):
         # Set all keys, even if it's the same value.
         conf["CONFIG_VERSION"] = self.json_get_version()
 
+        # Version 11 keys
+        try:
+           hostid_strict_check = conf["hostid_strict_check"]
+        except KeyError:
+            hostid_strict_check = "off"
+
+        # Set all keys, even if it's the same value.
+        conf["hostid_strict_check"] = hostid_strict_check
+        
         if not default:
             try:
                 if not renamed:
@@ -1151,6 +1160,7 @@ class IOCJson(object):
             "owner": ("string", ),
             "priority": str(tuple(range(1, 100))),
             "hostid": ("string", ),
+            "hostid_strict_check": ("no", "yes"),
             "jail_zfs": ("off", "on"),
             "jail_zfs_dataset": ("string", ),
             "jail_zfs_mountpoint": ("string", ),
@@ -1699,6 +1709,7 @@ class IOCJson(object):
                 "last_started": "none",
                 "template": "no",
                 "hostid": hostid,
+                "hostid_strict_check": "off",
                 "jail_zfs": "off",
                 "jail_zfs_mountpoint": "none",
                 "mount_procfs": "0",

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -90,10 +90,10 @@ class IOCStart(object):
             }, exit_on_error=self.exit_on_error, _callback=self.callback,
                 silent=self.silent)
 
-        if self.conf["hosid_strict_check"] == "on"
+        if self.conf["hosid_strict_check"] == "on":
             with open("/etc/hostid", "r") as _file:
                 hostid = _file.read().strip()
-            if self.conf["hosid"] != hostid
+            if self.conf["hosid"] != hostid:
                 msg = f"Hostid is not matiching for {self.uuid} an 'hosid_strict_check' is on!"
                 iocage.lib.ioc_common.logit({
                     "level": "EXCEPTION",

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -94,11 +94,10 @@ class IOCStart(object):
             with open("/etc/hostid", "r") as _file:
                 hostid = _file.read().strip()
             if self.conf["hostid"] != hostid:
-                msg = f"Hostid is not matiching for {self.uuid} and"
-                       " 'hostid_strict_check' is on!"
                 iocage.lib.ioc_common.logit({
                     "level": "EXCEPTION",
-                    "message": msg
+                    "message": f"Hostid is not matiching for {self.uuid} and"
+                               " 'hostid_strict_check' is on!"
                 }, exit_on_error=self.exit_on_error, _callback=self.callback,
                     silent=self.silent)
 

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -94,7 +94,8 @@ class IOCStart(object):
             with open("/etc/hostid", "r") as _file:
                 hostid = _file.read().strip()
             if self.conf["hostid"] != hostid:
-                msg = f"Hostid is not matiching for {self.uuid} an 'hosid_strict_check' is on!"
+                msg = f"Hostid is not matiching for {self.uuid} and"
+                       " 'hostid_strict_check' is on!"
                 iocage.lib.ioc_common.logit({
                     "level": "EXCEPTION",
                     "message": msg

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -96,8 +96,9 @@ class IOCStart(object):
             if self.conf["hostid"] != hostid:
                 iocage.lib.ioc_common.logit({
                     "level": "ERROR",
-                    "message": f"Hostid is not matiching for {self.uuid} and"
+                    "message": f"{self.uuid} hostid is not matiching and"
                                " 'hostid_strict_check' is on!"
+                               " - Not starting jail"
                 }, _callback=self.callback, silent=self.silent)
             return
 

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -90,6 +90,18 @@ class IOCStart(object):
             }, exit_on_error=self.exit_on_error, _callback=self.callback,
                 silent=self.silent)
 
+        if self.conf["hostid_strict_check"] == "on":
+            with open("/etc/hostid", "r") as _file:
+                hostid = _file.read().strip()
+            if self.conf["hostid"] != hostid:
+                iocage.lib.ioc_common.logit({
+                    "level": "ERROR",
+                    "message": f"{self.uuid} hostid is not matiching and"
+                               " 'hostid_strict_check' is on!"
+                               " - Not starting jail"
+                }, _callback=self.callback, silent=self.silent)
+            return
+
         mount_procfs = self.conf["mount_procfs"]
         host_domainname = self.conf["host_domainname"]
         host_hostname = self.conf["host_hostname"]

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -90,6 +90,17 @@ class IOCStart(object):
             }, exit_on_error=self.exit_on_error, _callback=self.callback,
                 silent=self.silent)
 
+        if self.conf["hosid_strict_check"] == "on"
+            with open("/etc/hostid", "r") as _file:
+                hostid = _file.read().strip()
+            if self.conf["hosid"] != hostid
+                msg = f"Hostid is not matiching for {self.uuid} an 'hosid_strict_check' is on!"
+                iocage.lib.ioc_common.logit({
+                    "level": "EXCEPTION",
+                    "message": msg
+                }, exit_on_error=self.exit_on_error, _callback=self.callback,
+                    silent=self.silent)
+
         mount_procfs = self.conf["mount_procfs"]
         host_domainname = self.conf["host_domainname"]
         host_hostname = self.conf["host_hostname"]

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -93,7 +93,7 @@ class IOCStart(object):
         if self.conf["hostid_strict_check"] == "on":
             with open("/etc/hostid", "r") as _file:
                 hostid = _file.read().strip()
-            if self.conf["hosid"] != hostid:
+            if self.conf["hostid"] != hostid:
                 msg = f"Hostid is not matiching for {self.uuid} an 'hosid_strict_check' is on!"
                 iocage.lib.ioc_common.logit({
                     "level": "EXCEPTION",

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -90,7 +90,7 @@ class IOCStart(object):
             }, exit_on_error=self.exit_on_error, _callback=self.callback,
                 silent=self.silent)
 
-        if self.conf["hosid_strict_check"] == "on":
+        if self.conf["hostid_strict_check"] == "on":
             with open("/etc/hostid", "r") as _file:
                 hostid = _file.read().strip()
             if self.conf["hosid"] != hostid:

--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -95,11 +95,11 @@ class IOCStart(object):
                 hostid = _file.read().strip()
             if self.conf["hostid"] != hostid:
                 iocage.lib.ioc_common.logit({
-                    "level": "EXCEPTION",
+                    "level": "ERROR",
                     "message": f"Hostid is not matiching for {self.uuid} and"
                                " 'hostid_strict_check' is on!"
-                }, exit_on_error=self.exit_on_error, _callback=self.callback,
-                    silent=self.silent)
+                }, _callback=self.callback, silent=self.silent)
+            return
 
         mount_procfs = self.conf["mount_procfs"]
         host_domainname = self.conf["host_domainname"]


### PR DESCRIPTION
This PR adds "hosid_strickt_check" as a new value.
The default is set to "off".
If the value is set set to "on" the jail will only start if `hostid` matches `/etc/hostid`

This was dicussed in https://github.com/iocage/iocage/issues/529