### PR TITLE
tkt-73236: Make booleans universal values

### DIFF
--- a/.travis/flake8.sh
+++ b/.travis/flake8.sh
@@ -2,7 +2,7 @@
 # Run pep8 on all .py files in all subfolders
 
 tmpafter=$(mktemp)
-find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --ignore=E127,E203,W503,F811 {} + > ${tmpafter}
+find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpafter}
 num_errors_after=`cat ${tmpafter} | wc -l`
 echo "Current Error Count: ${num_errors_after}"
 
@@ -15,7 +15,7 @@ echo "Comparing with last stable release: ${last_release}"
 git checkout ${last_release}
 
 tmpbefore=$(mktemp)
-find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --ignore=E127,E203,W503,F811 {} + > ${tmpbefore}
+find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpbefore}
 num_errors_before=`cat ${tmpbefore} | wc -l`
 echo "${last_release}'s Error Count: ${num_errors_before}"
 

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -353,7 +353,7 @@ def sort_boot(boot):
     """Sort the list by boot, then by name."""
     # Lame hack to get on above off.
     # 0 is on, 1 is off
-    _boot = 0 if boot[2] != "off" else 1
+    _boot = 0 if check_truthy(boot[2]) else 1
     return (_boot,) + get_name_sortkey(boot[1])
 
 
@@ -777,11 +777,11 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
         devfs_dict.update(paths)
 
     # We may end up setting all of these.
-    if conf['allow_mount_fusefs'] == '1':
+    if check_truthy(conf['allow_mount_fusefs']):
         devfs_dict['fuse'] = None
-    if conf['bpf'] == 'yes':
+    if check_truthy(conf['bpf']):
         devfs_dict['bpf*'] = None
-    if conf['allow_tun'] == '1':
+    if check_truthy(conf['allow_tun']):
         devfs_dict['tun*'] = None
 
     for include in devfs_includes:
@@ -902,3 +902,19 @@ def get_jail_freebsd_version(path, release):
                         2].strip('"')
 
     return new_release
+
+
+def check_truthy(value):
+    """Checks if the given value is 'True'"""
+    if str(value) in ('1', 'on', 'yes', 'true'):
+        return 1
+
+    return 0
+
+
+def construct_truthy(item, inverse=False):
+    """Will return an iterable with all truthy variations"""
+    if inverse:
+        return (f'{item}=off', f'{item}=no', f'{item}=0', f'{item}=false')
+
+    return (f'{item}=on', f'{item}=yes', f'{item}=1', f'{item}=true')

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -310,11 +310,15 @@ class IOCCreate(object):
             # Clones are expected to be as identical as possible.
 
             for k, v in config.items():
-                v = v.replace(clone_uuid, jail_uuid)
+                try:
+                    v = v.replace(clone_uuid, jail_uuid)
 
-                if '_mac' in k:
-                    # They want a unique mac on start
-                    config[k] = 'none'
+                    if '_mac' in k:
+                        # They want a unique mac on start
+                        config[k] = 'none'
+                except AttributeError:
+                    # Bool props
+                    pass
 
                 config[k] = v
         else:
@@ -374,17 +378,18 @@ class IOCCreate(object):
 
         for prop in self.props:
             key, _, value = prop.partition("=")
+            is_true = iocage_lib.ioc_common.check_truthy(value)
 
-            if key == "boot" and value == "on" and not self.empty:
+            if key == "boot" and is_true and not self.empty:
                 start = True
             elif self.plugin and key == "type" and value == "pluginv2":
                 config["type"] = value
-            elif key == "template" and value == "yes":
+            elif key == 'template' and is_true:
                 iocjson.json_write(config)  # Set counts on this.
                 location = location.replace("/jails/", "/templates/")
 
                 iocjson.json_set_value("type=template")
-                iocjson.json_set_value("template=yes")
+                iocjson.json_set_value("template=1")
                 iocjson.zfs_set_property(f"{self.pool}/iocage/templates/"
                                          f"{jail_uuid}", "readonly", "off")
 
@@ -396,49 +401,56 @@ class IOCCreate(object):
                 is_template = True
             elif key == 'ip6_addr':
                 if 'accept_rtadv' in value:
-                    if 'vnet=on' not in self.props:
+                    if iocage_lib.ioc_common.construct_truthy(
+                        'vnet'
+                    ) not in self.props:
                         iocage_lib.ioc_common.logit({
                             'level': 'WARNING',
                             'message': 'accept_rtadv requires vnet,'
-                            ' setting to on!'
+                            ' enabling!'
                         },
                             _callback=self.callback,
                             silent=self.silent)
-                        config['vnet'] = 'on'
+                        config['vnet'] = 1
 
                     rtsold_enable = 'YES'
-            elif (key == 'dhcp' and value == 'on') or (
+            elif (key == 'dhcp' and is_true) or (
                 key == 'ip4_addr' and 'DHCP' in value.upper()
             ):
-                if 'vnet=on' not in self.props:
+                if iocage_lib.ioc_common.construct_truthy(
+                    'vnet'
+                ) not in self.props:
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
-                        'message': 'dhcp requires vnet, setting to on!'
+                        'message': 'dhcp requires vnet, enabling!'
                     },
                         _callback=self.callback,
                         silent=self.silent)
-                    config['vnet'] = 'on'
-                if 'bpf=yes' not in self.props:
+                    config['vnet'] = 1
+                if iocage_lib.ioc_common.construct_truthy(
+                    'bpf'
+                ) not in self.props:
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
-                        'message': 'dhcp requires bpf, setting to yes!'
+                        'message': 'dhcp requires bpf, enabling!'
                     },
                         _callback=self.callback,
                         silent=self.silent)
-                    config['bpf'] = 'yes'
-            elif key == 'bpf' and value == 'yes':
-                if 'vnet=on' not in self.props:
+                    config['bpf'] = 1
+            elif key == 'bpf' and is_true:
+                if iocage_lib.ioc_common.construct_truthy(
+                    'vnet'
+                ) not in self.props:
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
-                        'message': 'bpf requires vnet, setting to on!'
+                        'message': 'bpf requires vnet, enabling!'
                     },
                         _callback=self.callback,
                         silent=self.silent)
-                    config['vnet'] = 'on'
+                    config['vnet'] = 1
 
             try:
                 value, config = iocjson.json_check_prop(key, value, config)
-
                 config[key] = value
             except RuntimeError as err:
                 iocjson.json_write(config)  # Destroy counts on this.
@@ -450,6 +462,8 @@ class IOCCreate(object):
                 iocage_lib.ioc_destroy.IOCDestroy().destroy_jail(location)
                 exit(1)
 
+        # We want these to represent reality on the FS
+        iocjson.fix_properties(config)
         if not self.plugin:
             # TODO: Should we probably only write once and maybe at the end
             # of the function ?
@@ -536,7 +550,7 @@ class IOCCreate(object):
             self.create_rc(
                 location,
                 config["host_hostname"],
-                config.get('basejail', 'no')
+                config.get('basejail', 0)
             )
 
             if rtsold_enable == 'YES':
@@ -571,7 +585,7 @@ class IOCCreate(object):
                 iocage_lib.ioc_fstab.IOCFstab(jail_uuid, "add", source,
                                               destination, "nullfs", "ro", "0",
                                               "0", silent=True)
-                config["basejail"] = "yes"
+                config["basejail"] = 1
 
             iocjson.json_write(config)
 
@@ -591,7 +605,9 @@ class IOCCreate(object):
         if self.pkglist:
             if config.get('ip4_addr', 'none') == 'none' and \
                 config.get('ip6_addr', 'none') == 'none' and \
-                    config.get('dhcp', 'off') != 'on':
+                    not iocage_lib.ioc_common.check_truthy(
+                        config.get('dhcp', 0)
+            ):
                 iocage_lib.ioc_common.logit({
                     "level": "WARNING",
                     "message": "You need an IP address for the jail to"
@@ -889,7 +905,7 @@ class IOCCreate(object):
         if self.plugin and pkg_err_list:
             return ','.join(pkg_err_list)
 
-    def create_rc(self, location, host_hostname, basejail='no'):
+    def create_rc(self, location, host_hostname, basejail=0):
         """
         Writes a boilerplate rc.conf file for a jail if it doesn't exist,
          otherwise changes the hostname.
@@ -926,7 +942,7 @@ ipv6_activate_all_interfaces=\"YES\"
         if not jail_rc_conf.is_file():
             shutil.copy(str(rc_conf), str(jail_rc_conf))
 
-        if basejail != 'no':
+        if basejail:
             su.Popen(
                 ['mount', '-F', f'{location}/fstab', '-a']).communicate()
 
@@ -934,7 +950,7 @@ ipv6_activate_all_interfaces=\"YES\"
                   f'hostname={host_hostname.replace("_", "-")}'],
                  stdout=su.PIPE).communicate()
 
-        if basejail != 'no':
+        if basejail:
             su.Popen(
                 ['umount', '-F', f'{location}/fstab', '-a']).communicate()
 

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -955,10 +955,9 @@ class IOCFetch(iocage_lib.ioc_json.IOCZFS):
                 _json = iocage_lib.ioc_json.IOCJson(path)
                 props = _json.json_get_value('all')
 
-                if props.get('basejail', 'no') == 'yes':
-                    if props['release'] == self.release:
-                        props['release'] = new_release
-                        _json.json_write(props)
+                if props['basejail'] and props['release'] == self.release:
+                    props['release'] = new_release
+                    _json.json_write(props)
 
         return new_release
 

--- a/iocage_lib/ioc_image.py
+++ b/iocage_lib/ioc_image.py
@@ -260,7 +260,7 @@ class IOCImage(object):
             silent=True).json_set_value("type=jail")
         iocage_lib.ioc_json.IOCJson(
             f"{self.iocroot}/jails/{uuid}", silent=True).json_set_value(
-                "template=no", _import=True)
+                "template=0", _import=True)
 
         msg = f"\nImported: {uuid}"
         iocage_lib.ioc_common.logit(

--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -126,11 +126,13 @@ class IOCList(object):
 
             uuid = conf["host_hostuuid"]
             ip4 = conf.get('ip4_addr', 'none')
-            dhcp = True if conf.get('dhcp') == 'on' or 'DHCP' in \
-                ip4.upper() else False
+            dhcp = True if iocage_lib.ioc_common.check_truthy(
+                conf.get('dhcp', 0)) or 'DHCP' in ip4.upper() else False
             ip4 = ip4 if not dhcp else 'DHCP'
 
-            if self.basejail_only and conf.get('basejail', 'no') != 'yes':
+            if self.basejail_only and not iocage_lib.ioc_common.check_truthy(
+                conf.get('basejail', 0)
+            ):
                 continue
 
             jail_list.append([uuid, ip4])
@@ -183,7 +185,9 @@ class IOCList(object):
                 state = 'CORRUPT'
                 jid = '-'
 
-            if self.basejail_only and conf.get('basejail', 'no') != 'yes':
+            if self.basejail_only and not iocage_lib.ioc_common.check_truthy(
+                conf.get('basejail', 0)
+            ):
                 continue
 
             uuid_full = conf["host_hostuuid"]
@@ -209,10 +213,12 @@ class IOCList(object):
             except IndexError:
                 short_ip4 = full_ip4 if full_ip4 != "none" else "-"
 
-            boot = conf["boot"]
+            boot = 'on' if iocage_lib.ioc_common.check_truthy(
+                conf.get('boot', 0)) else 'off'
             jail_type = conf["type"]
             full_release = conf["release"]
-            basejail = conf.get('basejail', 'no')
+            basejail = 'yes' if iocage_lib.ioc_common.check_truthy(
+                conf.get('basejail', 0)) else 'no'
 
             if "HBSD" in full_release:
                 full_release = re.sub(r"\W\w.", "-", full_release)
@@ -253,7 +259,9 @@ class IOCList(object):
             if "release" in template.lower() or "stable" in template.lower():
                 template = "-"
 
-            if conf["dhcp"] == "on" and status and os.geteuid() == 0:
+            if iocage_lib.ioc_common.check_truthy(
+                conf['dhcp']
+            ) and status and os.geteuid() == 0:
                 interface = conf["interfaces"].split(",")[0].split(":")[0]
 
                 if interface == "vnet0":
@@ -273,10 +281,14 @@ class IOCList(object):
                         full_ip4 = f'DHCP - Network Issue: {e}'
                     else:
                         full_ip4 = f'DHCP - Failed Parsing: {e}'
-            elif conf["dhcp"] == "on" and not status:
+            elif iocage_lib.ioc_common.check_truthy(
+                conf['dhcp']
+            ) and not status:
                 short_ip4 = "DHCP"
                 full_ip4 = "DHCP (not running)"
-            elif conf["dhcp"] == "on" and os.geteuid() != 0:
+            elif iocage_lib.ioc_common.check_truthy(
+                conf['dhcp']
+            ) and os.geteuid() != 0:
                 short_ip4 = "DHCP"
                 full_ip4 = "DHCP (running -- address requires root)"
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -136,7 +136,9 @@ class IOCPlugin(object):
                 for prop in props:
                     key, _, value = prop.partition("=")
 
-                    if key == "dhcp" and value == "on":
+                    if key == 'dhcp' and iocage_lib.ioc_common.check_truthy(
+                        value
+                    ):
                         if 'bpf*' not in plugin_devfs_paths:
                             plugin_devfs_paths["bpf*"] = None
 
@@ -363,7 +365,7 @@ class IOCPlugin(object):
         # fetch that bypasses the more naive check in cli/fetch
 
         if _conf["ip4_addr"] == "none" and _conf["ip6_addr"] == "none" and \
-           _conf["dhcp"] != "on":
+           not iocage_lib.ioc_common.check_truthy(_conf['dhcp']):
             iocage_lib.ioc_common.logit(
                 {
                     "level": "ERROR",

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -148,8 +148,8 @@ class IOCStart(object):
         bpf = self.conf["bpf"]
         dhcp = self.conf["dhcp"]
         rtsold = self.conf['rtsold']
-        wants_dhcp = True if dhcp or 'DHCP' in self.conf['ip4_addr'].upper(
-            ) else False
+        wants_dhcp = True if dhcp or 'DHCP' in self.conf[
+            'ip4_addr'].upper() else False
         vnet_interfaces = self.conf["vnet_interfaces"]
         ip6_addr = self.conf["ip6_addr"]
         prop_missing = False

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -101,7 +101,7 @@ class IOCStart(object):
                 silent=self.silent,
                 exception=ioc_exceptions.JailRunning)
 
-        if self.conf["hostid_strict_check"] == "on":
+        if self.conf['hostid_strict_check']:
             with open("/etc/hostid", "r") as _file:
                 hostid = _file.read().strip()
             if self.conf["hostid"] != hostid:
@@ -148,34 +148,34 @@ class IOCStart(object):
         bpf = self.conf["bpf"]
         dhcp = self.conf["dhcp"]
         rtsold = self.conf['rtsold']
-        wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.conf[
-            'ip4_addr'].upper() else False
+        wants_dhcp = True if dhcp or 'DHCP' in self.conf['ip4_addr'].upper(
+            ) else False
         vnet_interfaces = self.conf["vnet_interfaces"]
         ip6_addr = self.conf["ip6_addr"]
         prop_missing = False
         prop_missing_msgs = []
 
         if wants_dhcp:
-            if bpf != "yes":
+            if not bpf:
                 prop_missing_msgs.append(
-                    f"{self.uuid}: dhcp requires bpf=yes!"
+                    f"{self.uuid}: dhcp requires bpf!"
                 )
                 prop_missing = True
-            elif self.conf["vnet"] != "on":
+            elif not self.conf['vnet']:
                 # We are already setting a vnet variable below.
                 prop_missing_msgs.append(
-                    f"{self.uuid}: dhcp requires vnet=on!"
+                    f"{self.uuid}: dhcp requires vnet!"
                 )
                 prop_missing = True
 
-        if 'accept_rtadv' in ip6_addr and self.conf['vnet'] != 'on':
+        if 'accept_rtadv' in ip6_addr and not self.conf['vnet']:
             prop_missing_msgs.append(
-                f'{self.uuid}: accept_rtadv requires vnet=on!'
+                f'{self.uuid}: accept_rtadv requires vnet!'
             )
             prop_missing = True
 
-        if bpf == 'yes' and self.conf['vnet'] != 'on':
-            prop_missing_msgs.append(f'{self.uuid}: bpf requires vnet=on!')
+        if bpf and not self.conf['vnet']:
+            prop_missing_msgs.append(f'{self.uuid}: bpf requires vnet!')
             prop_missing = True
 
         if prop_missing:
@@ -188,10 +188,10 @@ class IOCStart(object):
         if wants_dhcp:
             self.__check_dhcp__()
 
-        if rtsold == 'on':
+        if rtsold:
             self.__check_rtsold__()
 
-        if mount_procfs == "1":
+        if mount_procfs:
             su.Popen(
                 [
                     'mount', '-t', 'procfs', 'proc', f'{self.path}/root/proc'
@@ -201,7 +201,7 @@ class IOCStart(object):
         try:
             mount_linprocfs = self.conf["mount_linprocfs"]
 
-            if mount_linprocfs == "1":
+            if mount_linprocfs:
                 if not os.path.isdir(f"{self.path}/root/compat/linux/proc"):
                     os.makedirs(f"{self.path}/root/compat/linux/proc", 0o755)
                 su.Popen(
@@ -213,7 +213,7 @@ class IOCStart(object):
         except Exception:
             pass
 
-        if self.conf["jail_zfs"] == "on":
+        if self.conf['jail_zfs']:
             allow_mount = "1"
             enforce_statfs = enforce_statfs if enforce_statfs != "2" \
                 else "1"
@@ -274,7 +274,7 @@ class IOCStart(object):
             _allow_mount_fusefs = f"allow.mount.fusefs={allow_mount_fusefs}"
             _allow_vmm = f"allow.vmm={allow_vmm}"
 
-        if self.conf['vnet'] == 'off':
+        if not self.conf['vnet']:
             ip4_addr = self.conf['ip4_addr']
             ip4_saddrsel = self.conf['ip4_saddrsel']
             ip4 = self.conf['ip4']
@@ -486,7 +486,7 @@ class IOCStart(object):
             },
                 _callback=self.callback)
 
-        if self.conf["jail_zfs"] == "on":
+        if self.conf['jail_zfs']:
             for jdataset in self.conf["jail_zfs_dataset"].split():
                 jdataset = jdataset.strip()
                 children = iocage_lib.ioc_common.checkoutput(
@@ -755,13 +755,13 @@ class IOCStart(object):
 
             try:
                 membermtu = self.find_bridge_mtu(bridge)
-                dhcp = self.get("dhcp")
+                dhcp = self.get('dhcp')
 
                 ifaces = []
 
                 for addrs, gw, ipv6 in net_configs:
                     if (
-                        dhcp == "on" or 'DHCP' in self.get('ip4_addr').upper()
+                        dhcp or 'DHCP' in self.get('ip4_addr').upper()
                     ) and 'accept_rtadv' not in addrs:
                         # Spoofing IP address, it doesn't matter with DHCP
                         addrs = f"{nic}|''"
@@ -916,7 +916,7 @@ class IOCStart(object):
         :return: If an error occurs it returns the error. Otherwise, it's None
         """
         dhcp = self.get('dhcp')
-        wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.get(
+        wants_dhcp = True if dhcp or 'DHCP' in self.get(
             'ip4_addr').upper() else False
 
         if 'vnet' in iface:
@@ -958,7 +958,7 @@ class IOCStart(object):
         host_time = self.get("host_time")
         file = f"{self.path}/root/etc/localtime"
 
-        if host_time != "yes":
+        if not iocage_lib.ioc_common.check_truthy(host_time):
             return
 
         if os.path.isfile(file):
@@ -1028,7 +1028,7 @@ class IOCStart(object):
 
     def __check_dhcp__(self):
         # legacy behavior to enable it on every NIC
-        if self.conf['dhcp'] == 'on':
+        if self.conf['dhcp']:
             nic_list = self.get('interfaces').split(',')
             nics = list(map(lambda x: x.split(':')[0], nic_list))
         else:
@@ -1097,11 +1097,11 @@ class IOCStart(object):
 
     def find_bridge_mtu(self, bridge):
         if self.unit_test:
-            dhcp = 'off'
+            dhcp = 0
             wants_dhcp = False
         else:
-            dhcp = self.get("dhcp")
-            wants_dhcp = True if dhcp == 'on' or 'DHCP' in self.get(
+            dhcp = self.get('dhcp')
+            wants_dhcp = True if dhcp or 'DHCP' in self.get(
                 'ip4_addr').upper() else False
 
         try:

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -148,7 +148,7 @@ class IOCStop(object):
                 finally:
                     f.write(success or error)
 
-            if self.conf["jail_zfs"] == "on":
+            if self.conf['jail_zfs']:
                 for jdataset in self.conf["jail_zfs_dataset"].split():
                     jdataset = jdataset.strip()
 
@@ -214,10 +214,10 @@ class IOCStop(object):
         # related resources if force is true, though we won't raise an
         # exception in that case
         # They haven't set an IP address, this interface won't exist
-        destroy_nic = True if dhcp == "on" or ip4_addr != "none" or \
-            ip6_addr != "none" else False
+        destroy_nic = True if dhcp or ip4_addr != 'none' or \
+            ip6_addr != 'none' else False
 
-        if vnet == "on" and destroy_nic:
+        if vnet and destroy_nic:
             vnet_err = []
 
             for nic in self.nics.split(","):

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -188,7 +188,7 @@ class IOCage(ioc_json.IOCZFS):
 
             # This removes having to grab all the JSON again later.
 
-            if boot == 'on':
+            if boot:
                 boot_order[jail] = int(priority)
 
             jail_order = collections.OrderedDict(
@@ -812,7 +812,7 @@ class IOCage(ioc_json.IOCZFS):
         uuid, path = self.__check_jail_existence__()
         exec_clean = self.get('exec_clean')
 
-        if exec_clean == '1':
+        if exec_clean:
             env_path = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:' \
                 '/usr/local/bin:/root/bin'
             env_lang = os.environ.get('LANG', 'en_US.UTF-8')
@@ -832,7 +832,7 @@ class IOCage(ioc_json.IOCZFS):
             ip6_addr = self.get("ip6_addr")
             dhcp = self.get("dhcp")
 
-            if ip4_addr == "none" and ip6_addr == "none" and dhcp != "on":
+            if ip4_addr == "none" and ip6_addr == "none" and not dhcp:
                 ioc_common.logit(
                     {
                         "level":
@@ -998,7 +998,7 @@ class IOCage(ioc_json.IOCZFS):
 
                 return rel_list
 
-            if not ip and "dhcp=on" not in props:
+            if not ip and ioc_common.construct_truthy('dhcp') not in props:
                 ioc_common.logit(
                     {
                         "level":
@@ -1449,7 +1449,7 @@ class IOCage(ioc_json.IOCZFS):
                 _callback=self.callback,
                 silent=self.silent)
 
-        if conf["template"] == "yes":
+        if ioc_common.check_truthy(conf['template']):
             target = f"{self.pool}/iocage/templates/{uuid}"
         else:
             target = f"{self.pool}/iocage/jails/{uuid}"
@@ -1547,9 +1547,11 @@ class IOCage(ioc_json.IOCZFS):
             return
 
         if "template" in key:
-            if prop == "template=yes" and path.startswith(
-                    f"{self.iocroot}/templates/"):
-
+            if prop in ioc_common.construct_truthy(
+                'template'
+            ) and path.startswith(
+                f'{self.iocroot}/templates/'
+            ):
                 ioc_common.logit(
                     {
                         "level": "EXCEPTION",
@@ -1558,9 +1560,11 @@ class IOCage(ioc_json.IOCZFS):
                     _callback=self.callback,
                     silent=self.silent)
 
-            elif prop == "template=no" and path.startswith(
-                    f"{self.iocroot}/jails/"):
-
+            elif prop in ioc_common.construct_truthy(
+                'template', inverse=True
+            ) and path.startswith(
+                f'{self.iocroot}/jails/'
+            ):
                 ioc_common.logit(
                     {
                         "level": "EXCEPTION",
@@ -1598,7 +1602,7 @@ class IOCage(ioc_json.IOCZFS):
         snap_list_temp = []
         snap_list_root = []
 
-        if conf["template"] == "yes":
+        if ioc_common.check_truthy(conf['template']):
             full_path = f"{self.pool}/iocage/templates/{uuid}"
         else:
             full_path = f"{self.pool}/iocage/jails/{uuid}"
@@ -1664,7 +1668,7 @@ class IOCage(ioc_json.IOCZFS):
         # Looks like foo/iocage/jails/df0ef69a-57b6-4480-b1f8-88f7b6febbdf@BAR
         conf = ioc_json.IOCJson(path, silent=self.silent).json_get_value('all')
 
-        if conf["template"] == "yes":
+        if ioc_common.check_truthy(conf['template']):
             target = f"{self.pool}/iocage/templates/{uuid}"
         else:
             target = f"{self.pool}/iocage/jails/{uuid}"
@@ -1889,7 +1893,7 @@ class IOCage(ioc_json.IOCZFS):
                     plugin=uuid,
                     callback=self.callback
                 ).update()
-            elif conf["basejail"] != "yes":
+            elif not ioc_common.check_truthy(conf['basejail']):
                 new_release = ioc_fetch.IOCFetch(
                     release,
                     callback=self.callback
@@ -1987,7 +1991,7 @@ class IOCage(ioc_json.IOCZFS):
                 ioc_start.IOCStart(uuid, path, silent=True)
                 started = True
 
-            if conf["basejail"] == "yes":
+            if ioc_common.check_truthy(conf['basejail']):
                 new_release = ioc_upgrade.IOCUpgrade(
                     release,
                     root_path,
@@ -2076,7 +2080,7 @@ Remove the snapshot: ioc_upgrade_{_date} if everything is OK
         uuid, path = self.__check_jail_existence__()
         conf = ioc_json.IOCJson(path, silent=self.silent).json_get_value('all')
 
-        if conf['template'] == 'yes':
+        if ioc_common.check_truthy(conf['template']):
             target = f'{self.pool}/iocage/templates/{uuid}@{snapshot}'
         else:
             target = f'{self.pool}/iocage/jails/{uuid}@{snapshot}'

--- a/tests/data_classes.py
+++ b/tests/data_classes.py
@@ -429,7 +429,7 @@ class Jail(Resource):
         props = self.jail_dataset['properties']
 
         ip4 = self.config.get('ip4_addr', 'none')
-        if self.config.get('dhcp', 'off') == 'on':
+        if self.config.get('dhcp', 0):
             if full and self.running:
                 ip4 = f'epair0b|{self.ips[0]}'
             else:
@@ -473,7 +473,7 @@ class Jail(Resource):
             'name': self.short_name if short_name else self.name,
             'jid': self.jid or 9999999,
             'state': 'up' if self.running else 'down',
-            'boot': self.config.get('boot', 'off'),
+            'boot': 'on' if self.config.get('boot', 0) else 'off',
             'type': 'jail' if not self.is_template else 'template',
             # TODO: Add support for plugins
             'ip6': '-',  # FIXME: Change when ip6 tests are added
@@ -596,7 +596,7 @@ class Jail(Resource):
 
     @property
     def is_basejail(self):
-        return self.config.get('basejail', 'no') == 'yes'
+        return self.config.get('basejail', 0)
 
     @property
     def is_empty(self):
@@ -610,7 +610,7 @@ class Jail(Resource):
 
     @property
     def is_rcjail(self):
-        return self.config.get('boot', 'off') == 'on'
+        return self.config.get('boot', 0)
 
     @property
     def is_cloned(self):

--- a/tests/functional_tests/0003_create_test.py
+++ b/tests/functional_tests/0003_create_test.py
@@ -118,7 +118,7 @@ def test_07_create_basejail(release, jail, invoke_cli):
 
     jail = jail('basejail')
     assert jail.exists is True
-    assert jail.is_basejail is True
+    assert jail.is_basejail
 
 
 @require_root

--- a/tests/functional_tests/0007_get_test.py
+++ b/tests/functional_tests/0007_get_test.py
@@ -37,7 +37,7 @@ def _test_value_and_match_config(jail, key, invoke_cli):
         ['get', key, jail.name]
     )
 
-    value = jail.config.get(key)
+    value = str(jail.config.get(key))
     assert result.output.strip() == value, \
         f'{key}\'s value "{value}" does not match output: {result.output}'
 


### PR DESCRIPTION
This greatly simplifies the user experience, in addition allows more boolean type properties to be easier added in the future with less regard to their parsing.

- All boolean properties can now be set as '1/0', 'on/off', 'yes/no', 'true/false'
- These now rest on disk as 1/0
- Fix some IP validation issues

FreeNAS Ticket: #73236