### PR TITLE
copy shared cli files from libiocage/ioc

### DIFF
--- a/iocage_cli/shared
+++ b/iocage_cli/shared
@@ -1,1 +1,0 @@
-../libiocage/ioc/shared

--- a/iocage_cli/shared/click.py
+++ b/iocage_cli/shared/click.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Click helpers for the CLI."""
+import typing
+import click.core
+
+import iocage.events
+import iocage.Logger
+import iocage.Host
+
+
+class IocageClickContext(click.core.Context):
+    """ioc ctx for Click CLI."""
+
+    logger: iocage.Logger.Logger
+    host: iocage.Host.Host
+    parent: 'IocageClickContext'
+    print_events: typing.Callable[
+        [typing.Generator[iocage.events.IocageEvent, None, None]],
+        None
+    ]

--- a/iocage_cli/shared/jail.py
+++ b/iocage_cli/shared/jail.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Get a specific jails with this CLI helper function."""
+import typing
+
+import iocage.errors
+import iocage.Jail
+import iocage.Logger
+
+from .click import IocageClickContext
+
+
+def get_jail(
+    jail_name: str,
+    ctx: IocageClickContext
+) -> iocage.Jail.JailGenerator:
+    """Return the jail matching the given name."""
+    try:
+        return iocage.Jail.JailGenerator(
+            jail_name,
+            logger=ctx.logger,
+            host=ctx.host
+        )
+    except iocage.errors.IocageException:
+        exit(1)
+
+
+def set_properties(
+    properties: typing.Iterable[str],
+    target: 'iocage.LaunchableResource.LaunchableResource'
+) -> set:
+    """Set a bunch of jail properties from a Click option tuple."""
+    updated_properties = set()
+
+    for prop in properties:
+
+        if _is_setter_property(prop):
+            key, value = prop.split("=", maxsplit=1)
+            changed = target.config.set(key, value)
+            if changed:
+                updated_properties.add(key)
+        else:
+            key = prop
+            try:
+                del target.config[key]
+                updated_properties.add(key)
+            except (iocage.errors.IocageException, KeyError):
+                pass
+
+    if len(updated_properties) > 0:
+        target.save()
+
+    return updated_properties
+
+
+def _is_setter_property(property_string: str) -> bool:
+    return ("=" in property_string)

--- a/iocage_cli/shared/output.py
+++ b/iocage_cli/shared/output.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Use CLI helper functions for console output."""
+import typing
+import texttable
+
+
+def print_table(
+    data: typing.List[typing.List[str]],
+    columns: typing.List[str],
+    show_header: bool=True,
+    sort_key: typing.Optional[str]=None
+) -> None:
+    """Print a table to stdout."""
+    table = texttable.Texttable(max_width=0)
+    table.set_cols_dtype(["t"] * len(columns))
+
+    table_head = (list(x.upper() for x in columns))
+    table_data = data
+
+    if sort_key is None:
+        sort_index = -1
+    else:
+        try:
+            sort_index = columns.index(sort_key)
+        except ValueError:
+            sort_index = -1
+
+    if sort_index > -1:
+        table_data.sort(key=lambda x: x[sort_index])
+
+    if show_header is True:
+        table.add_rows([table_head] + table_data)
+    else:
+        table.add_rows(table_data, header=False)
+
+    print(table.draw())


### PR DESCRIPTION
The shared CLI assets are copied from the libiocage submodule, so that they are always included.