### PR TITLE
Add allow.vmm jail parameter

### DIFF
--- a/iocage.8
+++ b/iocage.8
@@ -1630,6 +1630,21 @@ Default: 0
 .Pp
 Source:
 .Xr mlock 2
+.It Pf allow_vmm= Op 0 | 1
+Allow access to
+.Xr vmm 4
+inside the jail. The
+.Xr vmm 4
+kernel module must be loaded for this to take effect.
+.Pp
+Note: This requires
+.Fx 12.0
+or later.
+.Pp
+Default: 0
+.Pp
+Source:
+.Xr jail 8
 .It host_hostuuid=UUID
 .Pp
 Default: UUID

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -174,7 +174,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '16'
+        version = '17'
 
         return version
 
@@ -476,6 +476,10 @@ class IOCConfiguration(IOCZFS):
         if not conf.get('rtsold'):
             conf['rtsold'] = 'off'
 
+        # Version 17 keys
+        if not conf.get('allow_vmm'):
+            conf['allow_vmm'] = '0'
+
         if not default:
             conf.update(jail_conf)
 
@@ -729,6 +733,7 @@ class IOCConfiguration(IOCZFS):
             'allow_quotas': '0',
             'allow_socket_af': '0',
             'allow_tun': '0',
+            'allow_vmm': '0',
             'cpuset': 'off',
             'rlimits': 'off',
             'memoryuse': 'off',
@@ -1513,6 +1518,7 @@ class IOCJson(IOCConfiguration):
             "allow_mount_zfs": ("0", "1"),
             "allow_quotas": ("0", "1"),
             "allow_socket_af": ("0", "1"),
+            "allow_vmm": ("0", "1"),
             "vnet_interfaces": ("string", ),
             # RCTL limits
             "cpuset": ("off", "on"),

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -126,6 +126,7 @@ class IOCStart(object):
         allow_mount_zfs = self.conf["allow_mount_zfs"]
         allow_quotas = self.conf["allow_quotas"]
         allow_socket_af = self.conf["allow_socket_af"]
+        allow_vmm = self.conf["allow_vmm"]
         devfs_ruleset = iocage_lib.ioc_common.generate_devfs_ruleset(self.conf)
         exec_prestart = self.conf["exec_prestart"]
         exec_poststart = self.conf["exec_poststart"]
@@ -262,9 +263,11 @@ class IOCStart(object):
         if userland_version < 12.0:
             _allow_mlock = ""
             _allow_mount_fusefs = ""
+            _allow_vmm = ""
         else:
             _allow_mlock = f"allow.mlock={allow_mlock}"
             _allow_mount_fusefs = f"allow.mount.fusefs={allow_mount_fusefs}"
+            _allow_vmm = f"allow.vmm={allow_vmm}"
 
         if self.conf["vnet"] == "off":
             ip4_addr = self.conf["ip4_addr"]
@@ -350,7 +353,8 @@ class IOCStart(object):
 
         parameters = [
             _sysvmsg, _sysvsem, _sysvshm, fdescfs, _allow_mlock, tmpfs,
-            _allow_mount_fusefs, f"allow.set_hostname={allow_set_hostname}",
+            _allow_mount_fusefs, _allow_vmm,
+            f"allow.set_hostname={allow_set_hostname}",
             f"mount.devfs={mount_devfs}",
             f"allow.raw_sockets={allow_raw_sockets}",
             f"allow.sysvipc={allow_sysvipc}",


### PR DESCRIPTION
FreeBSD 12.0-RELEASE has a new jail(8) parameter "allow.vmm" to allow
jails to access vmm(4).

This adds a new allow_vmm config value to iocage to support this and
bumps the config version to 17.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
