### PR TITLE
tkt-67800: Jail Configuration Class

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -38,6 +38,7 @@ import re
 import shlex
 import glob
 
+import iocage_lib.ioc_exceptions
 import iocage_lib.ioc_exec
 
 
@@ -787,12 +788,15 @@ def runscript(script):
     else:
         return False, 'Script is not executable!'
 
-    with iocage_lib.ioc_exec.IOCExec(
-        script, None, None, unjailed=True, decode=True
-    ) as _exec:
-        success, error = list(_exec)[0]
-
-    return success.rstrip('\n'), error.rstrip('\n')
+    try:
+        with iocage_lib.ioc_exec.IOCExec(
+            script, None, uuid='', unjailed=True, decode=True
+        ) as _exec:
+            success, error = list(_exec)[0]
+    except iocage_lib.ioc_exceptions.CommandFailed as e:
+        return '', f'Script returned non-zero status: {e}'
+    else:
+        return success.rstrip('\n'), error.rstrip('\n')
 
 
 def match_to_dir(iocroot, uuid, old_uuid=None):

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -802,6 +802,7 @@ def runscript(script):
         return False, 'Script is not executable!'
 
     success, output = safe_checkoutput(script, stderr=su.STDOUT)
+
     return success, output.rstrip('\n')
 
 

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -801,12 +801,8 @@ def runscript(script):
     else:
         return False, 'Script is not executable!'
 
-    try:
-        out = checkoutput(script, stderr=su.STDOUT)
-    except su.CalledProcessError as err:
-        return False, err.output.decode().rstrip('\n')
-
-    return True, out.rstrip('\n')
+    success, output = safe_checkoutput(script, stderr=su.STDOUT)
+    return success, output.rstrip('\n')
 
 
 def match_to_dir(iocroot, uuid, old_uuid=None):

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -789,14 +789,13 @@ def runscript(script):
         return False, 'Script is not executable!'
 
     try:
-        with iocage_lib.ioc_exec.IOCExec(
-            script, None, uuid='', unjailed=True, decode=True
-        ) as _exec:
-            success, error = list(_exec)[0]
+        output = iocage_lib.ioc_exec.SilentExec(
+            script, None, unjailed=True, decode=True
+        )
     except iocage_lib.ioc_exceptions.CommandFailed as e:
         return '', f'Script returned non-zero status: {e}'
     else:
-        return success.rstrip('\n'), error.rstrip('\n')
+        return output.stdout.rstrip('\n'), output.stderr.rstrip('\n')
 
 
 def match_to_dir(iocroot, uuid, old_uuid=None):

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -238,9 +238,7 @@ class IOCExec(object):
                 if not self.decode:
                     yield rtrn_stdout, rtrn_stderr
                 else:
-                    yield rtrn_stdout.decode('utf-8'), rtrn_stderr.decode(
-                        'utf-8'
-                    )
+                    yield rtrn_stdout.decode(), rtrn_stderr.decode()
 
         error = True if self.proc.returncode != 0 else False
 
@@ -257,7 +255,8 @@ class IOCExec(object):
 
             if error:
                 raise iocage_lib.ioc_exceptions.CommandFailed(
-                    list(stderr_queue))
+                    list(stderr_queue)
+                )
 
 
 class SilentExec(object):

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -262,4 +262,7 @@ class IOCExec(object):
 class SilentExec(object):
     def __init__(self, *args, **kwargs):
         with IOCExec(*args, **kwargs) as silent:  # noqa
-            pass
+            self.output = list(silent)
+
+        self.stdout = ''.join([i[0] for i in self.output])
+        self.stderr = ''.join([i[1] for i in self.output])

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -45,7 +45,7 @@ import random
 import pathlib
 
 
-class JailConfiguration(object):
+class JailRuntimeConfiguration(object):
     def __init__(self, jail_name, data=None):
         # If data is provided, we make sure that this object reflects
         # what data holds and not what the conf file already has etc

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -135,7 +135,7 @@ class JailConfiguration(object):
                 if k == 'name':
                     continue
                 if k in ('ip4.addr', 'ip6.addr'):
-                    v = ', '.join(v.split(','))
+                    v = ', '.join(map(str.strip, v.split(',')))
                 normalized_data[k] = v
             else:
                 # This is a boolean value

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -94,6 +94,7 @@ class JailConfiguration(object):
                 k, v = data.split('=', 1)
                 k = k.strip()
                 v = v.replace(';', '').strip()
+
                 if 'ip4.addr' in k:
                     ip4.append(v)
                 elif 'ip6.addr' in k:
@@ -108,9 +109,9 @@ class JailConfiguration(object):
                 self.read_data[data.replace(';', '').strip()] = None
 
         if ip4:
-            self.read_data['ip4.addr'] = ', '.join(ip4)
+            self.read_data['ip4.addr'] = ','.join(ip4)
         if ip6:
-            self.read_data['ip6.addr'] = ', '.join(ip6)
+            self.read_data['ip6.addr'] = ','.join(ip6)
 
     def sync_changes(self):
         # We are going to write out the changes which are present in self.data
@@ -135,7 +136,7 @@ class JailConfiguration(object):
                 if k == 'name':
                     continue
                 if k in ('ip4.addr', 'ip6.addr'):
-                    v = ', '.join(map(str.strip, v.split(',')))
+                    v = ','.join(map(str.strip, v.split(',')))
                 normalized_data[k] = v
             else:
                 # This is a boolean value

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -581,10 +581,15 @@ class IOCStart(object):
                     _callback=self.callback,
                     silent=self.silent
                 )
+
+                iocage_lib.ioc_stop.IOCStop(
+                    self.uuid, self.path, force=True, silent=True
+                )
+
             else:
                 iocage_lib.ioc_common.logit({
                     'level': 'INFO',
-                    'message': '  + Running poststop OK'
+                    'message': '  + Running poststart OK'
                 },
                     _callback=self.callback,
                     silent=self.silent

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -401,18 +401,10 @@ class IOCStart(object):
 
         # Write the config out to a file. We'll be starting the jail using this
         # config and it is required for stopping the jail too.
-        try:
-            self.__write_jail_conf__(start_parameters)
-        except OSError as err:
-            msg = f"Error while writing jail config {err.filename}: " \
-                  + "{err.strerror}"
-
-            iocage_lib.ioc_common.logit({
-                "level": "EXCEPTION",
-                "message": msg
-            },
-                _callback=self.callback,
-                silent=self.silent)
+        jail = iocage_lib.ioc_json.JailConfiguration(
+            self.uuid, start_parameters
+        )
+        jail.sync_changes()
 
         start_cmd = ["jail", "-f", f"/var/run/jail.ioc-{self.uuid}.conf", "-c"]
 
@@ -1095,8 +1087,3 @@ class IOCStart(object):
         ).split()
 
         return membermtu[5]
-
-    def __write_jail_conf__(self, parameters):
-        # This function is used in the lambda below.
-        jail = iocage_lib.ioc_json.JailConfiguration(self.uuid, parameters)
-        jail.sync_changes()

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -396,7 +396,7 @@ class IOCStart(object):
 
         # Write the config out to a file. We'll be starting the jail using this
         # config and it is required for stopping the jail too.
-        jail = iocage_lib.ioc_json.JailConfiguration(
+        jail = iocage_lib.ioc_json.JailRuntimeConfiguration(
             self.uuid, start_parameters
         )
         jail.sync_changes()

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1098,40 +1098,5 @@ class IOCStart(object):
 
     def __write_jail_conf__(self, parameters):
         # This function is used in the lambda below.
-        def fix_param(p):
-            # If the param is an assignable variable, check if we have to
-            # treat it specially.
-            if "=" in p:
-                key, value = p.split("=", 1)
-
-                # name is specified at the start of the jail config block.
-                # The None will be filtered out before writing the config.
-                if key == "name":
-                    return None
-
-                # IP addr lists are special and use +=
-                if key == "ip4.addr" or key == "ip6.addr":
-                    lines = []
-                    for addr in value.split(","):
-                        lines.append(f"{key} += \"{addr}\";")
-
-                    return "\n\t".join(lines)
-
-                return f"{key} = \"{value}\";"
-
-            # Just a boolean parameter
-            return f"{p};"
-
-        # Generate our parameter string to write to the config.
-        config_parameters = "\n\t".join(
-            [x for x in map(lambda x: fix_param(x), parameters)
-             if x is not None
-             ]
-        )
-
-        # Write out the jail config.
-        with open(f"/var/run/jail.ioc-{self.uuid}.conf", 'w') as jail_conf:
-            jail_conf.write(f"ioc-{self.uuid} ")
-            jail_conf.write("{\n\t")
-            jail_conf.write(f"{config_parameters}")
-            jail_conf.write("\n}\n")
+        jail = iocage_lib.ioc_json.JailConfiguration(self.uuid, parameters)
+        jail.sync_changes()

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -535,12 +535,13 @@ class IOCStart(object):
         with open(
             f'{self.iocroot}/log/{self.uuid}-console.log', 'a'
         ) as f:
-            with iocage_lib.ioc_exec.IOCExec(
+            output = iocage_lib.ioc_exec.SilentExec(
                 ['setfib', self.exec_fib, 'jexec', f'ioc-{self.uuid}']
-                + exec_start, None, uuid='', unjailed=True, decode=True
-            ) as _exec:
-                success, error = list(_exec)[0]
+                + exec_start, None, unjailed=True, decode=True
+            )
 
+            success = output.stdout
+            error = output.stderr
             f.write(success or error)
 
         if not success:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -567,9 +567,10 @@ class IOCStart(object):
             )
 
             # Running exec_poststart now
-            poststart_success, poststop_output = iocage_lib.ioc_common.runscript(
-                exec_poststart
-            )
+            poststart_success, poststop_output = \
+                iocage_lib.ioc_common.runscript(
+                    exec_poststart
+                )
 
             if not poststart_success:
                 iocage_lib.ioc_common.logit({

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -537,7 +537,7 @@ class IOCStart(object):
         ) as f:
             with iocage_lib.ioc_exec.IOCExec(
                 ['setfib', self.exec_fib, 'jexec', f'ioc-{self.uuid}']
-                + exec_start, None, None, unjailed=True, decode=True
+                + exec_start, None, uuid='', unjailed=True, decode=True
             ) as _exec:
                 success, error = list(_exec)[0]
 
@@ -583,7 +583,7 @@ class IOCStart(object):
 
                 iocage_lib.ioc_common.logit({
                     'level': 'EXCEPTION',
-                    'message': '  + Running exec_poststart FAILED\n'
+                    'message': '  + Executing exec_poststart FAILED\n'
                     f'ERROR:\n{poststart_error}\n\nRefusing to '
                     f'start {self.uuid}: exec_poststart failed'
                 },
@@ -594,7 +594,7 @@ class IOCStart(object):
             else:
                 iocage_lib.ioc_common.logit({
                     'level': 'INFO',
-                    'message': '  + Running poststart OK'
+                    'message': '  + Executing poststart OK'
                 },
                     _callback=self.callback,
                     silent=self.silent

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -193,7 +193,7 @@ class IOCStop(object):
         else:
             # We should remove all exec* keys from jail.conf and make sure
             # we force stop the jail process
-            jail_conf = iocage_lib.ioc_json.JailConfiguration(self.uuid)
+            jail_conf = iocage_lib.ioc_json.JailRuntimeConfiguration(self.uuid)
             for r_key in [
                 k for k in jail_conf.data if str(k).startswith('exec')
             ]:

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -113,12 +113,13 @@ class IOCStop(object):
 
             exec_stop = self.conf['exec_stop'].split()
             with open(f'{self.iocroot}/log/{self.uuid}-console.log', 'a') as f:
-                with iocage_lib.ioc_exec.IOCExec(
+                output = iocage_lib.ioc_exec.SilentExec(
                     ['setfib', exec_fib, 'jexec', f'ioc-{self.uuid}']
-                    + exec_stop, None, uuid='', unjailed=True, decode=True
-                ) as _exec:
-                    success, error = list(_exec)[0]
+                    + exec_stop, None, unjailed=True, decode=True
+                )
 
+                success = output.stdout
+                error = output.stderr
                 f.write(success or error)
 
             if error:

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -91,7 +91,7 @@ class IOCStop(object):
                 self.conf['exec_prestop']
             )
             if prestop_error:
-                msg = f'  + Running prestop FAILED\n' \
+                msg = f'  + Executing prestop FAILED\n' \
                     f'ERROR:\n{prestop_error}\n\n{failed_message}'
 
                 iocage_lib.ioc_common.logit({
@@ -102,7 +102,7 @@ class IOCStop(object):
                     silent=self.silent
                 )
             else:
-                msg = '  + Running prestop OK'
+                msg = '  + Executing prestop OK'
                 iocage_lib.ioc_common.logit({
                     'level': 'INFO',
                     'message': msg
@@ -115,7 +115,7 @@ class IOCStop(object):
             with open(f'{self.iocroot}/log/{self.uuid}-console.log', 'a') as f:
                 with iocage_lib.ioc_exec.IOCExec(
                     ['setfib', exec_fib, 'jexec', f'ioc-{self.uuid}']
-                    + exec_stop, None, None, unjailed=True, decode=True
+                    + exec_stop, None, uuid='', unjailed=True, decode=True
                 ) as _exec:
                     success, error = list(_exec)[0]
 
@@ -344,7 +344,7 @@ class IOCStop(object):
         if poststop_error:
             # This is the only exec case where we won't raise an exception
             # as jail has already stopped
-            msg = f'  + Running poststop FAILED\n{poststop_error}\n\n' \
+            msg = f'  + Executing poststop FAILED\n{poststop_error}\n\n' \
                 'Jail has been stopped but there may be leftovers ' \
                 'from exec_poststop failure'
             iocage_lib.ioc_common.logit({
@@ -355,7 +355,7 @@ class IOCStop(object):
                 silent=self.silent
             )
         else:
-            msg = '  + Running poststop OK'
+            msg = '  + Executing poststop OK'
             iocage_lib.ioc_common.logit({
                 'level': 'INFO',
                 'message': msg

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -84,7 +84,7 @@ class IOCStop(object):
             _callback=self.callback,
             silent=self.silent)
 
-        failed_message = 'Please use force flag to force stop jail'
+        failed_message = 'Please use --force flag to force stop jail'
         if not self.force:
             prestop_success, prestop_output = iocage_lib.ioc_common.runscript(
                 self.conf['exec_prestop']
@@ -343,8 +343,8 @@ class IOCStop(object):
             # This is the only exec case where we won't raise an exception
             # as jail has already stopped
             msg = f'  + Running poststop FAILED\n{poststop_output}\n\n' \
-                'Jail has been stopped but there might be leftovers ' \
-                'from poststop failure'
+                'Jail has been stopped but there may be leftovers ' \
+                'from exec_poststop failure'
             iocage_lib.ioc_common.logit({
                 'level': 'ERROR',
                 'message': msg


### PR DESCRIPTION
This PR introduces the following changes:
1) Introduce a class to better manage jail.conf files
2) Make sure we don't perform post stop operations if jail process fails to exit
3) Bug fix for a case where we ran a few exec* operations twice