### PR TITLE
Add ignore exceptions flag

### DIFF
--- a/iocage_cli/start.py
+++ b/iocage_cli/start.py
@@ -30,25 +30,31 @@ import iocage_lib.iocage as ioc
 __rootcmd__ = True
 
 
-@click.command(name="start", help="Starts the specified jails or ALL.")
-@click.option("--rc", default=False, is_flag=True,
-              help="Will start all jails with boot=on, in the specified"
-                   " order with smaller value for priority starting first.")
+@click.command(name='start', help='Starts the specified jails or ALL.')
+@click.option(
+    '--rc', default=False, is_flag=True,
+    help='Will start all jails with boot=on, in the specified order with '
+         'smaller value for priority starting first.'
+)
+@click.option(
+    '--ignore', '-i', default=False, is_flag=True,
+    help='Suppress exceptions for jails which fail to start'
+)
 @click.argument("jails", nargs=-1)
-def cli(rc, jails):
+def cli(rc, jails, ignore):
     """
     Looks for the jail supplied and passes the uuid, path and configuration
     location to start_jail.
     """
     if not jails and not rc:
         ioc_common.logit({
-            "level"  : "EXCEPTION",
-            "message": 'Usage: iocage start [OPTIONS] JAILS...\n'
+            'level': 'EXCEPTION',
+            'message': 'Usage: iocage start [OPTIONS] JAILS...\n'
                        '\nError: Missing argument "jails".'
         })
 
     if rc:
-        ioc.IOCage(rc=rc, silent=True).start()
+        ioc.IOCage(rc=rc, silent=True).start(ignore_exception=ignore)
     else:
         for jail in jails:
-            ioc.IOCage(jail=jail, rc=rc).start()
+            ioc.IOCage(jail=jail, rc=rc).start(ignore_exception=ignore)

--- a/iocage_cli/stop.py
+++ b/iocage_cli/stop.py
@@ -30,28 +30,40 @@ import iocage_lib.iocage as ioc
 __rootcmd__ = True
 
 
-@click.command(name="stop", help="Stops the specified jails or ALL.")
-@click.option("--rc", default=False, is_flag=True,
-              help="Will stop all jails with boot=on, in the specified"
-                   " order with higher value for priority stopping first.")
-@click.option("-f", "--force", default=False, is_flag=True,
-              help="Skips all pre-stop actions like stop services."
-                   "Gently shuts down and kills the jail process.")
+@click.command(name='stop', help='Stops the specified jails or ALL.')
+@click.option(
+    '--rc', default=False, is_flag=True,
+    help='Will stop all jails with boot=on, in the specified order with '
+         'higher value for priority stopping first.'
+)
+@click.option(
+    '-f', '--force', default=False, is_flag=True,
+    help='Skips all pre-stop actions like stop services. Gently shuts '
+         'down and kills the jail process.'
+)
+@click.option(
+    '--ignore', '-i', default=False, is_flag=True,
+    help='Suppress exceptions for jails which fail to stop'
+)
 @click.argument("jails", nargs=-1)
-def cli(rc, force, jails):
+def cli(rc, force, jails, ignore):
     """
     Looks for the jail supplied and passes the uuid, path and configuration
     location to stop_jail.
     """
     if not jails and not rc:
         ioc_common.logit({
-            "level"  : "EXCEPTION",
+            "level": "EXCEPTION",
             "message": 'Usage: iocage stop [OPTIONS] JAILS...\n'
                        '\nError: Missing argument "jails".'
         })
 
     if rc:
-        ioc.IOCage(rc=rc, silent=True).stop(force=force)
+        ioc.IOCage(rc=rc, silent=True).stop(
+            force=force, ignore_exception=ignore
+        )
     else:
         for jail in jails:
-            ioc.IOCage(jail=jail, rc=rc).stop(force=force)
+            ioc.IOCage(jail=jail, rc=rc).stop(
+                force=force, ignore_exception=ignore
+            )

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -70,7 +70,7 @@ class IOCStart(object):
             self.exec_fib = self.conf["exec_fib"]
             try:
                 self.__start_jail__()
-            except SystemExit as e:
+            except (Exception, SystemExit) as e:
                 if not suppress_exception:
                     raise e
 

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -46,8 +46,10 @@ class IOCStart(object):
     for them. It also finds any scripts the user supplies for exec_*
     """
 
-    def __init__(self, uuid, path, silent=False, callback=None,
-                 is_depend=False, unit_test=False):
+    def __init__(
+        self, uuid, path, silent=False, callback=None,
+        is_depend=False, unit_test=False, suppress_exception=False
+    ):
         self.uuid = uuid.replace(".", "_")
         self.path = path
         self.callback = callback
@@ -66,7 +68,11 @@ class IOCStart(object):
                                                    silent=True).json_set_value
 
             self.exec_fib = self.conf["exec_fib"]
-            self.__start_jail__()
+            try:
+                self.__start_jail__()
+            except SystemExit as e:
+                if not suppress_exception:
+                    raise e
 
     def __start_jail__(self):
         """

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -53,7 +53,7 @@ class IOCStop(object):
 
         try:
             self.__stop_jail__()
-        except SystemExit as e:
+        except (Exception, SystemExit) as e:
             if not suppress_exception:
                 raise e
 

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -34,7 +34,10 @@ from pathlib import Path
 class IOCStop(object):
     """Stops a jail and unmounts the jails mountpoints."""
 
-    def __init__(self, uuid, path, silent=False, callback=None, force=False):
+    def __init__(
+        self, uuid, path, silent=False, callback=None,
+        force=False, suppress_exception=False
+    ):
         self.pool = iocage_lib.ioc_json.IOCJson(" ").json_get_value("pool")
         self.iocroot = iocage_lib.ioc_json.IOCJson(
             self.pool).json_get_value("iocroot")
@@ -48,7 +51,11 @@ class IOCStop(object):
         self.callback = callback
         self.silent = silent
 
-        self.__stop_jail__()
+        try:
+            self.__stop_jail__()
+        except SystemExit as e:
+            if not suppress_exception:
+                raise e
 
     def __stop_jail__(self):
         ip4_addr = self.conf["ip4_addr"]


### PR DESCRIPTION
This commit introduces a flag for suppressing exceptions when starting/stopping jails. This can be useful when we have jails which cannot really start and we don't want the system to exit in this case.
Ticket: #65391