### PR TITLE
tkt-69267: Add --debug(-d) and --images(-i) flag to clean

### DIFF
--- a/iocage_cli/clean.py
+++ b/iocage_cli/clean.py
@@ -30,52 +30,66 @@ import iocage_lib.iocage as ioc
 __rootcmd__ = True
 
 
-@click.command(name="clean", help="Destroy specified dataset types.")
-@click.option("--force", "-f", default=False, is_flag=True,
-              help="Runs the command with no further user interaction.")
-@click.option("--all", "-a", "dataset_type", flag_value="all",
-              help="Destroy all iocage data that has been created.")
-@click.option("--jails", "-j", "dataset_type", flag_value="jails",
-              help="Destroy all jails created.")
-@click.option("--base", "-r", "-b", "dataset_type", flag_value="release",
-              help="Destroy all RELEASEs fetched.")
-@click.option("--template", "-t", "dataset_type", flag_value="template",
-              help="Destroy all templates.")
+@click.command(name='clean', help='Destroy specified dataset types.')
+@click.option('--force', '-f', default=False, is_flag=True,
+              help='Runs the command with no further user interaction.')
+@click.option('--all', '-a', 'dataset_type', flag_value='all',
+              help='Destroy all iocage data that has been created.')
+@click.option('--jails', '-j', 'dataset_type', flag_value='jails',
+              help='Destroy all jails created.')
+@click.option('--base', '-r', '-b', 'dataset_type', flag_value='release',
+              help='Destroy all RELEASEs fetched.')
+@click.option('--template', '-t', 'dataset_type', flag_value='template',
+              help='Destroy all templates.')
+@click.option('--images', '-i', 'dataset_type', flag_value='images',
+              help='Destroy all exports created.')
+@click.option('--debug', '-d', 'dataset_type', flag_value='debug',
+              help='Destroy all debugs created.')
 def cli(force, dataset_type):
     """Calls the correct destroy function."""
-    if dataset_type == "jails":
+    if dataset_type == 'jails':
         msg = {
-            "level"  : "WARNING",
-            "message": "\nThis will destroy ALL jails and any "
-                       "snapshots on a RELEASE,"
-                       "including templates!"
+            'level': 'WARNING',
+            'message': '\nThis will destroy ALL jails and any '
+                       'snapshots on a RELEASE,'
+                       'including templates!'
         }
-    elif dataset_type == "all":
+    elif dataset_type == 'all':
         msg = {
-            "level"  : "WARNING",
-            "message": "\nThis will destroy ALL iocage data!"
+            'level': 'WARNING',
+            'message': '\nThis will destroy ALL iocage data!'
         }
-    elif dataset_type == "release":
+    elif dataset_type == 'release':
         msg = {
-            "level"  : "WARNING",
-            "message": "\nThis will destroy ALL fetched RELEASES and"
-                       " jails/templates created from them!"
+            'level': 'WARNING',
+            'message': '\nThis will destroy ALL fetched RELEASES and'
+                       ' jails/templates created from them!'
         }
-    elif dataset_type == "template":
+    elif dataset_type == 'template':
         msg = {
-            "level"  : "WARNING",
-            "message": "This will destroy ALL templates and jails"
-                       " created from them!"
+            'level': 'WARNING',
+            'message': 'This will destroy ALL templates and jails'
+                       ' created from them!'
+        }
+    elif dataset_type == 'images':
+        msg = {
+            'level': 'WARNING',
+            'message': 'This will destroy ALL exports created!'
+        }
+    elif dataset_type == 'debug':
+        msg = {
+            'level': 'WARNING',
+            'message': 'This will destroy ALL debugs created!'
         }
     else:
         ioc_common.logit({
-            "level"  : "EXCEPTION",
-            "message": "Please specify a dataset type to clean!"
+            'level': 'EXCEPTION',
+            'message': 'Please specify a dataset type to clean!'
         })
 
     if not force:
         ioc_common.logit(msg)
-        if not click.confirm("\nAre you sure?"):
+        if not click.confirm('\nAre you sure?'):
             exit()
 
     ioc.IOCage(skip_jails=True).clean(dataset_type)

--- a/iocage_cli/clean.py
+++ b/iocage_cli/clean.py
@@ -44,7 +44,8 @@ __rootcmd__ = True
 @click.option('--images', '-i', 'dataset_type', flag_value='images',
               help='Destroy all exports created.')
 @click.option('--debug', '-d', 'dataset_type', flag_value='debug',
-              help='Destroy all debugs created.')
+              help='Destroy all debugs created in the default debug directory.'
+              )
 def cli(force, dataset_type):
     """Calls the correct destroy function."""
     if dataset_type == 'jails':
@@ -79,7 +80,7 @@ def cli(force, dataset_type):
     elif dataset_type == 'debug':
         msg = {
             'level': 'WARNING',
-            'message': 'This will destroy ALL debugs created!'
+            'message': 'This will destroy ALL debugs created at iocage/debug!'
         }
     else:
         ioc_common.logit({

--- a/iocage_cli/clean.py
+++ b/iocage_cli/clean.py
@@ -53,7 +53,7 @@ def cli(force, dataset_type):
             'level': 'WARNING',
             'message': '\nThis will destroy ALL jails and any '
                        'snapshots on a RELEASE,'
-                       'including templates!'
+                       ' including templates!'
         }
     elif dataset_type == 'all':
         msg = {

--- a/iocage_lib/ioc_clean.py
+++ b/iocage_lib/ioc_clean.py
@@ -26,13 +26,17 @@
 import iocage_lib.ioc_common
 import iocage_lib.ioc_destroy
 import iocage_lib.ioc_json
+import shutil
 
 
-class IOCClean(object):
+class IOCClean(iocage_lib.ioc_json.IOCZFS):
     """Cleans datasets and snapshots of a given type."""
 
     def __init__(self, callback=None, silent=False):
-        self.pool = iocage_lib.ioc_json.IOCJson().json_get_value("pool")
+        super().__init__()
+        self.pool = iocage_lib.ioc_json.IOCJson().json_get_value('pool')
+        self.iocroot = iocage_lib.ioc_json.IOCJson(self.pool).json_get_value(
+            'iocroot')
 
         self.callback = callback
         self.silent = silent
@@ -40,61 +44,63 @@ class IOCClean(object):
     def clean_jails(self):
         """Cleans all jails and their respective snapshots."""
         iocage_lib.ioc_common.logit({
-            "level"  : "INFO",
-            "message": "Cleaning iocage/jails"
+            'level': 'INFO',
+            'message': 'Cleaning iocage/jails'
         },
             _callback=self.callback,
             silent=self.silent)
 
         iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(
-            f"{self.pool}/iocage/jails",
-            clean=True)
+            f'{self.pool}/iocage/jails',
+            clean=True
+        )
 
     def clean_releases(self):
         """Cleans all releases and the jails created from them."""
         iocage_lib.ioc_common.logit({
-            "level"  : "INFO",
-            "message": "Cleaning iocage/download"
+            'level': 'INFO',
+            'message': 'Cleaning iocage/download'
         },
             _callback=self.callback,
             silent=self.silent)
 
         iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(
-            f"{self.pool}/iocage/download",
-            clean=True)
+            f'{self.pool}/iocage/download',
+            clean=True
+        )
 
         iocage_lib.ioc_common.logit({
-            "level"  : "INFO",
-            "message": "Cleaning iocage/releases"
+            'level': 'INFO',
+            'message': 'Cleaning iocage/releases'
         },
             _callback=self.callback,
             silent=self.silent)
 
         iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(
-            f"{self.pool}/iocage/releases",
+            f'{self.pool}/iocage/releases',
             clean=True)
 
     def clean_all(self):
         """Cleans everything related to iocage."""
-        datasets = ("iocage", "iocage/download", "iocage/images",
-                    "iocage/jails", "iocage/log", "iocage/releases",
-                    "iocage/templates")
+        datasets = ('iocage', 'iocage/download', 'iocage/images',
+                    'iocage/jails', 'iocage/log', 'iocage/releases',
+                    'iocage/templates')
 
         for dataset in reversed(datasets):
             iocage_lib.ioc_common.logit({
-                "level"  : "INFO",
-                "message": f"Cleaning {dataset}"
+                'level': 'INFO',
+                'message': f'Cleaning {dataset}'
             },
                 _callback=self.callback,
                 silent=self.silent)
 
             iocage_lib.ioc_destroy.IOCDestroy().__destroy_parse_datasets__(
-                f"{self.pool}/{dataset}", clean=True)
+                f'{self.pool}/{dataset}', clean=True)
 
     def clean_templates(self):
         """Cleans all templates and their respective children."""
         iocage_lib.ioc_common.logit({
-            "level"  : "INFO",
+            "level": "INFO",
             "message": "Cleaning iocage/templates"
         },
             _callback=self.callback,
@@ -103,3 +109,29 @@ class IOCClean(object):
         iocage_lib.ioc_destroy.IOCDestroy().__destroy_parse_datasets__(
             f"{self.pool}/iocage/templates",
             clean=True)
+
+    def clean_images(self):
+        """Destroys the images dataset"""
+        iocage_lib.ioc_common.logit({
+            'level': 'INFO',
+            'message': 'Cleaning iocage/images'
+        },
+            _callback=self.callback,
+            silent=self.silent)
+
+        self.zfs_destroy_dataset(f'{self.pool}/iocage/images', force=True)
+
+    def clean_debug(self):
+        """Removes the debug directory"""
+        iocage_lib.ioc_common.logit({
+            'level': 'INFO',
+            'message': 'Cleaning iocage/debug'
+        },
+            _callback=self.callback,
+            silent=self.silent)
+
+        try:
+            shutil.rmtree(f'{self.iocroot}/debug')
+        except Exception:
+            # Doesn't exist, we don't care
+            pass

--- a/iocage_lib/ioc_clean.py
+++ b/iocage_lib/ioc_clean.py
@@ -33,7 +33,7 @@ class IOCClean(iocage_lib.ioc_json.IOCZFS):
     """Cleans datasets and snapshots of a given type."""
 
     def __init__(self, callback=None, silent=False):
-        super().__init__()
+        super().__init__(callback)
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value('pool')
         self.iocroot = iocage_lib.ioc_json.IOCJson(self.pool).json_get_value(
             'iocroot')

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -44,10 +44,11 @@ import iocage_lib.ioc_exec
 
 def callback(_log, callback_exception):
     """Helper to call the appropriate logging level"""
-    log = logging.getLogger("iocage")
-    level = _log["level"]
-    message = _log["message"]
-    force_raise = _log.get("force_raise")
+    log = logging.getLogger('iocage')
+    level = _log['level']
+    message = _log['message']
+    force_raise = _log.get('force_raise')
+    suppress_log = _log.get('suppress_log')
 
     if level == 'CRITICAL':
         log.critical(message)
@@ -74,7 +75,8 @@ def callback(_log, callback_exception):
                 ):
                     message = '\n'.join(message)
 
-                log.error(message)
+                if not suppress_log:
+                    log.error(message)
 
                 if force_raise:
                     raise callback_exception(message)

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -109,6 +109,7 @@ class IOCCreate(object):
         import iocage_lib.ioc_destroy  # Circular dep
         start = False
         is_template = False
+        source_template = None
         rtsold_enable = 'NO'
 
         if iocage_lib.ioc_common.match_to_dir(self.iocroot, jail_uuid):
@@ -151,6 +152,7 @@ class IOCCreate(object):
                     except KeyError:
                         # Thick jails won't have this
                         cloned_release = None
+                    source_template = self.release
                 elif self.clone:
                     _type = "jails"
                     clone_path = f"{self.iocroot}/{_type}/{self.release}"
@@ -211,7 +213,9 @@ class IOCCreate(object):
                 if cloned_release is None:
                     cloned_release = self.release
 
-                config = self.create_config(jail_uuid, cloned_release)
+                config = self.create_config(
+                    jail_uuid, cloned_release, source_template
+                )
             else:
                 clone_config = f"{self.iocroot}/jails/{jail_uuid}/config.json"
                 clone_fstab = f"{self.iocroot}/jails/{jail_uuid}/fstab"
@@ -609,7 +613,7 @@ class IOCCreate(object):
 
         return jail_uuid
 
-    def create_config(self, jail_uuid, release):
+    def create_config(self, jail_uuid, release, source_template):
         """
         Create the jail configuration with the minimal needed defaults.
         If self.thickconfig is True, it will create a jail with all properties.
@@ -628,6 +632,9 @@ class IOCCreate(object):
             d_conf = iocage_lib.ioc_json.IOCJson().check_default_config()
             jail_props.update(d_conf)
             jail_props['CONFIG_TYPE'] = 'THICK'
+
+        if source_template is not None:
+            jail_props['source_template'] = source_template
 
         return jail_props
 

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -30,7 +30,6 @@ import subprocess as su
 import uuid
 
 import iocage_lib.ioc_common
-import iocage_lib.ioc_destroy
 import iocage_lib.ioc_exec
 import iocage_lib.ioc_fstab
 import iocage_lib.ioc_json
@@ -77,6 +76,7 @@ class IOCCreate(object):
 
     def create_jail(self):
         """Helper to catch SIGINT"""
+        import iocage_lib.ioc_destroy  # Circular dep
 
         if self.uuid:
             jail_uuid = self.uuid
@@ -106,6 +106,7 @@ class IOCCreate(object):
         jail from that. The user can also specify properties to override the
         defaults.
         """
+        import iocage_lib.ioc_destroy  # Circular dep
         start = False
         is_template = False
         rtsold_enable = 'NO'

--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -180,7 +180,6 @@ class IOCDestroy(iocage_lib.ioc_json.IOCZFS):
             # We are purposely not using -R as those will hit templates
             # and we are not using IOCSnapshot for perfomance
             for dataset in self.release_snapshots:
-                print(dataset)
                 su.run(
                     [
                         'zfs',

--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -30,7 +30,6 @@ import iocage_lib.ioc_json
 import iocage_lib.ioc_stop
 import libzfs
 
-from contextlib import suppress
 from pathlib import Path
 
 

--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -39,7 +39,7 @@ class IOCDestroy(iocage_lib.ioc_json.IOCZFS):
     destroy that as well.
     """
     def __init__(self, callback=None):
-        super().__init__()
+        super().__init__(callback)
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value('pool')
         self.iocroot = iocage_lib.ioc_json.IOCJson(
             self.pool).json_get_value('iocroot')

--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -143,7 +143,12 @@ class IOCDestroy(iocage_lib.ioc_json.IOCZFS):
                 su.run(command, stderr=su.PIPE)
 
         if self.j_conf is not None:
-            release = self.j_conf['cloned_release']
+            try:
+                release = self.j_conf['cloned_release']
+            except KeyError:
+                # Thick jails
+                release = self.j_conf['release']
+
             release_snap = self.zfs_get_snapshot(
                 f'{self.pool}/iocage/releases/{release}/root@{uuid}'
             )

--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -192,7 +192,7 @@ class IOCDestroy(iocage_lib.ioc_json.IOCZFS):
                         '-r',
                         f'{self.pool}/iocage/releases@{dataset}'
                     ],
-                    capture_output=True
+                    stdout=su.PIPE, stderr=su.PIPE
                 )
 
     def __destroy_parse_datasets__(self, path, clean=False, stop=True):

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -64,7 +64,7 @@ class IOCFetch(iocage_lib.ioc_json.IOCZFS):
                  files=('MANIFEST', 'base.txz', 'lib32.txz', 'src.txz'),
                  silent=False,
                  callback=None):
-        super().__init__()
+        super().__init__(callback)
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value("pool")
         self.iocroot = iocage_lib.ioc_json.IOCJson(
             self.pool).json_get_value("iocroot")

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -224,8 +224,9 @@ class IOCSnapshot(object):
 
 class IOCZFS(object):
     # TODO: We should use a context manager for libzfs
-    def __init__(self):
+    def __init__(self, callback=None):
         self.zfs = libzfs.ZFS(history=True, history_prefix="<iocage>")
+        self.callback = callback
 
     @property
     def iocroot_path(self):
@@ -433,7 +434,7 @@ class Release(Resource):
 
 class IOCConfiguration(IOCZFS):
     def __init__(self, location, checking_datasets, silent, callback):
-        super().__init__()
+        super().__init__(callback)
         self.location = location
         self.silent = silent
         self.callback = callback

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -337,7 +337,7 @@ class IOCZFS(object):
 
         try:
             su.run(
-                cmd + [identifier], check=True, capture_output=True
+                cmd + [identifier], check=True, stdout=su.PIPE, stderr=su.PIPE
             )
         except su.CalledProcessError as e:
             if force:
@@ -357,7 +357,7 @@ class IOCZFS(object):
         try:
             datasets = list(su.run(
                 ['zfs', 'list', '-rHo', 'name', identifier],
-                check=True, capture_output=True
+                check=True, stdout=su.PIPE, stderr=su.PIPE
             ).stdout.decode().split())
         except su.CalledProcessError as e:
             iocage_lib.ioc_common.logit(

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -262,6 +262,18 @@ class IOCZFS(object):
         return self.zfs_get_dataset_and_dependents(self.iocroot_path)
         # Returns a list of all datasets
 
+    @property
+    def release_snapshots(self):
+        # Returns all jail snapshots on the RELEASE
+        rel_dir = pathlib.Path(f'{self.iocroot_path}/releases')
+        snaps = []
+
+        # Quicker than asking zfs and parsing
+        for snap in rel_dir.glob('**/root/.zfs/snapshot/*'):
+            snaps.append(snap.name)
+
+        return snaps
+
     def _zfs_get_properties(self, identifier):
         p_dict = {}
 

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -257,6 +257,11 @@ class IOCZFS(object):
 
         return []
 
+    @property
+    def iocroot_datasets(self):
+        return self.zfs_get_dataset_and_dependents(self.iocroot_path)
+        # Returns a list of all datasets
+
     def _zfs_get_properties(self, identifier):
         p_dict = {}
 
@@ -284,6 +289,8 @@ class IOCZFS(object):
     def zfs_get_property(self, identifier, key):
         with ioc_exceptions.ignore_exceptions(Exception):
             return self._zfs_get_properties(identifier)[key]
+        except Exception:
+            return '-'
 
         return '-'
 

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -45,15 +45,16 @@ class IOCStop(object):
             self.pool).json_get_value("iocroot")
         self.uuid = uuid.replace(".", "_")
         self.path = path
-        self.conf = iocage_lib.ioc_json.IOCJson(path).json_get_value('all')
         self.force = force
-        self.status, self.jid = iocage_lib.ioc_list.IOCList().list_get_jid(
-            uuid)
-        self.nics = self.conf["interfaces"]
         self.callback = callback
         self.silent = silent
 
         try:
+            self.conf = iocage_lib.ioc_json.IOCJson(
+                path, suppress_log=True).json_get_value('all')
+            self.status, self.jid = iocage_lib.ioc_list.IOCList().list_get_jid(
+                uuid)
+            self.nics = self.conf['interfaces']
             self.__stop_jail__()
         except (Exception, SystemExit) as e:
             if not suppress_exception:

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -45,7 +45,7 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
                  silent=False,
                  callback=None,
                  ):
-        super().__init__()
+        super().__init__(callback)
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value("pool")
         self.iocroot = iocage_lib.ioc_json.IOCJson(
             self.pool).json_get_value("iocroot")

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -441,44 +441,59 @@ class IOCage(ioc_json.IOCZFS):
 
     def clean(self, d_type):
         """Destroys all of a specified dataset types."""
-
-        if d_type == "jails":
+        if d_type == 'jails':
             ioc_clean.IOCClean(silent=self.silent).clean_jails()
             ioc_common.logit(
                 {
-                    "level": "INFO",
-                    "message": "All iocage jail datasets have been destroyed."
+                    'level': 'INFO',
+                    'message': 'All iocage jail datasets have been destroyed.'
                 },
                 _callback=self.callback,
                 silent=self.silent)
-        elif d_type == "all":
+        elif d_type == 'all':
             ioc_clean.IOCClean(silent=self.silent).clean_all()
             ioc_common.logit(
                 {
-                    "level": "INFO",
-                    "message": "All iocage datasets have been destroyed."
+                    'level': 'INFO',
+                    'message': 'All iocage datasets have been destroyed.'
                 },
                 _callback=self.callback,
                 silent=self.silent)
-        elif d_type == "release":
+        elif d_type == 'release':
             ioc_clean.IOCClean(silent=self.silent).clean_releases()
             ioc_common.logit(
                 {
-                    "level":
-                    "INFO",
-                    "message":
-                    "All iocage RELEASE and jail datasets have been"
-                    " destroyed."
+                    'level': 'INFO',
+                    'message': 'All iocage RELEASE and jail datasets have been'
+                               ' destroyed.'
                 },
                 _callback=self.callback,
                 silent=self.silent)
-        elif d_type == "template":
+        elif d_type == 'template':
             ioc_clean.IOCClean(silent=self.silent).clean_templates()
             ioc_common.logit(
                 {
-                    "level": "INFO",
-                    "message":
-                    "All iocage template datasets have been destroyed."
+                    'level': 'INFO',
+                    'message':
+                    'All iocage template datasets have been destroyed.'
+                },
+                _callback=self.callback,
+                silent=self.silent)
+        elif d_type == 'images':
+            ioc_clean.IOCClean(silent=self.silent).clean_images()
+            ioc_common.logit(
+                {
+                    'level': 'INFO',
+                    'message': 'The iocage images dataset has been destroyed.'
+                },
+                _callback=self.callback,
+                silent=self.silent)
+        elif d_type == 'debug':
+            ioc_clean.IOCClean(silent=self.silent).clean_debug()
+            ioc_common.logit(
+                {
+                    'level': 'INFO',
+                    'message': 'All iocage debugs have been destroyed.'
                 },
                 _callback=self.callback,
                 silent=self.silent)

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -51,7 +51,7 @@ import libzfs
 class PoolAndDataset(ioc_json.IOCZFS):
 
     def __init__(self):
-        super().__init__(callback)
+        super().__init__()
         self.pool = ioc_json.IOCJson().json_get_value("pool")
 
     def get_pool(self):

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -51,7 +51,7 @@ import libzfs
 class PoolAndDataset(ioc_json.IOCZFS):
 
     def __init__(self):
-        super().__init__()
+        super().__init__(callback)
         self.pool = ioc_json.IOCJson().json_get_value("pool")
 
     def get_pool(self):
@@ -103,7 +103,7 @@ class IOCage(ioc_json.IOCZFS):
                  activate=False,
                  skip_jails=False,
                  ):
-        super().__init__()
+        super().__init__(callback)
         self.rc = rc
 
         # FreeNAS won't be entering through the CLI, so we set sane defaults

--- a/tests/functional_tests/0013_import_test.py
+++ b/tests/functional_tests/0013_import_test.py
@@ -61,10 +61,3 @@ def test_01_import_jail(invoke_cli, jail, skip_test, remove_file, zfs):
     )
 
     assert jail.exists is True, f'{exported_jail} jail did not import'
-
-    # Let's do a clean up on the exported files
-    for file in os.listdir(images_dataset_path):
-        remove_file(os.path.join(images_dataset_path, file))
-
-    assert not os.listdir(images_dataset_path) is True, \
-        f'Failed to clean {images_dataset_path}'

--- a/tests/functional_tests/9999_ioc_clean_test.py
+++ b/tests/functional_tests/9999_ioc_clean_test.py
@@ -23,7 +23,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
-import shutil
 
 import pytest
 
@@ -35,13 +34,6 @@ require_zpool = pytest.mark.require_zpool
 @require_root
 @require_zpool
 def test_clean(invoke_cli, zfs):
-    iocage_dataset = zfs.iocage_dataset
-
-    for d in ('debug', 'debug2'):
-        p = os.path.join(iocage_dataset['mountpoint'], d)
-        if os.path.exists(p):
-            shutil.rmtree(p)
-
     # Unless we change directory (not sure why) this will crash pytest.
     os.chdir('/')
     actions = [['-j', '-f'], ['-t', '-f'], ['-a', '-f']]


### PR DESCRIPTION
Also switch over to subprocess zfs as occasionally the base dataset would not be destroyed properly by py-libzfs.

FreeNAS Ticket: #69267