### PR TITLE
Remove references to 'chroot' command from docs

### DIFF
--- a/doc/source/best-practices.rst
+++ b/doc/source/best-practices.rst
@@ -65,10 +65,3 @@ This section provides some generic guidelines and tips for working with
 
   Remove unnecessary snapshots, especially from jails where data is
   constantly changing!
-
-**Use** :command:`iocage chroot`
-
-  When accessing or modifying files in a template or stopped jail, use
-  :command:`iocage chroot [UUID | NAME] [Command ...]`. This
-  way you don't need to spin up the jail or convert the template.
-  

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -42,12 +42,10 @@ Done!
 
 **Customizing a template:**
 
-To make further customizations or just patch the template, there are two
-options:
+To make further customizations or just patch the template, you'll need
+to convert the template back into a jail, start it, and then convert it
+back to a template once you've completed your changes.
 
 * Convert the template back to a jail with
   :command:`iocage set template=no [UUID | NAME]`, then start the jail
   with :command:`iocage start [UUID | NAME]`.
-* If network access is unnecessary to make the changes, use
-  :command:`iocage chroot [UUID | NAME] [Command ...]` to run the
-  needed commands inside the template.

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -42,10 +42,50 @@ Done!
 
 **Customizing a template:**
 
-To make further customizations or just patch the template, you'll need
-to convert the template back into a jail, start it, and then convert it
-back to a template once you've completed your changes.
+To make changes to the template, you will need to know whether any existing
+jails are based on the template. Since modifying the template will require
+converting it back into a jail, it cannot be the base for any jails.
 
-* Convert the template back to a jail with
-  :command:`iocage set template=no [UUID | NAME]`, then start the jail
-  with :command:`iocage start [UUID | NAME]`.
+*** No jails based on the template ***
+
+1. Convert the template back into a jail:
+
+   :command:`iocage set template=no [UUID | NAME]`.
+
+2. Start the jail:
+
+   :command:`iocage start [UUID | NAME]`.
+
+3. Use any method you wish to connect to the jail and modify its contents.
+
+4. Stop the jail:
+
+   :command:`iocage stop [UUID | NAME]`.
+
+5. Convert the jail back into a template:
+
+   :command:`iocage set template=yes [UUID | NAME]`.
+
+*** Jails based on the template ***
+
+This process will create a new template, leaving the existing template
+and jails unaffected.
+
+1. Create a 'thick' jail from the template, so that it will be independent
+   from the template:
+
+   :command:`iocage create -T -t [UUID | NAME] -n newtemplate`.
+
+2. Start the jail:
+
+   :command:`iocage start newtemplate`.
+
+3. Use any method you wish to connect to the jail and modify its contents.
+
+4. Stop the jail:
+
+   :command:`iocage stop newtemplate`.
+
+5. Convert the jail into a template:
+
+   :command:`iocage set template=yes newtemplate`.


### PR DESCRIPTION
The 'chroot' command has been deprecated, so the docs should not refer to it
or suggest its use. For templates, this means that the only way to modify
a template is to convert it back into a jail, change it, and then convert to
a template again.

Closes issue #763