### PR TITLE
tkt-64332: Remove py-libzfs as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "py-libzfs"]
-	path = py-libzfs
-	url = https://github.com/freenas/py-libzfs
-	branch = master

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,20 @@
 ZPOOL=""
 SERVER=""
-SRC_BASE?="/usr/src"
+PYTHON?=/usr/local/bin/python3
 
 install:
-	echo -e "import os\ntry:\n  if not os.listdir('$(SRC_BASE)'): exit('$(SRC_BASE) must be populated!')\nexcept FileNotFoundError:\n  exit('$(SRC_BASE) must be populated!')" | python3
-	test -d .git && git pull || true
-	test -d .git && git submodule init py-libzfs && git submodule update py-libzfs || true
-	python3 -m ensurepip
-	export FREEBSD_SRC=$(SRC_BASE) && cd py-libzfs && ./configure && python3 setup.py build && python3 setup.py install
-	python3 -m pip install -Ur requirements.txt .
+	@(grep latest /etc/pkg/FreeBSD.conf) > /dev/null 2>&1 || (echo "Please ensure pkg url is using \"latest\" instead of \"quarterly\" in /etc/pkg/FreeBSD.conf before proceeding with installation"; exit 1)
+	${PYTHON} -m ensurepip
+	pkg install -y devel/py-libzfs
+	${PYTHON} -m pip install -Ur requirements.txt .
 uninstall:
-	python3 -m pip uninstall -y iocage-lib iocage-cli
+	${PYTHON} -m pip uninstall -y iocage-lib iocage-cli
 test:
 	pytest --zpool $(ZPOOL) --server $(SERVER)
 help:
 	@echo "    install"
 	@echo "        Installs iocage"
 	@echo "    uninstall"
-	@echo "        Removes iocage."
+	@echo "        Removes iocage"
 	@echo "    test"
 	@echo "        Run unit tests with pytest"


### PR DESCRIPTION
This commit removes py-libzfs as a submodule from iocage and instead uses pkg to install py-libzfs.
Ticket: #64332