### PR TITLE
Fixed bug: do not umount path if fstab entry is not found

### DIFF
--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -141,7 +141,7 @@ class IOCFstab(object):
             return dest  # Needed for umounting, otherwise we lack context.
 
         iocage_lib.ioc_common.logit({
-            "level": "INFO",
+            "level": "EXCEPTION",
             "message": "No matching fstab entry."
         },
             _callback=self.callback,


### PR DESCRIPTION
There is an exception when calling "iocage fstab --remove" for non-existing paths:

```
No matching fstab entry.
...
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_fstab.py", line 64, in __init__
    self.__fstab_parse__()
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_fstab.py", line 77, in __fstab_parse__
    self.__fstab_umount__(dest)
  File "/usr/local/lib/python3.6/site-packages/iocage_lib/ioc_fstab.py", line 180, in __fstab_umount__
    proc = su.Popen(["umount", "-f", dest], stdout=su.PIPE, stderr=su.PIPE)
  File "/usr/local/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/local/lib/python3.6/subprocess.py", line 1275, in _execute_child
    restore_signals, start_new_session, preexec_fn)
TypeError: expected str, bytes or os.PathLike object, not NoneType

```