### PR TITLE
Make links their own section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ This repository replaces `iocage_legacy`. To upgrade to the current version:
 1. Migrate the jails. This can be done by running `iocage list` as root
 1. Start the jails (`service iocage onestart`)
 
+## Links
+
+- **[iocage Project Website](https://iocage.github.io/)**
+- **[Documentation](http://iocage.readthedocs.org/en/latest/index.html)**
+- **[Mailing list](https://groups.google.com/forum/#!forum/iocage)**
+
 ## WARNING:
 
 - This is beta quality software, there be dragons! Please report them.
 - Some features of the previous iocage_legacy are either being dropped or simply not ported yet, feel free to open an issue asking about your favorite feature. But please search before opening a new one. PR's welcome for any feature you want!
-- **[iocage Project Webside](https://iocage.github.io/)**
-- **[DOCUMENTATION](http://iocage.readthedocs.org/en/latest/index.html)**
-- **[Mailing list](https://groups.google.com/forum/#!forum/iocage)**
 
 ## Raising an issue:
 


### PR DESCRIPTION
This makes the links look a bit nicer and doesn't hide them in the warnings section.

I'd also recommend to set the website or docs URL via the GitHub Project Settings.