### PR TITLE
Large rework to Exec interface

### DIFF
--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -27,5 +27,12 @@
 class PoolNotActivated(Exception):
     pass
 
+
 class JailRunning(Exception):
     pass
+
+
+class CommandFailed(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(message)

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -28,6 +28,7 @@ import iocage_lib.ioc_common
 import iocage_lib.ioc_json
 import iocage_lib.ioc_list
 import iocage_lib.ioc_start
+import iocage_lib.ioc_exceptions
 import select
 import fcntl
 import os
@@ -53,14 +54,13 @@ class IOCExec(object):
                  su_env=None,
                  callback=None):
         self.command = command
-        self.uuid = uuid.replace(".", "_")
+        self.uuid = uuid.replace(".", "_") if uuid is not None else uuid
         self.path = path
         self.host_user = host_user
         self.jail_user = jail_user
         self.plugin = plugin
         self.pkg = pkg
         self.skip = skip
-        self.console = console
         self.silent = silent
         self.msg_return = msg_return
         self.msg_err_return = msg_err_return
@@ -83,136 +83,173 @@ class IOCExec(object):
             flag = "-u"
             user = self.host_user
 
-        status, _ = iocage_lib.ioc_list.IOCList().list_get_jid(self.uuid)
-        conf = iocage_lib.ioc_json.IOCJson(self.path).json_load()
-        exec_fib = conf["exec_fib"]
+        if self.uuid is not None:
+            status, _ = iocage_lib.ioc_list.IOCList().list_get_jid(self.uuid)
+            conf = iocage_lib.ioc_json.IOCJson(self.path).json_load()
+            exec_fib = conf["exec_fib"]
 
-        if not status:
-            if not self.plugin and not self.skip:
+            if not status:
+                if not self.plugin and not self.skip:
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level": "INFO",
+                            "message": f"{self.uuid} is not running,"
+                            " starting jail"
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
+
+                if conf["type"] in ("jail", "plugin", "pluginv2", "clonejail"):
+                    iocage_lib.ioc_start.IOCStart(
+                        self.uuid, self.path, conf, silent=True)
+                elif conf["type"] == "basejail":
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level":
+                            "EXCEPTION",
+                            "message":
+                            "Please run \"iocage migrate\" before trying"
+                            f" to start {self.uuid}"
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
+                elif conf["type"] == "template":
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level":
+                            "EXCEPTION",
+                            "message":
+                            "Please convert back to a jail before trying"
+                            f" to start {self.uuid}"
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
+                else:
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level":
+                            "EXCEPTION",
+                            "message":
+                            f"{conf['type']} is not a supported jail"
+                            " type."
+                        },
+                        _callback=self.callback,
+                        silent=self.silent)
+
                 iocage_lib.ioc_common.logit(
                     {
                         "level": "INFO",
-                        "message": f"{self.uuid} is not running, starting jail"
+                        "message": "\nCommand output:"
                     },
                     _callback=self.callback,
                     silent=self.silent)
 
-            if conf["type"] in ("jail", "plugin", "pluginv2", "clonejail"):
-                iocage_lib.ioc_start.IOCStart(
-                    self.uuid, self.path, conf, silent=True)
-            elif conf["type"] == "basejail":
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level":
-                        "EXCEPTION",
-                        "message":
-                        "Please run \"iocage migrate\" before trying"
-                        f" to start {self.uuid}"
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
-            elif conf["type"] == "template":
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level":
-                        "EXCEPTION",
-                        "message":
-                        "Please convert back to a jail before trying"
-                        f" to start {self.uuid}"
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
+        try:
+            if not self.pkg:
+                cmd = [
+                    "/usr/sbin/setfib", exec_fib, "jexec", flag, user,
+                    f"ioc-{self.uuid}"
+                ] + list(self.command)
             else:
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level":
-                        "EXCEPTION",
-                        "message":
-                        f"{conf['type']} is not a supported jail"
-                        " type."
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
+                cmd = self.command
 
-            iocage_lib.ioc_common.logit(
-                {
-                    "level": "INFO",
-                    "message": "\nCommand output:"
-                },
-                _callback=self.callback,
-                silent=self.silent)
+            if self.msg_return or self.msg_err_return:
+                p = su.Popen(cmd, stdout=su.PIPE, stderr=su.PIPE,
+                             close_fds=True, bufsize=0, env=self.su_env)
 
-        if self.console:
-            login_flags = conf["login_flags"].split()
-            su.Popen([
-                "/usr/sbin/setfib", exec_fib, "jexec", f"ioc-{self.uuid}",
-                "login"] + login_flags, env=self.su_env).communicate()
+                # Courtesy of @william-gr
+                # service(8) and some rc.d scripts have the bad habit of
+                # exec'ing and never closing stdout/stderr. This makes
+                # sure we read only enough until the command exits and do
+                # not wait on the pipe to close on the other end.
+                #
+                # Same issue can be demonstrated with:
+                # $ jexec 1 service postgresql onerestart | cat
+                # ... <hangs>
+                # postgresql rc.d command never closes the pipe
+                rtrn_stdout = b''
+                rtrn_stderr = b''
+                for i in ('stdout', 'stderr'):
+                    fileno = getattr(p, i).fileno()
+                    fl = fcntl.fcntl(fileno, fcntl.F_GETFL)
+                    fcntl.fcntl(fileno, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
-            return None, False
-        else:
-            try:
-                if not self.pkg:
-                    cmd = [
-                        "/usr/sbin/setfib", exec_fib, "jexec", flag, user,
-                        f"ioc-{self.uuid}"
-                    ] + list(self.command)
-                else:
-                    cmd = self.command
+                timeout = 0.1
+                yield_stdout_now = False
+                yield_stderr_now = False
 
-                if self.msg_return or self.msg_err_return:
-                    p = su.Popen(cmd, stdout=su.PIPE, stderr=su.PIPE,
-                                 close_fds=True, bufsize=0, env=self.su_env)
+                while True:
+                    r = select.select([
+                        p.stdout.fileno(),
+                        p.stderr.fileno()], [], [], timeout)[0]
 
-                    # Courtesy of @william-gr
-                    # service(8) and some rc.d scripts have the bad habit of
-                    # exec'ing and never closing stdout/stderr. This makes
-                    # sure we read only enough until the command exits and do
-                    # not wait on the pipe to close on the other end.
-                    #
-                    # Same issue can be demonstrated with:
-                    # $ jexec 1 service postgresql onerestart | cat
-                    # ... <hangs>
-                    # postgresql rc.d command never closes the pipe
-                    rtrn_stdout = b''
-                    rtrn_stderr = b''
-                    for i in ('stdout', 'stderr'):
-                        fileno = getattr(p, i).fileno()
-                        fl = fcntl.fcntl(fileno, fcntl.F_GETFL)
-                        fcntl.fcntl(fileno, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+                    if p.poll() is not None:
+                        if timeout == 0:
+                            break
+                        else:
+                            timeout = 0
 
-                    timeout = 0.1
-                    while True:
-                        r = select.select([p.stdout.fileno(),
-                                           p.stderr.fileno()], [], [], timeout)[0]
-                        if r:
-                            if p.stdout.fileno() in r:
-                                rtrn_stdout += p.stdout.read()
-                            if p.stderr.fileno() in r:
-                                rtrn_stderr += p.stderr.read()
+                    if r:
+                        if p.stdout.fileno() in r:
+                            if rtrn_stdout.endswith(b'\n'):
+                                yield_stdout_now = True
 
-                        if p.poll() is not None:
-                            if timeout == 0:
-                                break
-                            else:
-                                timeout = 0
+                            if not yield_stdout_now:
+                                stdout = p.stdout.read()
+                                rtrn_stdout += stdout
 
-                    p.stdout.close()
-                    p.stderr.close()
+                                if rtrn_stdout.endswith(b'\n'):
+                                    yield_stdout_now = True
 
-                    error = True if p.returncode != 0 else False
+                        if p.stderr.fileno() in r:
+                            if rtrn_stderr.endswith(b'\n'):
+                                yield_stderr_now = True
 
-                    if self.msg_err_return:
-                        return rtrn_stdout, rtrn_stderr, error
+                            if not yield_stderr_now:
+                                stderr = p.stderr.read()
+                                rtrn_stderr += stderr
 
-                    return rtrn_stdout, error
-                else:
-                    stdout = None if not self.silent else su.DEVNULL
-                    stderr = None if not self.silent else su.DEVNULL
+                                if rtrn_stderr.endswith(b'\n'):
+                                    yield_stderr_now = True
 
-                    p = su.Popen(
-                        cmd, stdout=stdout, stderr=stderr, env=self.su_env
-                    ).communicate()
+                        if self.msg_err_return:
+                            if yield_stdout_now and yield_stderr_now:
+                                yield_stdout_now = yield_stderr_now = False
+                                _rtrn_stdout = rtrn_stdout
+                                _rtrn_stderr = rtrn_stderr
 
-                    return "", False
-            except su.CalledProcessError as err:
-                return err.output.decode("utf-8").rstrip(), True
+                                # Set up a new line
+                                rtrn_stdout = rtrn_stderr = b''
+
+                                yield _rtrn_stdout, _rtrn_stderr
+                        else:
+                            if yield_stdout_now:
+                                yield_stdout_now = False
+                                _rtrn_stdout = rtrn_stdout
+
+                                # Set up a new line
+                                rtrn_stdout = b''
+
+                                yield _rtrn_stdout
+
+                p.stdout.close()
+                p.stderr.close()
+
+                error = True if p.returncode != 0 else False
+
+                if error and self.uuid is not None:
+                    # self.uuid being None means a release being updated,
+                    # We will get false positives for EOL notices
+                    raise iocage_lib.ioc_exceptions.CommandFailed(
+                        rtrn_stderr)
+            else:
+                stdout = None if not self.silent else su.DEVNULL
+                stderr = None if not self.silent else su.DEVNULL
+
+                p = su.Popen(
+                    cmd, stdout=stdout, stderr=stderr, env=self.su_env
+                ).communicate()
+
+                return "", False
+        except su.CalledProcessError as err:
+            return err.output.decode("utf-8").rstrip(), True

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     install_requires=[
         'dulwich>=0.18.6',
         'netifaces>=0.10.6',
+        'dnspython>=1.15.0',
         'libzfs'
     ],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
iocage side of #37742, still requires plugin work in freenas/freenas.

- Use python dns.resolver
- Drop other types of DNS tests
- Make Exec a generator
- New Exception type CommandFailed for Exec failures
- Use Exec for RELEASE updating along with jail
- Break console out of Exec
- Log update progress now (means colors as well)

Ticket: #37742