### PR TITLE
Add "allow_mlock" as a new property

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -831,7 +831,7 @@ class IOCJson(object):
     @staticmethod
     def json_get_version():
         """Sets the iocage configuration version."""
-        version = "11"
+        version = "12"
 
         return version
 
@@ -1027,6 +1027,15 @@ class IOCJson(object):
         # Set all keys, even if it's the same value.
         conf["hostid_strict_check"] = hostid_strict_check
 
+        # Version 12 keys
+        try:
+            allow_mlock = conf["allow_mlock"]
+        except KeyError:
+            allow_mlock = "0"
+
+        # Set all keys, even if it's the same value.
+        conf["allow_mlock"] = allow_mlock
+
         if not default:
             try:
                 if not renamed:
@@ -1135,6 +1144,7 @@ class IOCJson(object):
             "allow_sysvipc": ("0", "1"),
             "allow_raw_sockets": ("0", "1"),
             "allow_chflags": ("0", "1"),
+            "allow_mlock": ("0", "1"),
             "allow_mount": ("0", "1"),
             "allow_mount_devfs": ("0", "1"),
             "allow_mount_nullfs": ("0", "1"),
@@ -1673,6 +1683,7 @@ class IOCJson(object):
                 "allow_sysvipc": "0",
                 "allow_raw_sockets": "0",
                 "allow_chflags": "0",
+                "allow_mlock": "0",
                 "allow_mount": "0",
                 "allow_mount_devfs": "0",
                 "allow_mount_nullfs": "0",

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -115,6 +115,7 @@ class IOCStart(object):
         allow_sysvipc = self.conf["allow_sysvipc"]
         allow_raw_sockets = self.conf["allow_raw_sockets"]
         allow_chflags = self.conf["allow_chflags"]
+        allow_mlock = self.conf["allow_mlock"]
         allow_mount = self.conf["allow_mount"]
         allow_mount_devfs = self.conf["allow_mount_devfs"]
         allow_mount_nullfs = self.conf["allow_mount_nullfs"]
@@ -224,6 +225,13 @@ class IOCStart(object):
             _sysvmsg = f"sysvmsg={sysvmsg}"
             _sysvsem = f"sysvsem={sysvsem}"
             _sysvshm = f"sysvshm={sysvshm}"
+
+        # FreeBSD before 12.0 does not support this.
+
+        if userland_version >= 12.0:
+            _allow_mlock = ""
+        else:
+            _allow_mlock = f"allow.mlock={allow_mlock}"
 
         if self.conf["vnet"] == "off":
             ip4_addr = self.conf["ip4_addr"]
@@ -351,6 +359,7 @@ class IOCStart(object):
                            _sysvshm,
                            f"allow.raw_sockets={allow_raw_sockets}",
                            f"allow.chflags={allow_chflags}",
+                           _allow_mlock,
                            f"allow.mount={allow_mount}",
                            f"allow.mount.devfs={allow_mount_devfs}",
                            f"allow.mount.nullfs={allow_mount_nullfs}",


### PR DESCRIPTION
Introduced [in FreeBSD 12.0](https://reviews.freebsd.org/rS336868). Enables running services that
require mlock() in a jail (e.g. MongoDB, some configurations of Elasticsearch)

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
