### PR TITLE
Fix quirks with 'iocage help' when using non-privileged user

### DIFF
--- a/iocage_cli/__init__.py
+++ b/iocage_cli/__init__.py
@@ -170,7 +170,7 @@ class IOCageCLI(click.MultiCommand):
             mod_name = mod.__name__.replace("iocage_cli.", "")
 
             try:
-                if mod.__rootcmd__ and "help" not in sys.argv[1:]:
+                if mod.__rootcmd__ and sys.argv[-1] not in ("help", "--help"):
                     if len(sys.argv) != 1:
                         if os.geteuid() != 0:
                             sys.exit("You need to have root privileges to"


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

This fixes some issues with `iocage --help` when using non-privileged user.  Examples:
```
iocage --help 
You need to have root privileges to run activate
```
```
iocage start --help   
You need to have root privileges to run start
```
Note that `iocage start help` and alike do work as expected.

```
iocage create -n help -r latest
``` 
This creates a Traceback.  I was expecting a _You need to have root privileges to run create_ message
