### PR TITLE
Make check for 'latest' repo more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SERVER=""
 PYTHON?=/usr/local/bin/python3
 
 install:
-	@(grep latest /etc/pkg/FreeBSD.conf) > /dev/null 2>&1 || (echo "Please ensure pkg url is using \"latest\" instead of \"quarterly\" in /etc/pkg/FreeBSD.conf before proceeding with installation"; exit 1)
+	@(pkg -vv | grep -e "url.*/latest") > /dev/null 2>&1 || (echo "Please ensure pkg url is using \"latest\" instead of \"quarterly\" in /etc/pkg/FreeBSD.conf before proceeding with installation"; exit 1)
 	${PYTHON} -m ensurepip
 	pkg install -y devel/py-libzfs
 	${PYTHON} -m pip install -Ur requirements.txt .


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

After PR #747 my builds failed, even though I'm on 'latest'.  I took the recommended approach as per the comments in `/etc/pkg/FreeBSD.conf` below.  This PR will make this check a bit more robust.
```
# To disable this repository, instead of modifying or removing this file,
# create a /usr/local/etc/pkg/repos/FreeBSD.conf file:
#
#   mkdir -p /usr/local/etc/pkg/repos
#   echo "FreeBSD: { enabled: no }" > /usr/local/etc/pkg/repos/FreeBSD.conf
#
```


