### PR TITLE
Fixed iocage list multiple IP4 addresses

### DIFF
--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -170,7 +170,7 @@ class IOCList(object):
             ip6 = conf["ip6_addr"]
 
             try:
-                short_ip4 = full_ip4.split("|")[1].split("/")[0]
+                short_ip4 = ",".join([item.split("|")[1].split("/")[0] for item in full_ip4.split(",")])
             except IndexError:
                 short_ip4 = full_ip4 if full_ip4 != "none" else "-"
 

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -170,7 +170,8 @@ class IOCList(object):
             ip6 = conf["ip6_addr"]
 
             try:
-                short_ip4 = ",".join([item.split("|")[1].split("/")[0] for item in full_ip4.split(",")])
+                short_ip4 = ",".join([item.split("|")[1].split("/")[0]
+                                      for item in full_ip4.split(",")])
             except IndexError:
                 short_ip4 = full_ip4 if full_ip4 != "none" else "-"
 


### PR DESCRIPTION
This pull request resolves iocage list problem when multiple IP4 addresses specified for jail.
For example, setting ip4_addr="lo1|192.168.1.1,lo1|192.168.2.2" leads to showing "192.168.1.1,lo1" instead of correct "192.168.1.1,192.168.2.2".