### PR TITLE
Fix typo: 'matiching' should be 'matching'

### DIFF
--- a/iocage/lib/ioc_start.py
+++ b/iocage/lib/ioc_start.py
@@ -96,7 +96,7 @@ class IOCStart(object):
             if self.conf["hostid"] != hostid:
                 iocage.lib.ioc_common.logit({
                     "level": "ERROR",
-                    "message": f"{self.uuid} hostid is not matiching and"
+                    "message": f"{self.uuid} hostid is not matching and"
                                " 'hostid_strict_check' is on!"
                                " - Not starting jail"
                 }, _callback=self.callback, silent=self.silent)


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

I noticed this minor typo; 'matiching' should be 'matching'

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
