### PR TITLE
Fixed building py-libzfs after updating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 	test -d .git && git pull || true
 	test -d .git && git submodule init py-libzfs && git submodule update py-libzfs || true
 	python3 -m ensurepip
-	export FREEBSD_SRC=$(SRC_BASE) && cd py-libzfs && python3 setup.py build && python3 setup.py install
+	export FREEBSD_SRC=$(SRC_BASE) && cd py-libzfs && ./configure && python3 setup.py build && python3 setup.py install
 	python3 -m pip install -U .
 uninstall:
 	python3 -m pip uninstall -y iocage-lib iocage-cli


### PR DESCRIPTION
py-libzfs added "configure" command in the latest version and iocage build fails without calling it.