### PR TITLE
if 'vnet_default_interface' is set to 'none' no host interface will be added to the bridge

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1007,11 +1007,7 @@ class IOCStart(object):
                 if default_if == 'auto':
                     default_if = self.get_default_gateway()[1]
 
-                if default_if == 'none':
-                    bridge_cmd = [
-                        "ifconfig", bridge, "create"
-                    ]
-                else:
+                if default_if != 'none':
                     bridge_cmd = [
                         "ifconfig", bridge, "create", "addm", default_if
                     ]

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -610,14 +610,15 @@ class IOCStart(object):
 
         vnet_default_interface = self.get('vnet_default_interface')
         if (
+                vnet_default_interface != 'auto' and
                 vnet_default_interface != 'none' and
                 vnet_default_interface not in netifaces.interfaces()
         ):
             # Let's not go into starting a vnet at all if the default
             # interface is supplied incorrectly
             return [
-                'Set property "vnet_default_interface" to "none" or a valid'
-                'interface e.g "lagg0"'
+                'Set property "vnet_default_interface" to "auto", "none" or a'
+                'valid interface e.g "lagg0"'
             ]
 
         for nic in nics:
@@ -700,7 +701,7 @@ class IOCStart(object):
         :return: If an error occurs it returns the error. Otherwise, it's None
         """
         vnet_default_interface = self.get('vnet_default_interface')
-        if vnet_default_interface == 'none':
+        if vnet_default_interface == 'auto':
             vnet_default_interface = self.get_default_gateway()[1]
 
         mac_a, mac_b = self.__start_generate_vnet_mac__(nic)
@@ -769,10 +770,11 @@ class IOCStart(object):
 
             try:
                 # Host interface as supplied by user also needs to be on the bridge
-                iocage_lib.ioc_common.checkoutput(
-                    ["ifconfig", bridge, "addm", vnet_default_interface],
-                    stderr=su.STDOUT
-                )
+                if vnet_default_interface != 'none':
+                    iocage_lib.ioc_common.checkoutput(
+                        ["ifconfig", bridge, "addm", vnet_default_interface],
+                        stderr=su.STDOUT
+                    )
             except su.CalledProcessError:
                 # Already exists
                 pass
@@ -1002,12 +1004,18 @@ class IOCStart(object):
             if dhcp == "on":
                 # Let's get the default vnet interface
                 default_if = self.get('vnet_default_interface')
-                if default_if == 'none':
+                if default_if == 'auto':
                     default_if = self.get_default_gateway()[1]
 
-                bridge_cmd = [
-                    "ifconfig", bridge, "create", "addm", default_if
-                ]
+                if default_if == 'none':
+                    bridge_cmd = [
+                        "ifconfig", bridge, "create"
+                    ]
+                else:
+                    bridge_cmd = [
+                        "ifconfig", bridge, "create", "addm", default_if
+                    ]
+
             else:
                 bridge_cmd = ["ifconfig", bridge, "create", "addm"]
 


### PR DESCRIPTION
if 'vnet_default_interface' is set to 'none' no host interface will be added to the bridge. 
Auto-detected interface is added to bridge if 'vnet_default_interface' is set to 'auto'

please see https://github.com/iocage/iocage/issues/521
