### PR TITLE
iocage console hangs

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -815,6 +815,7 @@ class IOCage(object):
                 "login"] + login_flags
 
             su.Popen(console_cmd, env=su_env).communicate()
+            return
 
         try:
             msg = ioc_exec.IOCExec(


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

It needs a `return` here; when exiting out of "iocage console", there no need to execute the next code block.  In fact, it makes the terminal client hang.