### PR TITLE
Changed chroot command for better security

### DIFF
--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -422,7 +422,10 @@ class IOCage(object):
                 _callback=self.callback,
                 silent=self.silent)
 
-        chroot = su.Popen(["chroot", f"{path}/root"] + command)
+        if len(command) == 0:
+                chroot = su.Popen(["jexec", f"ioc-{uuid.replace('.', '_')}", "/bin/sh"])
+        else:
+                chroot = su.Popen(["jexec", f"ioc-{uuid.replace('.', '_')}"] + command)
         chroot.communicate()
 
         udevfs_stderr = self.__umount__(f"{path}/root/dev", "devfs")

--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -423,9 +423,11 @@ class IOCage(object):
                 silent=self.silent)
 
         if len(command) == 0:
-                chroot = su.Popen(["jexec", f"ioc-{uuid.replace('.', '_')}", "/bin/sh"])
+                chroot = su.Popen(["jexec", f"ioc-{uuid.replace('.', '_')}",
+                                   "/bin/sh"])
         else:
-                chroot = su.Popen(["jexec", f"ioc-{uuid.replace('.', '_')}"] + command)
+                chroot = su.Popen(["jexec", f"ioc-{uuid.replace('.', '_')}"]
+                                  + command)
         chroot.communicate()
 
         udevfs_stderr = self.__umount__(f"{path}/root/dev", "devfs")


### PR DESCRIPTION
Previous `iocage chroot` command use `chroot` command, but it gives only filesystem level isolation. When some malicious binary from jail root will be runned, it can jump out of chroot space and do something above jail process space.
Better option is usage of `jexec` to run shell inside jail root.