### PR TITLE
Check release upon create

### DIFF
--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -106,6 +106,10 @@ def cli(release, template, count, props, pkglist, basejail, thickjail, empty,
     elif release and release.lower() == "latest":
         release = ioc_common.parse_latest_release()
 
+    if release:
+        release = release.upper()
+        ioc_common.check_release_newer(release)
+
     # We don't really care it's not a RELEASE at this point.
     release = template if template else release
 


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
Hi @skarekrow 
While I was testing the previous commits, I found one more way to fetch a release that is greater than the host:
```
/home/jurgen/iocage jurgen@trinity%  freebsd-version
11.1-RELEASE-p11
                                                                                                                                    
/home/jurgen/iocage jurgen@trinity%  sudo iocage create -n foo -r latest
Fetching: 11.2-RELEASE

Downloading : MANIFEST [####################] 100% 
Downloading : base.txz [####################] 100% 
Downloading : lib32.txz [####################] 100% 
Downloading : doc.txz [####################] 100% 
Downloading : src.txz [####################] 100% 
Extracting: base.txz... 
Extracting: lib32.txz... 
Extracting: doc.txz... 
Extracting: src.txz... 

* Updating 11.2-RELEASE to the latest patch level... 
Looking up update.FreeBSD.org mirrors... 2 mirrors found.
Fetching public key from update4.freebsd.org... done.
Fetching metadata signature for 11.2-RELEASE from update4.freebsd.org... done.
Fetching metadata index... done.
Fetching 1 metadata files... done.
Inspecting system... done.
Preparing to download files... done.

No updates needed to update system to 11.2-RELEASE-p0.
No updates are available to install.
Run '/tmp/tmp0eysniy7 fetch' first.
foo successfully created!
```
...and then the jail doesn't start, as expected
```                                                                                                                                    
/home/jurgen/iocage jurgen@trinity%  sudo iocage start foo

Host: 11.1 is not greater than jail: 11.2
This is unsupported.
```
This commit fixes this issue.

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
