### PR TITLE
tkt-62547: No longer start network services explicitly

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -374,7 +374,9 @@ class IOCCreate(object):
                         config['vnet'] = 'on'
 
                     rtsold_enable = 'YES'
-            elif key == 'dhcp' and value == 'on':
+            elif (key == 'dhcp' and value == 'on') or (
+                key == 'ip4_addr' and 'DHCP' in value
+            ):
                 if 'vnet=on' not in self.props:
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
@@ -889,8 +891,8 @@ ipv6_activate_all_interfaces=\"YES\"
             su.Popen(
                 ['mount', '-F', f'{location}/fstab', '-a']).communicate()
 
-        su.Popen(["sysrc", "-R", f"{location}/root",
-                  f"hostname={host_hostname}"],
+        su.Popen(['sysrc', '-f', f'{location}/root/etc/rc.conf',
+                  f'hostname={host_hostname}'],
                  stdout=su.PIPE).communicate()
 
         if basejail != 'no':

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -375,7 +375,7 @@ class IOCCreate(object):
 
                     rtsold_enable = 'YES'
             elif (key == 'dhcp' and value == 'on') or (
-                key == 'ip4_addr' and 'DHCP' in value
+                key == 'ip4_addr' and 'DHCP' in value.upper()
             ):
                 if 'vnet=on' not in self.props:
                     iocage_lib.ioc_common.logit({

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -114,7 +114,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '15'
+        version = '16'
 
         return version
 
@@ -411,6 +411,10 @@ class IOCConfiguration(IOCZFS):
         # Version 15 keys
         if not conf.get('allow_mount_fusefs'):
             conf['allow_mount_fusefs'] = '0'
+
+        # Version 16 keys
+        if not conf.get('rtsold'):
+            conf['rtsold'] = 'off'
 
         if not default:
             conf.update(jail_conf)
@@ -720,7 +724,8 @@ class IOCConfiguration(IOCZFS):
             'dedup': 'off',
             'reservation': 'none',
             'depends': 'none',
-            'vnet_interfaces': 'none'
+            'vnet_interfaces': 'none',
+            'rtsold': 'off'
         }
 
         try:
@@ -1492,7 +1497,8 @@ class IOCJson(IOCConfiguration):
             "comment": ("string", ),
             "host_time": ("no", "yes"),
             "depends": ("string", ),
-            "allow_tun": ("0", "1")
+            "allow_tun": ("0", "1"),
+            'rtsold': ('off', 'on')
         }
 
         zfs_props = {

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -126,8 +126,9 @@ class IOCList(object):
 
             uuid = conf["host_hostuuid"]
             ip4 = conf.get('ip4_addr', 'none')
-            dhcp = conf.get('dhcp', 'off')  # Not using defaults for speed
-            ip4 = ip4 if dhcp != 'on' else 'DHCP'
+            dhcp = True if conf.get('dhcp') == 'on' or 'DHCP' in \
+                ip4.upper() else False
+            ip4 = ip4 if not dhcp else 'DHCP'
 
             if self.basejail_only and conf.get('basejail', 'no') != 'yes':
                 continue

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -523,7 +523,7 @@ fingerprint: {fingerprint}
         if '|' in ip6:
             ip6 = ip6.split("|")[1].rsplit("/")[0]
 
-        if ip4 != "none":
+        if ip4 != "none" and 'DHCP' not in ip4.upper():
             ip = ip4
         elif ip6 != "none":
             # If they had an IP4 address and an IP6 one,

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -143,7 +143,7 @@ class IOCStart(object):
         dhcp = self.conf["dhcp"]
         rtsold = self.conf['rtsold']
         wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.conf[
-            'ip4_addr'] else False
+            'ip4_addr'].upper() else False
         vnet_interfaces = self.conf["vnet_interfaces"]
         ip6_addr = self.conf["ip6_addr"]
         prop_missing = False
@@ -316,8 +316,8 @@ class IOCStart(object):
             _callback=self.callback,
             silent=self.silent)
 
-        if wants_dhcp and self.conf["type"] != "pluginv2" \
-                and self.conf['devfs_ruleset'] != "4":
+        if wants_dhcp and self.conf['type'] != 'pluginv2' \
+                and self.conf['devfs_ruleset'] != '4':
             iocage_lib.ioc_common.logit({
                 "level": "WARNING",
                 "message": f"  {self.uuid} is not using the devfs_ruleset"
@@ -544,17 +544,17 @@ class IOCStart(object):
                 failed_dhcp = False
 
                 try:
-                    interface = self.conf["interfaces"].split(",")[0].split(
-                        ":")[0]
+                    interface = self.conf['interfaces'].split(',')[0].split(
+                        ':')[0]
 
                     if 'vnet' in interface:
                         # Jails default is epairNb
-                        interface = f"{interface.replace('vnet', 'epair')}b"
+                        interface = f'{interface.replace("vnet", "epair")}b'
 
                     # We'd like to use ifconfig -f inet:cidr here,
                     # but only FreeBSD 11.0 and newer support it...
-                    cmd = ["jexec", f"ioc-{self.uuid}", "ifconfig",
-                           interface, "inet"]
+                    cmd = ['jexec', f'ioc-{self.uuid}', 'ifconfig',
+                           interface, 'inet']
                     out = su.check_output(cmd)
 
                     # ...so we extract the ip4 address and mask,
@@ -562,16 +562,16 @@ class IOCStart(object):
                     addr_split = out.splitlines()[2].split()
                     ip4_addr = addr_split[1].decode()
                     hexmask = addr_split[3].decode()
-                    maskcidr = sum([bin(int(hexmask, 16)).count("1")])
+                    maskcidr = sum([bin(int(hexmask, 16)).count('1')])
 
-                    addr = f"{ip4_addr}/{maskcidr}"
+                    addr = f'{ip4_addr}/{maskcidr}'
 
-                    if "0.0.0.0" in addr:
+                    if '0.0.0.0' in addr:
                         failed_dhcp = True
 
                 except (su.CalledProcessError, IndexError):
                     failed_dhcp = True
-                    addr = "ERROR, check jail logs"
+                    addr = 'ERROR, check jail logs'
 
                 if failed_dhcp:
                     iocage_lib.ioc_stop.IOCStop(
@@ -579,16 +579,16 @@ class IOCStart(object):
                     )
 
                     iocage_lib.ioc_common.logit({
-                        "level": "EXCEPTION",
-                        "message": "  + Acquiring DHCP address: FAILED,"
-                        f" address received: {addr}\n"
-                        f"\nStopped {self.uuid} due to DHCP failure"
+                        'level': 'EXCEPTION',
+                        'message': '  + Acquiring DHCP address: FAILED,'
+                        f' address received: {addr}\n'
+                        f'\nStopped {self.uuid} due to DHCP failure'
                     },
                         _callback=self.callback)
 
                 iocage_lib.ioc_common.logit({
-                    "level": "INFO",
-                    "message": f"  + DHCP Address: {addr}"
+                    'level': 'INFO',
+                    'message': f'  + DHCP Address: {addr}'
                 },
                     _callback=self.callback,
                     silent=self.silent)
@@ -662,7 +662,7 @@ class IOCStart(object):
 
                 for addrs, gw, ipv6 in net_configs:
                     if (
-                        dhcp == "on" or 'DHCP' in self.get('ip4_addr')
+                        dhcp == "on" or 'DHCP' in self.get('ip4_addr').upper()
                     ) and 'accept_rtadv' not in addrs:
                         # Spoofing IP address, it doesn't matter with DHCP
                         addrs = f"{nic}|''"
@@ -818,7 +818,7 @@ class IOCStart(object):
         """
         dhcp = self.get('dhcp')
         wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.get(
-            'ip4_addr') else False
+            'ip4_addr').upper() else False
 
         if 'vnet' in iface:
             # Inside jails they are epairNb
@@ -930,14 +930,14 @@ class IOCStart(object):
     def __check_dhcp__(self):
         # legacy behavior to enable it on every NIC
         if self.conf['dhcp'] == 'on':
-            nic_list = self.get("interfaces").split(",")
-            nics = list(map(lambda x: x.split(":")[0], nic_list))
+            nic_list = self.get('interfaces').split(',')
+            nics = list(map(lambda x: x.split(':')[0], nic_list))
         else:
             nics = []
             for ip4 in self.conf['ip4_addr'].split(','):
                 nic, addr = ip4.rsplit('/', 1)[0].split('|')
 
-                if addr == 'DHCP':
+                if addr.upper() == 'DHCP':
                     nics.append(nic)
 
         for nic in nics:
@@ -998,10 +998,11 @@ class IOCStart(object):
     def find_bridge_mtu(self, bridge):
         if self.unit_test:
             dhcp = 'off'
+            wants_dhcp = False
         else:
             dhcp = self.get("dhcp")
             wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.get(
-                'ip4_addr') else False
+                'ip4_addr').upper() else False
 
         try:
             if wants_dhcp:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -141,12 +141,15 @@ class IOCStart(object):
         sysvshm = self.conf["sysvshm"]
         bpf = self.conf["bpf"]
         dhcp = self.conf["dhcp"]
+        rtsold = self.conf['rtsold']
+        wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.conf[
+            'ip4_addr'] else False
         vnet_interfaces = self.conf["vnet_interfaces"]
         ip6_addr = self.conf["ip6_addr"]
         prop_missing = False
         prop_missing_msgs = []
 
-        if dhcp == "on":
+        if wants_dhcp:
             if bpf != "yes":
                 prop_missing_msgs.append(
                     f"{self.uuid}: dhcp requires bpf=yes!"
@@ -176,8 +179,11 @@ class IOCStart(object):
             }, _callback=self.callback,
                 silent=self.silent)
 
-        if dhcp == 'on':
+        if wants_dhcp:
             self.__check_dhcp__()
+
+        if rtsold == 'on':
+            self.__check_rtsold__()
 
         if mount_procfs == "1":
             su.Popen(
@@ -310,7 +316,7 @@ class IOCStart(object):
             _callback=self.callback,
             silent=self.silent)
 
-        if dhcp == 'on' and self.conf["type"] != "pluginv2" \
+        if wants_dhcp and self.conf["type"] != "pluginv2" \
                 and self.conf['devfs_ruleset'] != "4":
             iocage_lib.ioc_common.logit({
                 "level": "WARNING",
@@ -439,58 +445,6 @@ class IOCStart(object):
                 _callback=self.callback,
                 silent=self.silent)
 
-            if dhcp == "on":
-                failed_dhcp = False
-
-                try:
-                    interface = self.conf["interfaces"].split(",")[0].split(
-                        ":")[0]
-
-                    if 'vnet' in interface:
-                        # Jails default is epairNb
-                        interface = f"{interface.replace('vnet', 'epair')}b"
-
-                    # We'd like to use ifconfig -f inet:cidr here,
-                    # but only FreeBSD 11.0 and newer support it...
-                    cmd = ["jexec", f"ioc-{self.uuid}", "ifconfig",
-                           interface, "inet"]
-                    out = su.check_output(cmd)
-
-                    # ...so we extract the ip4 address and mask,
-                    # and calculate cidr manually
-                    addr_split = out.splitlines()[2].split()
-                    ip4_addr = addr_split[1].decode()
-                    hexmask = addr_split[3].decode()
-                    maskcidr = sum([bin(int(hexmask, 16)).count("1")])
-
-                    addr = f"{ip4_addr}/{maskcidr}"
-
-                    if "0.0.0.0" in addr:
-                        failed_dhcp = True
-
-                except (su.CalledProcessError, IndexError):
-                    failed_dhcp = True
-                    addr = "ERROR, check jail logs"
-
-                if failed_dhcp:
-                    iocage_lib.ioc_stop.IOCStop(
-                        self.uuid, self.path, force=True, silent=True
-                    )
-
-                    iocage_lib.ioc_common.logit({
-                        "level": "EXCEPTION",
-                        "message": "  + Acquiring DHCP address: FAILED,"
-                        f" address received: {addr}\n"
-                        f"\nStopped {self.uuid} due to DHCP failure"
-                    },
-                        _callback=self.callback)
-
-                iocage_lib.ioc_common.logit({
-                    "level": "INFO",
-                    "message": f"  + DHCP Address: {addr}"
-                },
-                    _callback=self.callback,
-                    silent=self.silent)
         elif vnet_err and vnet:
             iocage_lib.ioc_common.logit({
                 "level": "ERROR",
@@ -586,6 +540,59 @@ class IOCStart(object):
                 _callback=self.callback,
                 silent=self.silent)
 
+            if not vnet_err and vnet and wants_dhcp:
+                failed_dhcp = False
+
+                try:
+                    interface = self.conf["interfaces"].split(",")[0].split(
+                        ":")[0]
+
+                    if 'vnet' in interface:
+                        # Jails default is epairNb
+                        interface = f"{interface.replace('vnet', 'epair')}b"
+
+                    # We'd like to use ifconfig -f inet:cidr here,
+                    # but only FreeBSD 11.0 and newer support it...
+                    cmd = ["jexec", f"ioc-{self.uuid}", "ifconfig",
+                           interface, "inet"]
+                    out = su.check_output(cmd)
+
+                    # ...so we extract the ip4 address and mask,
+                    # and calculate cidr manually
+                    addr_split = out.splitlines()[2].split()
+                    ip4_addr = addr_split[1].decode()
+                    hexmask = addr_split[3].decode()
+                    maskcidr = sum([bin(int(hexmask, 16)).count("1")])
+
+                    addr = f"{ip4_addr}/{maskcidr}"
+
+                    if "0.0.0.0" in addr:
+                        failed_dhcp = True
+
+                except (su.CalledProcessError, IndexError):
+                    failed_dhcp = True
+                    addr = "ERROR, check jail logs"
+
+                if failed_dhcp:
+                    iocage_lib.ioc_stop.IOCStop(
+                        self.uuid, self.path, force=True, silent=True
+                    )
+
+                    iocage_lib.ioc_common.logit({
+                        "level": "EXCEPTION",
+                        "message": "  + Acquiring DHCP address: FAILED,"
+                        f" address received: {addr}\n"
+                        f"\nStopped {self.uuid} due to DHCP failure"
+                    },
+                        _callback=self.callback)
+
+                iocage_lib.ioc_common.logit({
+                    "level": "INFO",
+                    "message": f"  + DHCP Address: {addr}"
+                },
+                    _callback=self.callback,
+                    silent=self.silent)
+
         self.set(
             "last_started={}".format(datetime.datetime.utcnow().strftime(
                 "%F %T")))
@@ -654,7 +661,9 @@ class IOCStart(object):
                 ifaces = []
 
                 for addrs, gw, ipv6 in net_configs:
-                    if dhcp == "on" and 'accept_rtadv' not in addrs:
+                    if (
+                        dhcp == "on" or 'DHCP' in self.get('ip4_addr')
+                    ) and 'accept_rtadv' not in addrs:
                         # Spoofing IP address, it doesn't matter with DHCP
                         addrs = f"{nic}|''"
 
@@ -808,6 +817,8 @@ class IOCStart(object):
         :return: If an error occurs it returns the error. Otherwise, it's None
         """
         dhcp = self.get('dhcp')
+        wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.get(
+            'ip4_addr') else False
 
         if 'vnet' in iface:
             # Inside jails they are epairNb
@@ -829,7 +840,7 @@ class IOCStart(object):
                 route = 'none'
 
         try:
-            if dhcp == 'off' and ip != 'accept_rtadv':
+            if not wants_dhcp and ip != 'accept_rtadv':
                 # Jail side
                 iocage_lib.ioc_common.checkoutput(
                     ['setfib', self.exec_fib, 'jexec', f'ioc-{self.uuid}',
@@ -839,19 +850,6 @@ class IOCStart(object):
                     iocage_lib.ioc_common.checkoutput(
                         ['setfib', self.exec_fib, 'jexec', f'ioc-{self.uuid}',
                          'route'] + route, stderr=su.STDOUT)
-            else:
-                if ipv6:
-                    if ip == 'accept_rtadv':
-                        # rtsold support
-                        iocage_lib.ioc_common.checkoutput(
-                            ['setfib', self.exec_fib, 'jexec',
-                             f'ioc-{self.uuid}', 'service', 'rtsold',
-                             'onestart'], stderr=su.STDOUT)
-                else:
-                    iocage_lib.ioc_common.checkoutput(
-                        ['setfib', self.exec_fib, 'jexec', f'ioc-{self.uuid}',
-                         'service', 'dhclient', 'start', iface],
-                        stderr=su.STDOUT)
         except su.CalledProcessError as err:
             return f'{err.output.decode("utf-8")}'.rstrip()
         else:
@@ -930,29 +928,49 @@ class IOCStart(object):
         return mac_a, mac_b
 
     def __check_dhcp__(self):
-        nic_list = self.get("interfaces").split(",")
-        nics = list(map(lambda x: x.split(":")[0], nic_list))
-        _rc = open(f"{self.path}/root/etc/rc.conf").readlines()
+        # legacy behavior to enable it on every NIC
+        if self.conf['dhcp'] == 'on':
+            nic_list = self.get("interfaces").split(",")
+            nics = list(map(lambda x: x.split(":")[0], nic_list))
+        else:
+            nics = []
+            for ip4 in self.conf['ip4_addr'].split(','):
+                nic, addr = ip4.rsplit('/', 1)[0].split('|')
+
+                if addr == 'DHCP':
+                    nics.append(nic)
 
         for nic in nics:
             if 'vnet' in nic:
                 # Inside jails they are epairNb
                 nic = f"{nic.replace('vnet', 'epair')}b"
-            replaced = False
 
-            for no, line in enumerate(_rc):
-                if f"ifconfig_{nic}" in line:
-                    _rc[no] = f'ifconfig_{nic}="DHCP"\n'
-                    replaced = True
+            su.run(
+                [
+                    'sysrc', '-f', f'{self.path}/root/etc/rc.conf',
+                    f'ifconfig_{nic}=SYNCDHCP'
+                ],
+                stdout=su.PIPE
+            )
 
-            if not replaced:
-                # They didn't have any interface in their rc.conf,
-                # fresh jail perhaps?
-                _rc.insert(0, f'ifconfig_{nic}="DHCP"\n')
+    def __check_rtsold__(self):
+        if 'accept_rtadv' not in self.conf['ip6_addr']:
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'EXCEPTION',
+                    'message': 'Must set atleast one ip6_addr to accept_rtadv!'
+                },
+                _callback=self.callback,
+                silent=self.silent
+            )
 
-            with open(f"{self.path}/root/etc/rc.conf", "w") as rc:
-                for line in _rc:
-                    rc.write(line)
+        su.run(
+            [
+                'sysrc', '-f', f'{self.path}/root/etc/rc.conf',
+                f'rtsold_enable=YES'
+            ],
+            stdout=su.PIPE
+        )
 
     def get_default_gateway(self):
         # e.g response - ('192.168.122.1', 'lagg0')
@@ -982,9 +1000,11 @@ class IOCStart(object):
             dhcp = 'off'
         else:
             dhcp = self.get("dhcp")
+            wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.get(
+                'ip4_addr') else False
 
         try:
-            if dhcp == "on":
+            if wants_dhcp:
                 # Let's get the default vnet interface
                 default_if = self.get('vnet_default_interface')
                 if default_if == 'auto':

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -958,7 +958,8 @@ class IOCStart(object):
             iocage_lib.ioc_common.logit(
                 {
                     'level': 'EXCEPTION',
-                    'message': 'Must set atleast one ip6_addr to accept_rtadv!'
+                    'message':
+                        'Must set at least one ip6_addr to accept_rtadv!'
                 },
                 _callback=self.callback,
                 silent=self.silent


### PR DESCRIPTION
- Use explicit fstab for sysrc during creation
- New syntax for ip4_addr
EXAMPLE : ip4_addr='vnet0|DHCP' 
This replaces dhcp=on, as that previous property would start DHCP on all interfaces, which isn't always desired.
- Simplify setting rc.conf in start to use sysrc for DHCP or rtsold.
- New property 'rtsold', this will enable the service in the jail. This requires having accept_rtadv in the ip6_addr, this new property allows one to rely on just rtsol instead of always starting rtsold.

Closes #711
FreeNAS Ticket: #62547