### PR TITLE
Improve support for dots in jailname

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -746,7 +746,7 @@ def runscript(script):
     return True, None
 
 
-def match_to_dir(iocroot, uuid, rename=None):
+def match_to_dir(iocroot, uuid, old_uuid=None):
     """
     Checks for existence of jail/template with specified uuid.
     Replaces dots and underscores in the uuid with pattern [._] and returns
@@ -760,9 +760,9 @@ def match_to_dir(iocroot, uuid, rename=None):
     matches = glob.glob(f"{iocroot}/jails/{uuid}") \
         + glob.glob(f"{iocroot}/templates/{uuid}")
 
-    if rename:
+    if old_uuid:
         try:
-            matches.remove(rename)
+            matches.remove(old_uuid)
         except ValueError:
             pass
 

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -36,6 +36,7 @@ import requests
 import datetime as dt
 import re
 import shlex
+import glob
 
 
 def callback(_log, callback_exception):
@@ -743,3 +744,29 @@ def runscript(script):
         return True, out.rstrip("\n")
 
     return True, None
+
+
+def match_to_dir(iocroot, uuid, rename=None):
+    """
+    Checks for existence of jail/template with specified uuid.
+    Replaces dots and underscores in the uuid with pattern [._] and returns
+    the template- or jail directory that matches, or returns None if no match
+    was found.
+    Background: jail(8) doesn't allow dots in the name, they will be replaced
+    with underscores. Because of this, foo.bar and foo_bar will be considered
+    identical, as they cannot coexist.
+    """
+    uuid = uuid.replace(".", "_").replace("_", "[._]")
+    matches = glob.glob(f"{iocroot}/jails/{uuid}") \
+        + glob.glob(f"{iocroot}/templates/{uuid}")
+
+    if rename:
+        try:
+            matches.remove(rename)
+        except ValueError:
+            pass
+
+    if matches:
+        return matches[0]
+    else:
+        return None

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -104,13 +104,13 @@ class IOCCreate(object):
         start = False
         is_template = False
 
-        if os.path.isdir(location) or os.path.isdir(
-                f"{self.iocroot}/templates/{jail_uuid}"):
+        if iocage_lib.ioc_common.match_to_dir(self.iocroot, jail_uuid):
             if not self.plugin:
                 raise RuntimeError(f"Jail: {jail_uuid} already exists!")
 
             for i in itertools.count(start=2, step=1):
-                if os.path.isdir(f'{location}_{i}'):
+                if iocage_lib.ioc_common.match_to_dir(self.iocroot,
+                                                      f'{jail_uuid}_{i}'):
                     continue
 
                 # They now have a uniquely named plugin

--- a/iocage_lib/ioc_debug.py
+++ b/iocage_lib/ioc_debug.py
@@ -114,7 +114,7 @@ class IOCDebug(object):
 
     def __execute_debug__(self, command, jail=None, jexec=False):
         if jail is not None and jexec:
-            jail_cmd = ['jexec', f'ioc-{jail}']
+            jail_cmd = ['jexec', f'ioc-{jail.replace(".", "_")}']
             command = jail_cmd + command
 
         cmd_stdout = su.run(command, stdout=su.PIPE, stderr=su.STDOUT)

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -223,8 +223,8 @@ class IOCList(object):
                     interface = f"{interface.replace('vnet', 'epair')}b"
 
                 short_ip4 = "DHCP"
-                full_ip4_cmd = ["jexec", f"ioc-{uuid_full}", "ifconfig",
-                                interface, "inet"]
+                full_ip4_cmd = ["jexec", f"ioc-{uuid_full.replace('.', '_')}",
+                                "ifconfig", interface, "inet"]
                 out = su.check_output(full_ip4_cmd)
                 full_ip4 = f"{interface}|" \
                     f"{out.splitlines()[2].split()[1].decode()}"

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -614,7 +614,8 @@ fingerprint: {fingerprint}
                         interface = f"{interface.replace('vnet', 'epair')}b"
 
                     ip4_cmd = [
-                        "jexec", f"ioc-{uuid}", "ifconfig", interface, "inet"
+                        "jexec", f"ioc-{uuid.replace('.', '_')}",
+                        "ifconfig", interface, "inet"
                     ]
                     out = su.check_output(ip4_cmd).decode()
                     ip = f"{out.splitlines()[2].split()[1]}"

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1164,8 +1164,7 @@ class IOCage(object):
 
         new_mountpoint = f"{self.iocroot}/{_folders[0]}/{new_name}"
 
-        if (os.path.isdir(new_mountpoint) or
-                os.path.isdir(f"{self.iocroot}/{_folders[1]}/{new_name}")):
+        if ioc_common.match_to_dir(self.iocroot, new_name, old_mountpoint):
 
             ioc_common.logit(
                 {

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1164,7 +1164,8 @@ class IOCage(object):
 
         new_mountpoint = f"{self.iocroot}/{_folders[0]}/{new_name}"
 
-        if ioc_common.match_to_dir(self.iocroot, new_name, old_mountpoint):
+        if ioc_common.match_to_dir(self.iocroot, new_name,
+                                   old_uuid=old_mountpoint):
 
             ioc_common.logit(
                 {


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

This makes the handling of jails that have a period/dot in the name more robust
- Fixes `iocage debug` for jails that have dot in the name
- When checking if a jail exists, it will treat underscores and dots as equal.  This is to avoid potential conflicts between e.g. foo.bar and foo_bar
- Fixes issue #588 where `iocage list -l` fails for jails that have `dhcp=on` .  Please refer to this issue for more information.