### PR TITLE
Rename templates

### DIFF
--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -1156,7 +1156,7 @@ class IOCage(object):
         new_mountpoint = f"{self.iocroot}/{_folders[0]}/{new_name}"
 
         if (os.path.isdir(new_mountpoint) or
-            os.path.isdir(f"{self.iocroot}/{_folders[1]}/{new_name}")):
+                os.path.isdir(f"{self.iocroot}/{_folders[1]}/{new_name}")):
 
             ioc_common.logit(
                 {

--- a/iocage/lib/iocage.py
+++ b/iocage/lib/iocage.py
@@ -1248,8 +1248,9 @@ class IOCage(object):
             with open(jail_fstab, "r") as fstab:
                 with ioc_common.open_atomic(jail_fstab, "w") as _fstab:
                     for line in fstab.readlines():
-                        _fstab.write(line.replace(f"{self.iocroot}/jails/{uuid}/",
-                                                  f"{self.iocroot}/jails/{new_name}/"))
+                        _fstab.write(line.replace(
+                            f"{self.iocroot}/jails/{uuid}/",
+                            f"{self.iocroot}/jails/{new_name}/"))
         except OSError:
             pass
 


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
This PR adds support for renaming templates, as per #533   The main trick was to temporary flip the "readonly" zfs property while renaming

Full disclose with additional fixes/features:
- fix typo "runnning" should be running"
- added validation to ensure that you cannot use a name that is already taken, i.e. name that already exists as jail or template (identical to the check that happens during "create")
- I found the "path.replace(uuid, new_name)" to be problematic when using generic names such as "jail" of "template" or any name that (even partially) matched a substring in the mountpoint directory; That was made that more robust
- it had hardcoded to only handle the default jail_zfs_dataset {jail_path}\data and this was beefed up to actually properly parse property **jail_zfs_dataset** to process the actual zfs_datasets
- will always show the full jail name in the message "Jail: {} rename to {}", even when a partial name was used.
- The property **host_hostuuid** will now be changed only _after_ the zfs rename is successful, to prevent that the jail ends in some insonsistent state (there are some reports of that in a few of the rename-related issues)
- if the hostname (i.e. property **host_hostname**) was identical to the the old jail name, then host_hostname will also be changed to be the new name.  There's similar logic in some of the migration methods and it prevent things from getting confusing when running the native jls command  

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
