### PR TITLE
Bug fix for template jails

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -416,6 +416,8 @@ class IOCCreate(object):
                 exit(1)
 
         if not self.plugin:
+            # TODO: Should we probably only write once and maybe at the end
+            # of the function ?
             iocjson.json_write(config)
 
         # Just "touch" the fstab file, since it won't exist and write
@@ -435,6 +437,12 @@ class IOCCreate(object):
             # They supplied just a normal tag
             jail_uuid_short = jail_uuid
             jail_hostname = jail_uuid
+
+        # If jail is template, the dataset would be readonly at this point
+        if is_template:
+            iocjson.zfs_set_property(
+                f"{self.pool}/iocage/templates/{jail_uuid}", "readonly", "off"
+            )
 
         if self.empty:
             open(f"{location}/fstab", "wb").close()


### PR DESCRIPTION
This commit fixes a bug which prevented creating a template jail at the same time the jail was being created for the first time. The dataset was readonly at that point and system tried to complete the relevant configuration files but failed to do so because of the readonly property set to true.
Ticket: #62190
