### PR TITLE
Fix branch name for plugin repo

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -76,7 +76,7 @@ class IOCPlugin(object):
             freebsd_version = su.run(['freebsd-version'],
                                      stdout=su.PIPE,
                                      stderr=su.STDOUT)
-            r = freebsd_version.stdout.decode().rstrip().rsplit('-', 1)[0]
+            r = freebsd_version.stdout.decode().rstrip().split('-', 1)[0]
 
             self.branch = f'{r}-RELEASE' if '.' in r else f'{r}.0-RELEASE'
         elif self.branch is None and self.hardened:


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Small regression in the logic where it determines the default branch name for the plugin repo.
Works ok in FreeNAS but in vanilla FreeBSD, it comes up with e.g. **11.2-RELEASE-RELEASE** as freebsd-version includes extra dash/hyphen with the patchlevel.
```
/home/jurgen jurgen@trinity%  freebsd-version
11.2-RELEASE-p2

/home/jurgen jurgen@trinity%  sudo iocage fetch --plugins ip4_addr="wlan0|192.168.0.213/24"

Branch 11.2-RELEASE-RELEASE does not exist at https://github.com/freenas/iocage-ix-plugins.git!
Using "master" branch for plugin, this may not work with your RELEASE

[0] BackupPC - BackupPC is a high-performance, enterprise-grade system for backing up Linux, WinXX and MacOSX PCs and laptops to a server's disk. (backuppc)
[1] Bacula-server - programs to manage backup, recovery, and verification of computer data across a network of computers of different kinds (bacula-server)
(  ..omitted...). 
[31] Zoneminder - ZoneMinder is a free, open source Closed-circuit television software application developed for Linux which supports IP, USB and Analog cameras. (zoneminder)

Type the number of the desired plugin
Press [Enter] or type EXIT to quit: 
```