### PR TITLE
Read output one more time after process is finished

### DIFF
--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -170,14 +170,21 @@ class IOCExec(object):
                         fl = fcntl.fcntl(fileno, fcntl.F_GETFL)
                         fcntl.fcntl(fileno, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
-                    while p.poll() is None:
+                    timeout = 0.1
+                    while True:
                         r = select.select([p.stdout.fileno(),
-                                           p.stderr.fileno()], [], [], 0.1)[0]
+                                           p.stderr.fileno()], [], [], timeout)[0]
                         if r:
                             if p.stdout.fileno() in r:
                                 rtrn_stdout += p.stdout.read()
                             if p.stderr.fileno() in r:
                                 rtrn_stderr += p.stderr.read()
+
+                        if p.poll() is not None:
+                            if timeout == 0:
+                                break
+                            else:
+                                timeout = 0
 
                     p.stdout.close()
                     p.stderr.close()


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
This is one last tweak related to the infamous FreeNAS issue 42018.
Based on my testing, it needs to read/check the stout one more time after the subprocess is finished to be sure to capture all output.  Credit to @william-gr as he hinted to this construct in the code review; with this added I can't break it anymore. :+1: 
I'll cross-post this in the FreeNAS issue

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
