### PR TITLE
Fix Traceback when pkg-static install fails

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -631,8 +631,8 @@ class IOCCreate(object):
         while True:
             pkg_install = su.run(["pkg-static", "-j", jid, "install", "-q",
                                   "-y", "pkg"],
-                                 stdout=su.DEVNULL,
-                                 stderr=su.DEVNULL)
+                                 stdout=su.PIPE,
+                                 stderr=su.STDOUT)
             pkg_err = pkg_install.returncode
 
             if pkg_err == 0:


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Properly pipe the output of pkg_install command to fix the traceback below when pkg-static install fails during plugin installation.  The prevents the jails from being properly destroyed, so you'll want this commit in the FreeNAS fork.
```
Type the number of the desired plugin
Press [Enter] or type EXIT to quit: 16
Plugin: Plex
  Official Plugin: True
  Using RELEASE: 11.2-RELEASE
  Using Branch: 11.2-RELEASE
  Post-install Artifact: https://github.com/freenas/iocage-plugin-plexmediaserver-plexpass.git
  These pkgs will be installed:
    - multimedia/plexmediaserver-plexpass

Testing SRV response to iocage-plugins
Testing DNSSEC response to iocage-plugins
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/iocage_cli/fetch.py", line 127, in cli
    ioc.IOCage().fetch(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/iocage.py", line 929, in fetch
    props, accept_license=accept, official=official)
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_plugin.py", line 736, in fetch_plugin_index
    props, 0, accept_license)
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_plugin.py", line 168, in fetch_plugin
    _conf, pkg, props, repo_dir)
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_plugin.py", line 515, in __fetch_plugin_install_packages__
    uuid, jaildir, _conf, repo=conf["packagesite"], site=repo_name)
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_create.py", line 652, in create_install_packages
    pkg_err_output = pkg_install.stdout.decode().rstrip()
AttributeError: 'NoneType' object has no attribute 'decode'
```

