### PR TITLE
Flag debug as rootcmd

### DIFF
--- a/iocage_cli/debug.py
+++ b/iocage_cli/debug.py
@@ -26,6 +26,8 @@
 import click
 import iocage_lib.iocage as ioc
 
+__rootcmd__ = True
+
 
 @click.command(name="debug", help="Create a directory with all the debug"
                " for iocage jails.")


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

When running `iocage debug` as non-root user, one gets a Traceback.  This fix is to require running this command as root.
```
/home/jurgen/iocage jurgen@trinity%  iocage debug
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/iocage_cli/debug.py", line 38, in cli
    ioc.IOCage().debug(directory)
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/iocage.py", line 1855, in debug
    ioc_debug.IOCDebug(directory).run_debug()
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_debug.py", line 61, in run_debug
    self.run_host_debug()
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_debug.py", line 78, in run_host_debug
    self.__write_debug__(zfs_datasets, host_path, 'ZFS')
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_debug.py", line 128, in __write_debug__
    with open(f'{path}.txt', 'a+') as f:
PermissionError: [Errno 13] Permission denied: '/iocage/debug/host.txt'
```
