### PR TITLE
Added package dnspython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     install_requires=[
         'dulwich>=0.18.6',
         'netifaces>=0.10.6',
+        'dnspython>=1.15.0',
         'libzfs'
     ],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Commit 52116ac is missing the `dns.resolver` package and didn't build.  Adding dnspython fixed it.

```
/home/jurgen/iocage jurgen@trinity%  iocage list
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 6, in <module>
    from iocage_cli import cli
  File "/usr/local/lib/python3.6/site-packages/iocage_cli/__init__.py", line 37, in <module>
    import iocage_lib.ioc_check as ioc_check
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_check.py", line 29, in <module>
    import iocage_lib.ioc_json
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_json.py", line 37, in <module>
    import iocage_lib.ioc_create
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_create.py", line 43, in <module>
    import dns.resolver
ModuleNotFoundError: No module named 'dns'
```