### PR TITLE
Fixed bug: setting ZFS properties via 'iocage set' raised exception

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1241,6 +1241,8 @@ class IOCJson(object):
 
             self.zfs_set_property(f"{pool}/iocage/{_type}/{uuid}", key, value)
 
+            return value, conf
+
         elif key in props.keys():
             # Either it contains what we expect, or it's a string.
 


### PR DESCRIPTION
Setting ZFS properties via 'iocage set' leads to raising exception because of lacking return statement at json_check_prop().

```
# iocage set quota=8g test

...
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_json.py", line 759, in json_set_value
    value, conf = self.json_check_prop(key, value, conf)
TypeError: 'NoneType' object is not iterable
```