### PR TITLE
update/upgrade ALL processes last jail twice

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1802,6 +1802,7 @@ class IOCage(ioc_json.IOCZFS):
         """Updates a jail to the latest patchset."""
         if self._all:
             self.update_all()
+            return
 
         uuid, path = self.__check_jail_existence__()
         conf = ioc_json.IOCJson(
@@ -1901,6 +1902,7 @@ class IOCage(ioc_json.IOCZFS):
     def upgrade(self, release):
         if self._all:
             self.upgrade_all(release)
+            return
 
         if release is not None:
             host_release = float(os.uname()[2].rsplit("-", 1)[0].rsplit(


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Follow up to #748 ; missing `return` causes the last jail to be processed twice.