### PR TITLE
Optionally allow mounting fusefs from within the jail.

### DIFF
--- a/iocage.8
+++ b/iocage.8
@@ -1540,6 +1540,18 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
+.It Pf allow_mount_fusefs= Op 0 | 1
+Allow privileged users inside the jail to mount and unmount fusefs file
+systems.
+This permission is effective only together with allow_mount and if
+enforce_statfs is set to a value lower than 2.
+.Pp
+Note: This requires FreeBSD 12.0 or later.
+.Pp
+Default: 0
+.Pp
+Source:
+.Xr jail 8
 .It Pf allow_mount_nullfs= Op 0 | 1
 Allow privileged users inside the jail to mount and unmount the nullfs
 file system.

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -711,10 +711,12 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
         devfs_dict.update(paths)
 
     # We may end up setting all of these.
-    if conf['allow_tun'] == '1':
-        devfs_dict['tun*'] = None
+    if conf['allow_mount_fusefs'] == '1':
+        devfs_dict['fuse'] = None
     if conf['dhcp'] == 'on':
         devfs_dict['bpf*'] = None
+    if conf['allow_tun'] == '1':
+        devfs_dict['tun*'] = None
 
     for include in devfs_includes:
         su.run(

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -842,7 +842,7 @@ class IOCJson(object):
     @staticmethod
     def json_get_version():
         """Sets the iocage configuration version."""
-        version = "14"
+        version = "15"
 
         return version
 
@@ -1028,6 +1028,10 @@ class IOCJson(object):
         if not conf.get('allow_tun'):
             conf['allow_tun'] = '0'
 
+        # Version 15 keys
+        if not conf.get('allow_mount_fusefs'):
+            conf['allow_mount_fusefs'] = '0'
+
         if not default:
             try:
                 if not renamed:
@@ -1138,6 +1142,7 @@ class IOCJson(object):
             "allow_mlock": ("0", "1"),
             "allow_mount": ("0", "1"),
             "allow_mount_devfs": ("0", "1"),
+            "allow_mount_fusefs": ("0", "1"),
             "allow_mount_nullfs": ("0", "1"),
             "allow_mount_procfs": ("0", "1"),
             "allow_mount_tmpfs": ("0", "1"),
@@ -1732,6 +1737,7 @@ class IOCJson(object):
             "allow_mlock": "0",
             "allow_mount": "0",
             "allow_mount_devfs": "0",
+            "allow_mount_fusefs": "0",
             "allow_mount_nullfs": "0",
             "allow_mount_procfs": "0",
             "allow_mount_tmpfs": "0",

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -122,6 +122,7 @@ class IOCStart(object):
         allow_mlock = self.conf["allow_mlock"]
         allow_mount = self.conf["allow_mount"]
         allow_mount_devfs = self.conf["allow_mount_devfs"]
+        allow_mount_fusefs = self.conf["allow_mount_fusefs"]
         allow_mount_nullfs = self.conf["allow_mount_nullfs"]
         allow_mount_procfs = self.conf["allow_mount_procfs"]
         allow_mount_tmpfs = self.conf["allow_mount_tmpfs"]
@@ -346,6 +347,7 @@ class IOCStart(object):
                            _allow_mlock,
                            f"allow.mount={allow_mount}",
                            f"allow.mount.devfs={allow_mount_devfs}",
+                           f"allow.mount.fusefs={allow_mount_fusefs}",
                            f"allow.mount.nullfs={allow_mount_nullfs}",
                            f"allow.mount.procfs={allow_mount_procfs}",
                            tmpfs,

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -242,8 +242,10 @@ class IOCStart(object):
 
         if userland_version < 12.0:
             _allow_mlock = ""
+            _allow_mount_fusefs = ""
         else:
             _allow_mlock = f"allow.mlock={allow_mlock}"
+            _allow_mount_fusefs = f"allow.mount.fusefs={allow_mount_fusefs}"
 
         if self.conf["vnet"] == "off":
             ip4_addr = self.conf["ip4_addr"]
@@ -347,7 +349,7 @@ class IOCStart(object):
                            _allow_mlock,
                            f"allow.mount={allow_mount}",
                            f"allow.mount.devfs={allow_mount_devfs}",
-                           f"allow.mount.fusefs={allow_mount_fusefs}",
+                           _allow_mount_fusefs,
                            f"allow.mount.nullfs={allow_mount_nullfs}",
                            f"allow.mount.procfs={allow_mount_procfs}",
                            tmpfs,


### PR DESCRIPTION
Add a new parameter that allows mounting fuse filesystems within the jail.  Requires FreeBSD 12.0 or newer on the host.  Tested with fusefs-encfs, a 13.0-CURRENT host, and an 11.2-RELEASE guest.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
