### PR TITLE
Fix various Tracebacks for non-root users

### DIFF
--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -51,6 +51,10 @@ class CommandFailed(ExceptionWithMsg):
     pass
 
 
+class CommandNeedsRoot(ExceptionWithMsg):
+    pass
+
+
 class JailMisconfigured(ExceptionWithMsg):
     pass
 

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -308,10 +308,10 @@ class IOCList(object):
                                 )
                         except KeyError:
                             pass
+                        except iocage_lib.ioc_exceptions.CommandNeedsRoot:
+                            admin_portal = "Admin Portal requires root"
                         except iocage_lib.ioc_exceptions.CommandFailed as e:
-                            admin_portal = b' '.join(
-                                e.message).decode() if os.geteuid() == 0 else \
-                                "Admin Portal requires root"
+                            admin_portal = b' '.join(e.message).decode()
 
                 except FileNotFoundError:
                     # They just didn't set a admin portal.

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1158,9 +1158,18 @@ class IOCage(ioc_json.IOCZFS):
             if prop == "state":
                 return state
             elif plugin:
-                _prop = prop.split(".")
-                props = ioc_json.IOCJson(path).json_plugin_get_value(
-                    _prop)
+                try:
+                    _prop = prop.split(".")
+                    props = ioc_json.IOCJson(path).json_plugin_get_value(
+                        _prop)
+                except ioc_exceptions.CommandNeedsRoot as err:
+                    ioc_common.logit(
+                        {
+                            'level': 'EXCEPTION',
+                            'message': err.message
+                        },
+                        _callback=self.callback,
+                        silent=False)
 
                 if isinstance(props, dict):
                     return json.dumps(props, indent=4)


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

This fixes a few Tracebacks that occur when running iocage as a non-privileged user, e.g.
- iocage list, the first time after bumping the config version
- iocage get -P, to get plugin specific properties either wants to start the jail or run jexec if the jails is already running


