### PR TITLE
Strip subnet from IP4_ADDR when building plugin's adminportal URL

### DIFF
--- a/iocage/lib/ioc_list.py
+++ b/iocage/lib/ioc_list.py
@@ -246,8 +246,8 @@ class IOCList(object):
 
                 try:
                     with open(f"{mountpoint}/plugin/ui.json", "r") as u:
-                        ip = full_ip4.split("|", 1)[
-                            1] if "DHCP" not in full_ip4 else "DHCP"
+                        ip = full_ip4.split("|", 1)[1].split("/", 1)[
+                            0] if "DHCP" not in full_ip4 else "DHCP"
                         admin_portal = json.load(u)["adminportal"]
                         admin_portal = admin_portal.replace("%%IP%%", ip)
                 except FileNotFoundError:


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature

This PR fixes the following issue:
When creating a plugin using shared IP, the subnet is specified in property **ip4_addr**, e.g.:

```root@freenas:~ # iocage get ip4_addr plex
em0|192.168.0.210/24
root@freenas:~ # iocage list -l
+-----+------+------+-------+----------+------------------+----------------------+-----+----------+
| JID | NAME | BOOT | STATE |   TYPE   |     RELEASE      |         IP4          | IP6 | TEMPLATE |
+=====+======+======+=======+==========+==================+======================+=====+==========+
| 3   | plex | on   | up    | pluginv2 | 11.1-RELEASE-p11 | em0|192.168.0.210/24 | -   | -        |
+-----+------+------+-------+----------+------------------+----------------------+-----+----------+
```

Unfortunately, the subnet string /24 doesn't get stripped off when it's building the url for the adminporrtal URL (as per ui.json).

```root@freenas:~ # iocage list -P
+-----+------+------+-------+----------+------------------+----------------------+-----+----------+-----------------------------------+
| JID | NAME | BOOT | STATE |   TYPE   |     RELEASE      |         IP4          | IP6 | TEMPLATE |              PORTAL               |
+=====+======+======+=======+==========+==================+======================+=====+==========+===================================+
| 3   | plex | on   | up    | pluginv2 | 11.1-RELEASE-p11 | em0|192.168.0.210/24 | -   | -        | http://192.168.0.210/24:32400/web |
+-----+------+------+-------+----------+------------------+----------------------+-----+----------+-----------------------------------+
```

The url should be **http://192.168.0.210:32400/web** instead of **http://192.168.0.210/24:32400/web**

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
