### PR TITLE
Proper exception handling for subprocess.check_call() 

### DIFF
--- a/iocage/lib/ioc_stop.py
+++ b/iocage/lib/ioc_stop.py
@@ -141,9 +141,12 @@ class IOCStop(object):
 
             exec_stop = self.conf["exec_stop"].split()
             with open(f"{self.iocroot}/log/{self.uuid}-console.log", "a") as f:
-                services = su.check_call(["setfib", exec_fib, "jexec",
-                                          f"ioc-{self.uuid}"] + exec_stop,
-                                         stdout=f, stderr=su.PIPE)
+                try:
+                    services = su.check_call(["setfib", exec_fib, "jexec",
+                                              f"ioc-{self.uuid}"] + exec_stop,
+                                             stdout=f, stderr=su.PIPE)
+                except su.CalledProcessError as err:
+                    services = err.returncode
 
             if services:
                 msg = "  + Stopping services FAILED"
@@ -302,9 +305,11 @@ class IOCStop(object):
                                 raise RuntimeError(
                                     "{}".format(
                                         err.output.decode("utf-8").strip()))
-
-        stop = su.check_call(["jail", "-r", f"ioc-{self.uuid}"],
-                             stderr=su.PIPE)
+        try:
+            stop = su.check_call(["jail", "-r", f"ioc-{self.uuid}"],
+                                 stderr=su.PIPE)
+        except su.CalledProcessError as err:
+            stop = err.returncode
 
         if stop:
             msg = "  + Removing jail process FAILED"


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
Calling [subprocess.check_call() ](https://docs.python.org/3/library/subprocess.html#subprocess.check_call)raises CalledProcessError when the returncode is not equal to zero.  
The CalledProcessError object then has the return code in the returncode attribute.  
This exception was not properly caught and this is causing the trace back in #560 

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
