### PR TITLE
tkt-69942: Fix renaming templates

### DIFF
--- a/iocage_lib/ioc_destroy.py
+++ b/iocage_lib/ioc_destroy.py
@@ -193,7 +193,7 @@ class IOCDestroy(iocage_lib.ioc_json.IOCZFS):
             # We need to make sure we remove the snapshots from the RELEASES
             # We are purposely not using -R as those will hit templates
             # and we are not using IOCSnapshot for perfomance
-            for dataset in self.release_snapshots:
+            for dataset in self.release_snapshots.keys():
                 su.run(
                     [
                         'zfs',

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -265,13 +265,13 @@ class IOCZFS(object):
 
     @property
     def release_snapshots(self):
-        # Returns all jail snapshots on the RELEASE
+        # Returns all jail snapshots on each RELEASE dataset
         rel_dir = pathlib.Path(f'{self.iocroot_path}/releases')
-        snaps = []
+        snaps = {}
 
         # Quicker than asking zfs and parsing
         for snap in rel_dir.glob('**/root/.zfs/snapshot/*'):
-            snaps.append(snap.name)
+            snaps[snap.name] = str(snap).rsplit('/.zfs', 1)[0]
 
         return snaps
 
@@ -331,7 +331,7 @@ class IOCZFS(object):
             return su.run(
                 ['zfs', 'get', '-pHo', 'name', 'mountpoint', name],
                 stdout=su.PIPE, stderr=su.PIPE
-            ).stdout.decode()
+            ).stdout.decode().rstrip()
 
     def zfs_get_snapshot(self, snap_id):
         # Let's return snapshot object from which additional information


### PR DESCRIPTION
This PR addresses the following:
- Change the release_snapshots structure from a list to a dict containing the snapshot name and the RELEASE dataset path it belongs too
- Strip unneeded whitespace on get_dataset_name
- Correctly rename the RELEASE snapshot of the target instead of trying a recursive, possible failure scenario.
- Set template readonly=off later down the line as other zfs set's were causing it to set back to readonly=on
- Loop through all the jails and update the source_template property if they have one

FreeNAS Ticket: #69942