### PR TITLE
tkt-70977: Add interactive upgrade variable

### DIFF
--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -268,3 +268,50 @@ class SilentExec(object):
         join_str = b'' if not decode else ''
         self.stdout = join_str.join([i[0] for i in self.output])
         self.stderr = join_str.join([i[1] for i in self.output])
+
+
+class InteractiveExec(IOCExec):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not self.unjailed:
+            if not self.uuid or self.uuid is None:
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'EXCEPTION',
+                        'message': 'UUID is required'
+                    },
+                    exception=iocage_lib.ioc_exceptions.ValueNotFound,
+                    _callback=self.callback)
+
+            if not self.path or self.path is None:
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'EXCEPTION',
+                        'message': 'Path is required'
+                    },
+                    exception=iocage_lib.ioc_exceptions.ValueNotFound,
+                    _callback=self.callback)
+
+            if not self.status:
+                iocage_lib.ioc_start.IOCStart(
+                    self.uuid, self.path, silent=True
+                )
+                self.status, _ = iocage_lib.ioc_list.IOClist(
+                    'jid', uuid=self.uuid
+                )
+
+        try:
+            su.run(
+                self.cmd, check=True, env=self.su_env
+            )
+        except su.CalledProcessError:
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'EXCEPTION',
+                    'message': f'Command: {" ".join(self.command)} failed!'
+                },
+                exception=iocage_lib.ioc_exceptions.CommandFailed,
+                _callback=self.callback)
+        except Exception:
+            raise

--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -100,8 +100,8 @@ class IOCExec(object):
                     user = self.host_user
 
                 self.cmd = [
-                    "/usr/sbin/setfib", exec_fib, "jexec", flag, user,
-                    f"ioc-{self.uuid}"
+                    '/usr/sbin/setfib', exec_fib, 'jexec', flag, user,
+                    f'ioc-{self.uuid.replace(".", "_")}'
                 ] + list(self.command)
 
     def __enter__(self):
@@ -156,6 +156,7 @@ class IOCExec(object):
                     "jail", "plugin", "pluginv2", "clonejail"):
                 iocage_lib.ioc_start.IOCStart(self.uuid, self.path,
                                               silent=True)
+                self.status = True
             elif self.conf["type"] == "basejail":
                 iocage_lib.ioc_common.logit(
                     {
@@ -186,12 +187,13 @@ class IOCExec(object):
                     },
                     _callback=self.callback)
 
-            iocage_lib.ioc_common.logit(
-                {
-                    "level": "INFO",
-                    "message": "\nCommand output:"
-                },
-                _callback=self.callback)
+            if not self.skip:
+                iocage_lib.ioc_common.logit(
+                    {
+                        "level": "INFO",
+                        "message": "\nCommand output:"
+                    },
+                    _callback=self.callback)
 
     def exec_jail(self):
         # Courtesy of @william-gr

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -42,10 +42,11 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
     def __init__(self,
                  new_release,
                  path,
+                 interactive=True,
                  silent=False,
                  callback=None,
                  ):
-        super().__init__(callback)
+        super().__init__()
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value("pool")
         self.iocroot = iocage_lib.ioc_json.IOCJson(
             self.pool).json_get_value("iocroot")
@@ -65,6 +66,7 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
         self._freebsd_version = f"{self.iocroot}/jails/" \
             f"{self.uuid}/root/bin/freebsd-version"
         self.date = datetime.datetime.utcnow().strftime("%F")
+        self.interactive = interactive
         self.silent = silent
 
         path = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:'\
@@ -78,6 +80,8 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
         }
 
         self.callback = callback
+        # Work around for https://github.com/freebsd/freebsd/commit/bffa924f
+        os.environ['UNAME_r'] = self.jail_release
 
     def upgrade_jail(self):
         tmp_dataset = self.zfs_get_dataset_name('/tmp')
@@ -102,8 +106,9 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
 
         self.__upgrade_check_conf__()
 
-        f = "https://raw.githubusercontent.com/freebsd/freebsd" \
-            "/master/usr.sbin/freebsd-update/freebsd-update.sh"
+        f_rel = f'{self.new_release.rsplit("-RELEASE")[0]}.0'
+        f = 'https://raw.githubusercontent.com/freebsd/freebsd' \
+            f'/release/{f_rel}/usr.sbin/freebsd-update/freebsd-update.sh'
 
         tmp = None
         try:
@@ -120,21 +125,62 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
                 "--not-running-from-cron", "--currently-running "
                 f"{self.jail_release}", "-r", self.new_release, "upgrade"
             ]
-            with iocage_lib.ioc_exec.IOCExec(
-                fetch_cmd,
-                self.path.replace('/root', ''),
-                uuid=self.uuid,
-                unjailed=True,
-                stdin_bytestring=b'y\n',
-                callback=self.callback,
-            ) as _exec:
-                iocage_lib.ioc_common.consume_and_log(
-                    _exec,
-                    callback=self.callback
-                )
 
-            while not self.__upgrade_install__(tmp.name):
-                pass
+            # FreeNAS MW/Others, this is a best effort as things may require
+            # stdin input, in which case dropping to a tty is the best solution
+            if not self.interactive:
+                with iocage_lib.ioc_exec.IOCExec(
+                    fetch_cmd,
+                    self.path.replace('/root', ''),
+                    uuid=self.uuid,
+                    unjailed=True,
+                    stdin_bytestring=b'y\n',
+                    callback=self.callback,
+                ) as _exec:
+                    iocage_lib.ioc_common.consume_and_log(
+                        _exec,
+                        callback=self.callback
+                    )
+            else:
+                try:
+                    iocage_lib.ioc_exec.InteractiveExec(
+                        fetch_cmd,
+                        self.path.replace('/root', ''),
+                        uuid=self.uuid,
+                        unjailed=True
+                    )
+                except iocage_lib.ioc_exceptions.CommandFailed:
+                    self.__rollback_jail__()
+                    msg = f'Upgrade failed! Rolling back jail'
+                    iocage_lib.ioc_common.logit(
+                        {
+                            "level": "EXCEPTION",
+                            "message": msg
+                        },
+                        _callback=self.callback,
+                        silent=self.silent
+                    )
+
+
+            if not self.interactive:
+                while not self.__upgrade_install__(tmp.name):
+                    pass
+            else:
+                # FreeBSD update loops 3 times
+                for _ in range(3):
+                    try:
+                        self.__upgrade_install__(tmp.name)
+                    except iocage_lib.ioc_exceptions.CommandFailed:
+                        self.__rollback_jail__()
+                        msg = f'Upgrade failed! Rolling back jail'
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'EXCEPTION',
+                                'message': msg
+                            },
+                            _callback=self.callback,
+                            silent=self.silent
+                        )
 
             new_release = iocage_lib.ioc_common.get_jail_freebsd_version(
                 self.path,
@@ -300,23 +346,31 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
             "install"
         ]
 
-        with iocage_lib.ioc_exec.IOCExec(
-            install_cmd,
-            self.path.replace('/root', ''),
-            uuid=self.uuid,
-            unjailed=True,
-            callback=self.callback,
-        ) as _exec:
-            update_output = iocage_lib.ioc_common.consume_and_log(
-                _exec,
-                callback=self.callback
+        if not self.interactive:
+            with iocage_lib.ioc_exec.IOCExec(
+                install_cmd,
+                self.path.replace('/root', ''),
+                uuid=self.uuid,
+                unjailed=True,
+                callback=self.callback,
+            ) as _exec:
+                update_output = iocage_lib.ioc_common.consume_and_log(
+                    _exec,
+                    callback=self.callback
+                )
+
+            for i in update_output:
+                if i == 'No updates are available to install.':
+                    return True
+
+            return False
+        else:
+            iocage_lib.ioc_exec.InteractiveExec(
+                install_cmd,
+                self.path.replace('/root', ''),
+                uuid=self.uuid,
+                unjailed=True
             )
-
-        for i in update_output:
-            if i == 'No updates are available to install.':
-                return True
-
-        return False
 
     def __upgrade_check_conf__(self):
         """

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -161,7 +161,6 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
                         silent=self.silent
                     )
 
-
             if not self.interactive:
                 while not self.__upgrade_install__(tmp.name):
                     pass

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -802,7 +802,6 @@ class IOCage(ioc_json.IOCZFS):
                 },
                 _callback=self.callback,
                 silent=self.silent)
-        u = ('-U', jail_user) if jail_user is not None else ('-u', host_user)
 
         uuid, path = self.__check_jail_existence__()
         exec_clean = self.get('exec_clean')
@@ -855,7 +854,14 @@ class IOCage(ioc_json.IOCZFS):
             return
 
         if interactive:
-            ioc_exec.InteractiveExec(command, path, uuid=uuid)
+            ioc_exec.InteractiveExec(
+                command,
+                path,
+                uuid=uuid,
+                host_user=host_user,
+                jail_user=jail_user,
+                skip=True
+            )
             return
 
         try:

--- a/tests/functional_tests/0008_exec_test.py
+++ b/tests/functional_tests/0008_exec_test.py
@@ -42,7 +42,7 @@ def test_01_exec_on_jail(resource_selector, skip_test, invoke_cli):
         ['exec', jail.name, 'touch', '/tmp/testing_file']
     )
 
-    assert jail.running is False
+    assert jail.running is True
 
     assert os.path.exists(
         os.path.join(jail.absolute_path, 'root/tmp/testing_file')
@@ -64,7 +64,7 @@ def test_02_exec_jail_user_on_jail(resource_selector, skip_test, invoke_cli):
     )
 
     result = invoke_cli(['exec', '-U', 'foo', jail.name, 'whoami'])
-    assert jail.running is False
+    assert jail.running is True
 
     output = result.output.rstrip()
 
@@ -81,7 +81,7 @@ def test_03_exec_host_user_on_jail(resource_selector, skip_test, invoke_cli):
     result = invoke_cli(
         ['exec', '-u', 'nobody', jail.name, 'whoami']
     )
-    assert jail.running is False
+    assert jail.running is True
 
     output = result.output.rstrip()
 

--- a/tests/functional_tests/0009_clone_test.py
+++ b/tests/functional_tests/0009_clone_test.py
@@ -38,6 +38,11 @@ def test_01_cloning_thickconfig_jail(
     skip_test(not jails)
 
     thickconfig_jail = jails[0]
+    invoke_cli(['stop', '-f', thickconfig_jail.name])
+
+    assert thickconfig_jail.running is False, \
+        f'Failed to stop {thickconfig_jail.name}'
+
     invoke_cli(
         ['clone', thickconfig_jail.name, '-n', 'cloned_jail']
     )
@@ -70,6 +75,12 @@ def test_02_cloning_thickconfig_jail_setting_props(
     skip_test(not jails)
 
     thickconfig_jail = jails[0]
+
+    invoke_cli(['stop', '-f', thickconfig_jail.name])
+
+    assert thickconfig_jail.running is False, \
+        f'Failed to stop {thickconfig_jail.name}'
+
     invoke_cli([
         'clone', thickconfig_jail.name, '-n',
         'cloned_jail2', 'notes=check_cloned_note'
@@ -91,6 +102,11 @@ def test_03_cloning_jail_using_count_flag(
 
     count = 3
     clone_jail = jails[0]
+
+    invoke_cli(['stop', '-f', clone_jail.name])
+
+    assert clone_jail.running is False, f'Failed to stop {clone_jail.name}'
+
     invoke_cli([
         'clone', clone_jail.name, '-n',
         'cloned_jail_count_test', '-c', count,


### PR DESCRIPTION
This will sidestep a lot of issues that came up from the one stdin mode we had for noninteractive cases.

- Add InteractiveExec class
- Workaround for master issues with fetching freebsd-update
- No longer fetch master freebsd-update scripts for upgrade, but instead grab the target RELEASEs version of the script
- Add interactive switch and change behavior depending on mode
- Remove a lot of unneeded code now from interactive commands (from iocage API side) and console.

FreeNAS Ticket: #70977
Closes #771
Closes #769