### PR TITLE
Drop "zero dependency" from description

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,7 +7,7 @@
 iocage - A FreeBSD Jail Manager
 ===============================
 
-iocage is a zero dependency drop in jail/container manager, combining
+iocage is a drop in jail/container manager written in Python, combining
 some of the best features and technologies the FreeBSD operating system
 has to offer. It is geared for ease of use with a simplistic and easy to
 learn command syntax.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,7 +7,7 @@
 iocage - A FreeBSD Jail Manager
 ===============================
 
-iocage is a drop in jail/container manager written in Python, combining
+iocage is a jail/container manager written in Python, combining
 some of the best features and technologies the FreeBSD operating system
 has to offer. It is geared for ease of use with a simplistic and easy to
 learn command syntax.


### PR DESCRIPTION
This still stemmed from the old shell based iocage.

No further comment/explanation needed here, I guess...
