### PR TITLE
Initialize reference to repo after succesful porcelain.pull()

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1230,7 +1230,8 @@ fingerprint: {fingerprint}
         """
         try:
             with open('/dev/null', 'wb') as devnull:
-                repo = porcelain.pull(destination, repo_url, errstream=devnull)
+                porcelain.pull(destination, repo_url, errstream=devnull)
+                repo = porcelain.open_repo(destination)
         except dulwich.errors.NotGitRepository:
             with open('/dev/null', 'wb') as devnull:
                 repo = porcelain.clone(


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

This is a fix for issue #605

- [X] Explain the feature

Fixes error `expected str, bytes or os.PathLike object, not NoneType` during `iocage fetch --plugins`

- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
