### PR TITLE
Correct net property ip4/ip6 to valid jail(8) opts

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1554,10 +1554,10 @@ class IOCJson(IOCConfiguration):
             "ip4_saddrsel": (
                 "0",
                 "1", ),
-            "ip4": ("new", "inherit", "none"),
+            "ip4": ("new", "inherit", "disable"),
             "ip6_addr": ("string", ),
             "ip6_saddrsel": ("0", "1"),
-            "ip6": ("new", "inherit", "none"),
+            "ip6": ("new", "inherit", "disable"),
             "defaultrouter": ("string", ),
             "defaultrouter6": ("string", ),
             "resolver": ("string", ),


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Bugfix.

Seen behavior previously:
myserver:%>sudo iocage set ip6=disable jailname                                                                                                                                                                                                                      
disable is not a valid value for ip6.
Value must be new or inherit or none
myserver:%>sudo iocage set ip6=none jailname
Property: ip6 has been updated to none
myserver:%>sudo iocage start jailname
* Starting jailname
  + Start FAILED
jail: ip6: unknown jailsys value "none"
myserver:%>sudo vim /iocage/jails/jailname/config.json (manually set ip6 value to "disable")
myserver:%>sudo iocage start jailname
* Starting jailname
  + Started OK
  + Starting services OK

Seen behavior post-bugfix:
myserver:%>sudo iocage set ip6=disable jailname
Property: ip6 has been updated to disable
myserver:%>sudo iocage start jailname
* Starting jailname
  + Started OK
  + Starting services OK