### PR TITLE
Leverage jail(8) for shared IP networking behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ build/
 venv-*/
 .python-version
 .pytest_cache/
+*~
 
 nvim\.core

--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -71,8 +71,13 @@ class IOCDestroy(object):
 
                     su.Popen(cmd).communicate()
 
+                    # Don't let a failure to unlink the jail conf stop the
+                    # destruction process.
                     if jail_conf_file.is_file():
-                        jail_conf_file.unlink()
+                        try:
+                            jail_conf_file.unlink()
+                        except OSError:
+                            pass
 
         for dataset in datasets.dependents:
             if "jails" not in dataset.name:

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -174,7 +174,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '17'
+        version = '16'
 
         return version
 
@@ -475,10 +475,6 @@ class IOCConfiguration(IOCZFS):
         # Version 16 keys
         if not conf.get('rtsold'):
             conf['rtsold'] = 'off'
-
-        # Version 17 keys
-        if not conf.get('legacy_networking_behaviour'):
-            conf['legacy_networking_behaviour'] = 'off'
 
         if not default:
             conf.update(jail_conf)
@@ -789,8 +785,7 @@ class IOCConfiguration(IOCZFS):
             'reservation': 'none',
             'depends': 'none',
             'vnet_interfaces': 'none',
-            'rtsold': 'off',
-            'legacy_networking_behaviour': 'off'
+            'rtsold': 'off'
         }
 
         try:
@@ -1481,7 +1476,6 @@ class IOCJson(IOCConfiguration):
             "vnet1_mac": ("string", ),
             "vnet2_mac": ("string", ),
             "vnet3_mac": ("string", ),
-            "legacy_networking_behaviour": ("off", "on"),
             # Jail Properties
             "devfs_ruleset": ("string", ),
             "exec_start": ("string", ),
@@ -1615,18 +1609,17 @@ class IOCJson(IOCConfiguration):
 
             if props[key][0] == "string":
                 if key == "ip4_addr":
-                    if props["legacy_networking_behaviour"] == "on":
-                        try:
-                            interface, ip = value.split("|")
+                    try:
+                        interface, ip = value.split("|")
 
-                            if interface == "DEFAULT":
-                                gws = netifaces.gateways()
-                                def_iface = gws["default"][netifaces.AF_INET][1]
+                        if interface == "DEFAULT":
+                            gws = netifaces.gateways()
+                            def_iface = gws["default"][netifaces.AF_INET][1]
 
-                                value = f"{def_iface}|{ip}"
-                                conf[key] = value
-                        except ValueError:
-                            pass
+                            value = f"{def_iface}|{ip}"
+                            conf[key] = value
+                    except ValueError:
+                        pass
                 elif key in [f'vnet{i}_mac' for i in range(0, 4)]:
                     if value and value != 'none':
                         value = value.replace(',', ' ')

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -174,7 +174,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '16'
+        version = '17'
 
         return version
 
@@ -475,6 +475,10 @@ class IOCConfiguration(IOCZFS):
         # Version 16 keys
         if not conf.get('rtsold'):
             conf['rtsold'] = 'off'
+
+        # Version 17 keys
+        if not conf.get('legacy_networking_behaviour'):
+            config['legacy_networking_behaviour'] = 'off'
 
         if not default:
             conf.update(jail_conf)
@@ -785,7 +789,8 @@ class IOCConfiguration(IOCZFS):
             'reservation': 'none',
             'depends': 'none',
             'vnet_interfaces': 'none',
-            'rtsold': 'off'
+            'rtsold': 'off',
+            'legacy_networking_behaviour': 'off'
         }
 
         try:

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -478,7 +478,7 @@ class IOCConfiguration(IOCZFS):
 
         # Version 17 keys
         if not conf.get('legacy_networking_behaviour'):
-            config['legacy_networking_behaviour'] = 'off'
+            conf['legacy_networking_behaviour'] = 'off'
 
         if not default:
             conf.update(jail_conf)

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1481,6 +1481,7 @@ class IOCJson(IOCConfiguration):
             "vnet1_mac": ("string", ),
             "vnet2_mac": ("string", ),
             "vnet3_mac": ("string", ),
+            "legacy_networking_behaviour": ("off", "on"),
             # Jail Properties
             "devfs_ruleset": ("string", ),
             "exec_start": ("string", ),

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1615,17 +1615,18 @@ class IOCJson(IOCConfiguration):
 
             if props[key][0] == "string":
                 if key == "ip4_addr":
-                    try:
-                        interface, ip = value.split("|")
+                    if props["legacy_networking_behaviour"] == "on":
+                        try:
+                            interface, ip = value.split("|")
 
-                        if interface == "DEFAULT":
-                            gws = netifaces.gateways()
-                            def_iface = gws["default"][netifaces.AF_INET][1]
+                            if interface == "DEFAULT":
+                                gws = netifaces.gateways()
+                                def_iface = gws["default"][netifaces.AF_INET][1]
 
-                            value = f"{def_iface}|{ip}"
-                            conf[key] = value
-                    except ValueError:
-                        pass
+                                value = f"{def_iface}|{ip}"
+                                conf[key] = value
+                        except ValueError:
+                            pass
                 elif key in [f'vnet{i}_mac' for i in range(0, 4)]:
                     if value and value != 'none':
                         value = value.replace(',', ' ')

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -392,6 +392,7 @@ class IOCStart(object):
         except OSError as err:
             msg = f"Error while writing jail config {err.filename}: " \
                    + "{err.strerror}"
+
             iocage_lib.ioc_common.logit({
                 "level": "EXCEPTION",
                 "message": msg

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -275,13 +275,7 @@ class IOCStart(object):
             net = []
 
             if ip4_addr != "none":
-                ip4_addrs = []
-
-                for _ip4_addr in ip4_addr.split(","):
-                    ip4_addrs.append(f"{_ip4_addr}")
-
-                ip4_addrs_str = ",".join(ip4_addrs)
-                net.append(f"ip4.addr={ip4_addrs_str}")
+                net.append(f"ip4.addr={ip4_addr}")
 
             if ip6_addr != "none":
                 net.append(f"ip6.addr={ip6_addr}")

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -369,8 +369,8 @@ class IOCStart(object):
             f"allow.mount.zfs={allow_mount_zfs}"
         ]
 
-        start_cmd = [x for x in ["jail", "-c"] + net + [
-            x for x in parameters if '1' in x] + [
+        start_parameters = [x for x in [
+            net + [x for x in parameters if '1' in x] + [
                 f'name=ioc-{self.uuid}',
                 f'host.domainname={host_domainname}',
                 f'host.hostname={host_hostname}',
@@ -392,7 +392,10 @@ class IOCStart(object):
                 f'exec.consolelog={self.iocroot}/log/ioc-'
                 f'{self.uuid}-console.log',
                 'persist'
+            ]
         ] if x != '']
+
+        start_cmd = ["jail", "-c"] + start_parameters
 
         start_env = {
             **os.environ,

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1095,4 +1095,4 @@ class IOCStart(object):
             jail_conf.write(f"ioc-{self.uuid} ")
             jail_conf.write("{\n\t")
             jail_conf.write(f"{config_parameters}")
-            jail_conf.write("\n}")
+            jail_conf.write("\n}\n")

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -277,6 +277,7 @@ class IOCStart(object):
 
             if ip4_addr != "none":
                 gws = netifaces.gateways()
+                ip4_addrs = []
 
                 for _ip4_addr in ip4_addr.split(","):
                     if "|" not in _ip4_addr and legacy_networking == "on":
@@ -287,7 +288,10 @@ class IOCStart(object):
                             # Best effort for default interface
                             pass
 
-                    net.append(f"ip4.addr={_ip4_addr}")
+                    ip4_addrs.append(f"{_ip4_addr}")
+
+                ip4_addrs_str = ",".join(ip4_addrs)
+                net.append(f"ip4.addr={ip4_addrs_str}")
 
             if ip6_addr != "none":
                 net.append(f"ip6.addr={ip6_addr}")

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -359,9 +359,10 @@ class IOCStart(object):
             f"allow.mount.zfs={allow_mount_zfs}"
         ]
 
-        start_parameters = [x for x in net +
-            [x for x in parameters if '1' in x] +
-            [
+        start_parameters = [
+            x for x in net
+            + [x for x in parameters if '1' in x]
+            + [
                 f'name=ioc-{self.uuid}',
                 f'host.domainname={host_domainname}',
                 f'host.hostname={host_hostname}',
@@ -1078,7 +1079,7 @@ class IOCStart(object):
         config_parameters = "\n\t".join(
             [x for x in map(lambda x: fix_param(x), parameters)
              if x is not None
-            ]
+             ]
         )
 
         # Write out the jail config.

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -392,7 +392,7 @@ class IOCStart(object):
             self.__write_jail_conf__(start_parameters)
         except OSError as err:
             msg = f"Error while writing jail config {err.filename}: " \
-                   + "{err.strerror}"
+                  + "{err.strerror}"
 
             iocage_lib.ioc_common.logit({
                 "level": "EXCEPTION",

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -273,21 +273,11 @@ class IOCStart(object):
             ip6_saddrsel = self.conf["ip6_saddrsel"]
             ip6 = self.conf["ip6"]
             net = []
-            legacy_networking = self.conf['legacy_networking_behaviour']
 
             if ip4_addr != "none":
-                gws = netifaces.gateways()
                 ip4_addrs = []
 
                 for _ip4_addr in ip4_addr.split(","):
-                    if "|" not in _ip4_addr and legacy_networking == "on":
-                        try:
-                            def_iface = gws["default"][netifaces.AF_INET][1]
-                            _ip4_addr = f'{def_iface}|{_ip4_addr}'
-                        except KeyError:
-                            # Best effort for default interface
-                            pass
-
                     ip4_addrs.append(f"{_ip4_addr}")
 
                 ip4_addrs_str = ",".join(ip4_addrs)

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -273,12 +273,13 @@ class IOCStart(object):
             ip6_saddrsel = self.conf["ip6_saddrsel"]
             ip6 = self.conf["ip6"]
             net = []
+            legacy_networking = self.conf['legacy_networking_behaviour']
 
             if ip4_addr != "none":
                 gws = netifaces.gateways()
 
                 for _ip4_addr in ip4_addr.split(","):
-                    if "|" not in _ip4_addr:
+                    if "|" not in _ip4_addr and legacy_networking == "on":
                         try:
                             def_iface = gws["default"][netifaces.AF_INET][1]
                             _ip4_addr = f'{def_iface}|{_ip4_addr}'

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -280,7 +280,7 @@ class IOCStop(object):
 
         try:
             # Build up a jail stop command.
-            cmd = ["jail"]
+            cmd = ["jail", "-q"]
 
             # We check for the existence of the jail.conf here as on iocage
             # upgrade people likely will not have these files. These files

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -234,7 +234,7 @@ class IOCStop(object):
                 and vnet == "off" and legacy_networking == "on" \
                 else False
 
-        if destroy_ip4_alias
+        if destroy_ip4_alias:
             gws = netifaces.gateways()
 
             for ip4 in ip4_addr.split(","):

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -286,6 +286,7 @@ class IOCStop(object):
             # upgrade people likely will not have these files. These files
             # will be written on the next jail start/restart.
             jail_conf_file = Path(f"/var/run/jail.ioc-{self.uuid}.conf")
+
             if jail_conf_file.is_file():
                 cmd.extend(["-f", f"{jail_conf_file}"])
 

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -29,6 +29,7 @@ import iocage_lib.ioc_common
 import iocage_lib.ioc_json
 import iocage_lib.ioc_list
 
+from pathlib import Path
 
 class IOCStop(object):
     """Stops a jail and unmounts the jails mountpoints."""
@@ -344,13 +345,14 @@ class IOCStop(object):
 
         try:
             # Build up a jail stop command.
-            from pathlib import Path
             cmd = ["jail"]
 
-            jail_config_file = Path(f"/var/run/jail.ioc-{self.uuid}.conf")
-            jail_config_arg = ""
-            if jail_config_file.is_file():
-                cmd.extend(["-f", f"{jail_config_file}"])
+            # We check for the existence of the jail.conf here as on iocage
+            # upgrade people likely will not have these files. These files
+            # will be written on the next jail start/restart.
+            jail_conf_file = Path(f"/var/run/jail.ioc-{self.uuid}.conf")
+            if jail_conf_file.is_file():
+                cmd.extend(["-f", f"{jail_conf_file}"])
 
             cmd.extend(["-r", f"ioc-{self.uuid}"])
 

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -343,8 +343,18 @@ class IOCStop(object):
                 silent=self.silent)
 
         try:
-            stop = su.check_call(["jail", "-r", f"ioc-{self.uuid}"],
-                                 stderr=su.PIPE)
+            # Build up a jail stop command.
+            from pathlib import Path
+            cmd = ["jail"]
+
+            jail_config_file = Path(f"/var/run/jail.ioc-{self.uuid}.conf")
+            jail_config_arg = ""
+            if jail_config_file.is_file():
+                cmd.extend(["-f", f"{jail_config_file}"])
+
+            cmd.extend(["-r", f"ioc-{self.uuid}"])
+
+            stop = su.check_call(cmd, stderr=su.PIPE)
         except su.CalledProcessError as err:
             stop = err.returncode
 

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -313,6 +313,9 @@ class IOCStop(object):
                 _callback=self.callback,
                 silent=self.silent)
 
+            if jail_conf_file.is_file():
+                jail_conf_file.unlink()
+
         poststop, poststop_err = iocage_lib.ioc_common.runscript(
             self.conf["exec_poststop"])
 

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -57,7 +57,6 @@ class IOCStop(object):
         dhcp = self.conf["dhcp"]
         exec_fib = self.conf["exec_fib"]
         devfs_ruleset = self.conf['devfs_ruleset']
-        legacy_networking = self.conf['legacy_networking_behaviour']
 
         if not self.status:
             msg = f"{self.uuid} is not running!"
@@ -230,70 +229,6 @@ class IOCStop(object):
                     },
                         _callback=self.callback,
                         silent=self.silent)
-
-        destroy_ip4_alias = True if ip4_addr not in ("inherit", "none") \
-                and vnet == "off" and legacy_networking == "on" \
-                else False
-
-        if destroy_ip4_alias:
-            gws = netifaces.gateways()
-
-            for ip4 in ip4_addr.split(","):
-                # Don't try to remove an alias if there's no interface.
-
-                if "|" not in ip4:
-                    try:
-                        def_iface = gws["default"][netifaces.AF_INET][1]
-                        ip4 = f'{def_iface}|{ip4}'
-                    except KeyError:
-                        # Best effort for default interface
-                        continue
-
-                try:
-                    iface, addr = ip4.split("/")[0].split("|")
-                    addr = addr.split()
-                    iocage_lib.ioc_common.checkoutput(
-                        ['ifconfig', iface] + addr + ['-alias'],
-                        stderr=su.STDOUT
-                    )
-                except su.CalledProcessError as err:
-                    if "Can't assign requested address" in \
-                            err.output.decode("utf-8"):
-                        # They may have a new address that somehow
-                        # didn't set correctly. We shouldn't bail on
-                        # that.
-                        pass
-                    elif not self.force:
-                        raise RuntimeError(
-                            "{}".format(
-                                err.output.decode("utf-8").strip()))
-
-        destroy_ip6_alias = True if ip6_addr not in ("inherit", "none") and \
-                vnet == "off" and legacy_networking == "on" else False
-
-        if destroy_ip6_alias:
-            for ip6 in ip6_addr.split(","):
-                # Don't try to remove an alias if there's no interface.
-
-                if "|" not in ip6:
-                    continue
-                try:
-                    iface, addr = ip6.split("/")[0].split("|")
-                    addr = addr.split()
-                    iocage_lib.ioc_common.checkoutput(
-                        ["ifconfig", iface, "inet6"] + addr + ["-alias"],
-                        stderr=su.STDOUT
-                    )
-                except su.CalledProcessError as err:
-                    if "Can't assign requested address" in \
-                            err.output.decode("utf-8"):
-                        # They may have a new address that somehow
-                        # didn't set correctly. We shouldn't bail on
-                        # that.
-                        pass
-                    elif not self.force:
-                        raise RuntimeError(
-                            "{}".format(err.output.decode("utf-8").strip()))
 
         # Clean up after our dynamic devfs rulesets
         ruleset = su.check_output(

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -313,8 +313,13 @@ class IOCStop(object):
                 _callback=self.callback,
                 silent=self.silent)
 
+            # If we have issues unlinking, don't let that get in the way. The
+            # jail is already stopped so we're happy.
             if jail_conf_file.is_file():
-                jail_conf_file.unlink()
+                try:
+                    jail_conf_file.unlink()
+                except OSError:
+                    pass
 
         poststop, poststop_err = iocage_lib.ioc_common.runscript(
             self.conf["exec_poststop"])

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -23,13 +23,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """This stops jails."""
 import subprocess as su
-import netifaces
 
 import iocage_lib.ioc_common
 import iocage_lib.ioc_json
 import iocage_lib.ioc_list
 
 from pathlib import Path
+
 
 class IOCStop(object):
     """Stops a jail and unmounts the jails mountpoints."""


### PR DESCRIPTION
As discussed in #758, this PR changes the behaviour of `iocage` to let `jail(8)` take on the heavy lifting of managing shared IP jails.

The main change to enable this behaviour is that `iocage` will now write out a `jail.conf` for each jail it manages under `/var/run`, it will then use these configs when starting and stopping the jails.
This allows users to (ip4 given as examples, but it works the same for ip6):
  - Have jailed shared with the host, managed via `/etc/rc.conf`, `ip4.addr=192.168.1.1`.
  - Have jails share IPs with each other, using the above.
  - Have `iocage` (really `jail(8)`) manage the addition and removal of aliases on jail start/stop, `ip4.addr=lo1|127.0.1.1`, etc.

The old behaviour of `iocage` trying to work out:
  - On start: If it should add the "primary" network interface to an `ip4_addr` that was given simply as `1.2.3.4`.
  - On stop: Which `ip4_addr` aliases it should remove via `ifconfig`.

have been completely removed. It would be possible to support both the old and new behaviour, but it gets quite complicated, and I'm not sure there's a good reason to keep them when FreeBSD can manage it via `jail(8)`.

Another small side effect of these changes was that we fixed a small bug where `iocage` could orphan addresses on interfaces if the `ip4_addr` was changed while a jail was running and the jail was then restarted. Vim backup files `*~` were also added to `.gitignore`.

I have not yet squashed this PR, as if changes are requested my history might be useful, but I will squash it if/when the PR is accepted.
I have also not yet fixed up the documentation, pending review of the work so far.

While testing this I've been managing 6-7 jails with varying combinations of address setups successfully, however, I only use shared IP behaviours so I have not tested `vnet` based jails. I believe they should be working as they were before, but someone else may want to test that.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
- [ ] Documentation updated
- [ ] Squashed