### PR TITLE
Ignore exception when trying to unmount datasets that do not exist

### DIFF
--- a/iocage/lib/ioc_stop.py
+++ b/iocage/lib/ioc_stop.py
@@ -170,7 +170,7 @@ class IOCStop(object):
                         children = iocage.lib.ioc_common.checkoutput(
                             ["zfs", "list", "-H", "-r", "-o", "name",
                              "-S", "name",
-                             f"{self.pool}/{jdataset}"])
+                             f"{self.pool}/{jdataset}"], stderr=su.STDOUT)
 
                         for child in children.split():
                             child = child.strip()


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
Avoid runtime error when attempting to stop jail when dataset in jail_zfs_dataset does not exist. See issue #157.  This PR replaces #559 that had a merge confilct,

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
