### PR TITLE
Ignore exception when trying to unmount datasets that do not exist

### DIFF
--- a/iocage/lib/ioc_stop.py
+++ b/iocage/lib/ioc_stop.py
@@ -161,39 +161,52 @@ class IOCStop(object):
                 silent=self.silent)
 
         if self.conf["jail_zfs"] == "on":
+
             for jdataset in self.conf["jail_zfs_dataset"].split():
                 jdataset = jdataset.strip()
-                children = iocage.lib.ioc_common.checkoutput(
-                    ["zfs", "list", "-H", "-r", "-o", "name", "-S", "name",
-                     f"{self.pool}/{jdataset}"])
 
-                for child in children.split():
-                    child = child.strip()
+                try:
+
+                    children = iocage.lib.ioc_common.checkoutput(
+                        ["zfs", "list", "-H", "-r", "-o", "name", "-S", "name",
+                         f"{self.pool}/{jdataset}"], stderr=su.STDOUT)
+
+                    for child in children.split():
+                        child = child.strip()
+
+                        try:
+                            iocage.lib.ioc_common.checkoutput(
+                                ["setfib", exec_fib, "jexec", f"ioc-{self.uuid}",
+                                 "zfs", "umount", child], stderr=su.STDOUT)
+                        except su.CalledProcessError as err:
+                            mountpoint = iocage.lib.ioc_common.checkoutput(
+                                ["zfs", "get", "-H", "-o", "value", "mountpoint",
+                                 f"{self.pool}/{jdataset}"]).strip()
+
+                            if mountpoint == "none":
+                                pass
+                            else:
+                                raise RuntimeError(
+                                    "{}".format(
+                                        err.output.decode("utf-8").rstrip()))
 
                     try:
                         iocage.lib.ioc_common.checkoutput(
-                            ["setfib", exec_fib, "jexec", f"ioc-{self.uuid}",
-                             "zfs", "umount", child], stderr=su.STDOUT)
+                            ["zfs", "unjail", f"ioc-{self.uuid}",
+                             f"{self.pool}/{jdataset}"], stderr=su.STDOUT)
                     except su.CalledProcessError as err:
-                        mountpoint = iocage.lib.ioc_common.checkoutput(
-                            ["zfs", "get", "-H", "-o", "value", "mountpoint",
-                             f"{self.pool}/{jdataset}"]).strip()
+                        raise RuntimeError(
+                            "{}".format(
+                                err.output.decode("utf-8").rstrip()))
 
-                        if mountpoint == "none":
-                            pass
-                        else:
-                            raise RuntimeError(
-                                "{}".format(
-                                    err.output.decode("utf-8").rstrip()))
-
-                try:
-                    iocage.lib.ioc_common.checkoutput(
-                        ["zfs", "unjail", f"ioc-{self.uuid}",
-                         f"{self.pool}/{jdataset}"], stderr=su.STDOUT)
                 except su.CalledProcessError as err:
-                    raise RuntimeError(
-                        "{}".format(
-                            err.output.decode("utf-8").rstrip()))
+                    if "dataset does not exist" in err.output.decode("utf-8"):
+                        # There's nothing to do if dataset doesn't exit
+                        pass
+                    else:
+                        raise RuntimeError(
+                            "{}".format(
+                                err.output.decode("utf-8").rstrip()))
 
         # They haven't set an IP address, this interface won't exist
         destroy_nic = True if dhcp == "on" or ip4_addr != "none" or \

--- a/iocage/lib/ioc_stop.py
+++ b/iocage/lib/ioc_stop.py
@@ -203,7 +203,7 @@ class IOCStop(object):
 
                 except su.CalledProcessError as err:
                     if "dataset does not exist" in err.output.decode("utf-8"):
-                        # There's nothing to do if dataset doesn't exit
+                        # There's nothing to do if dataset doesn't exist
                         pass
                     else:
                         raise RuntimeError(

--- a/iocage/lib/ioc_stop.py
+++ b/iocage/lib/ioc_stop.py
@@ -176,11 +176,13 @@ class IOCStop(object):
 
                         try:
                             iocage.lib.ioc_common.checkoutput(
-                                ["setfib", exec_fib, "jexec", f"ioc-{self.uuid}",
+                                ["setfib", exec_fib, "jexec",
+                                 f"ioc-{self.uuid}",
                                  "zfs", "umount", child], stderr=su.STDOUT)
                         except su.CalledProcessError as err:
                             mountpoint = iocage.lib.ioc_common.checkoutput(
-                                ["zfs", "get", "-H", "-o", "value", "mountpoint",
+                                ["zfs", "get", "-H", "-o",
+                                 "value", "mountpoint",
                                  f"{self.pool}/{jdataset}"]).strip()
 
                             if mountpoint == "none":


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
Avoid runtime error when attempting to stop jail when dataset in _jail_zfs_dataset_ does not exist.  See issue #157  Also note that in most cases this situation could be avoided by suggested feature #556 Any feedback on that? 

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
