### PR TITLE
Allow dots in the name for 'iocage console' (issue 677)

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -820,7 +820,8 @@ class IOCage(object):
             login_flags = self.get('login_flags').split()
             exec_fib = self.get('exec_fib')
             console_cmd = [
-                "/usr/sbin/setfib", exec_fib, "jexec", f"ioc-{uuid}",
+                "/usr/sbin/setfib", exec_fib,
+                "jexec", f"ioc-{uuid.replace('.', '_')}",
                 "login"] + login_flags
 
             su.Popen(console_cmd, env=su_env).communicate()
@@ -829,7 +830,8 @@ class IOCage(object):
         if interactive:
             exec_fib = self.get('exec_fib')
             interactive_cmd = (
-                "/usr/sbin/setfib", exec_fib, "jexec", f"ioc-{uuid}"
+                "/usr/sbin/setfib", exec_fib,
+                "jexec", f"ioc-{uuid.replace('.', '_')}"
                 ) + command
 
             try:


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Fixes #677; fix support for `iocage console` and `iocage exec` for jail names that contain dots.
