### PR TITLE
Make renaming jails more robust

### DIFF
--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -1196,6 +1196,17 @@ class IOCage(object):
             _callback=self.callback,
             silent=self.silent)
 
+        # Adjust mountpoints in fstab
+        old_mountpoint = f"{self.iocroot}/jails/{uuid}"
+        new_mountpoint = f"{self.iocroot}/jails/{new_name}"
+        jail_fstab = f"{new_mountpoint}/fstab"
+
+        with open(jail_fstab, "r") as fstab:
+            with ioc_common.open_atomic(jail_fstab, "w") as _fstab:
+                for line in fstab.readlines():
+                    _fstab.write(line.replace(old_mountpoint, new_mountpoint))
+
+
     def restart(self, soft=False):
         if self._all:
             if not soft:

--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -1206,7 +1206,6 @@ class IOCage(object):
                 for line in fstab.readlines():
                     _fstab.write(line.replace(old_mountpoint, new_mountpoint))
 
-
     def restart(self, soft=False):
         if self._all:
             if not soft:

--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -1146,7 +1146,7 @@ class IOCage(object):
     def rename(self, new_name):
         uuid, _ = self.__check_jail_existence__()
         path = f"{self.pool}/iocage/jails/{uuid}"
-        new_path = path.replace(self.jail, new_name)
+        new_path = path.replace(uuid, new_name)
 
         _silent = self.silent
         self.silent = True


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- Will adjust the mountpoints in fstab when renaming a jail. Please refer to issues #468 and #525 
- Fixes the mountpount when renaming jail using partial jailname (i.e. when only using first characters of uuid)

- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
