### PR TITLE
Fix 'iocage fetch' sorting

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -358,7 +358,7 @@ def sort_template(template):
     return sort_name(_template) + get_name_sortkey(template[1])
 
 
-def sort_release(releases, split=False):
+def sort_release(releases, split=False, fetch_releases=False):
     """
     Sort the list by RELEASE, if split is true it's expecting full
     datasets.
@@ -373,7 +373,9 @@ def sort_release(releases, split=False):
 
         length = len(releases)
 
-        if length == 9 or length == 10:
+        if fetch_releases:
+            pass
+        elif length == 9 or length == 10:
             # Attempt to split off the -p* stuff.
             try:
                 _release, _patch = releases[5].rsplit("-p", 1)

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -394,7 +394,8 @@ class IOCFetch(object):
                         _callback=self.callback,
                         silent=self.silent)
 
-                releases = iocage_lib.ioc_common.sort_release(releases)
+                releases = iocage_lib.ioc_common.sort_release(
+                    releases, fetch_releases=True)
 
                 for r in releases:
                     iocage_lib.ioc_common.logit(
@@ -461,10 +462,11 @@ class IOCFetch(object):
                         _callback=self.callback,
                         silent=self.silent)
 
+                releases = iocage_lib.ioc_common.sort_release(
+                    releases, fetch_releases=True)
+
                 if _list:
                     return releases
-
-                releases = iocage_lib.ioc_common.sort_release(releases)
 
                 for r in releases:
                     if r in eol:


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Fixes the following:
1. `iocage fetch` recently broke; with FreeBSD 12.0-RELEASE out, due to the somewhat hacky way function sort_releases was implemented.  Now that there are 9 releases, it's falling apart.  :smiley: 
```
➜  iocage git:(fix_releases) ✗ sudo iocage fetch
[0] 11.1
[1] 0
[2] RELEASE
[3] 10.2-RELEASE (EOL)
[1] 0

Type the number of the desired RELEASE
Press [Enter] to fetch the default selection: (11.2-RELEASE)
Type EXIT to quit: EXIT
```
2. While I was fixing this, I noted the sort was missing for `iocage list -R`; it listed the releases as per https://download.freebsd.org/ftp/releases/amd64/ with 9.3 at the bottom.