### PR TITLE
tkt-73740: Add ip_hostname support to iocage

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -611,11 +611,15 @@ class IOCCreate(object):
                 silent=self.silent)
 
         if self.pkglist:
-            if config.get('ip4_addr', 'none') == 'none' and \
-                config.get('ip6_addr', 'none') == 'none' and \
-                    not iocage_lib.ioc_common.check_truthy(
-                        config.get('dhcp', 0)
-            ):
+            dhcp_or_hostname = iocage_lib.ioc_common.check_truthy(
+                config.get('dhcp', 0)
+            ) or iocage_lib.ioc_common.check_truthy(
+                config.get('ip_hostname', 0)
+            )
+
+            if config.get('ip4_addr', 'none') == "none" and \
+                config.get('ip6_addr', 'none') == "none" and \
+                    not dhcp_or_hostname:
                 iocage_lib.ioc_common.logit({
                     "level": "WARNING",
                     "message": "You need an IP address for the jail to"

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -611,11 +611,7 @@ class IOCCreate(object):
                 silent=self.silent)
 
         if self.pkglist:
-            dhcp_or_hostname = iocage_lib.ioc_common.check_truthy(
-                config.get('dhcp', 0)
-            ) or iocage_lib.ioc_common.check_truthy(
-                config.get('ip_hostname', 0)
-            )
+            dhcp_or_hostname = config.get('dhcp') or config.get('ip_hostname')
 
             if config.get('ip4_addr', 'none') == "none" and \
                 config.get('ip6_addr', 'none') == "none" and \

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -448,7 +448,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '17'
+        version = '18'
 
         return version
 
@@ -779,6 +779,10 @@ class IOCConfiguration(IOCZFS):
         if not conf.get('allow_vmm'):
             conf['allow_vmm'] = 0
 
+        # Version 18 keys
+        if not conf.get('ip_hostname'):
+            conf['ip_hostname'] = 0
+
         if not default:
             conf.update(jail_conf)
 
@@ -1089,7 +1093,8 @@ class IOCConfiguration(IOCZFS):
             'reservation': 'none',
             'depends': 'none',
             'vnet_interfaces': 'none',
-            'rtsold': 0
+            'rtsold': 0,
+            'ip_hostname': 0
         }
 
         try:
@@ -1186,7 +1191,8 @@ class IOCJson(IOCConfiguration):
             'mount_fdescfs',
             'mount_devfs',
             'ip6_saddrsel',
-            'ip4_saddrsel'
+            'ip4_saddrsel',
+            'ip_hostname'
         ]
         super().__init__(location, checking_datasets, silent, callback)
 
@@ -1935,7 +1941,8 @@ class IOCJson(IOCConfiguration):
             "host_time": truth_variations,
             "depends": ("string", ),
             "allow_tun": truth_variations,
-            'rtsold': truth_variations
+            'rtsold': truth_variations,
+            'ip_hostname': truth_variations
         }
 
         zfs_props = {

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -364,8 +364,14 @@ class IOCPlugin(object):
         # We do this test again as the user could supply a malformed IP to
         # fetch that bypasses the more naive check in cli/fetch
 
+        dhcp_or_hostname = iocage_lib.ioc_common.check_truthy(
+            _conf['dhcp']
+        ) or iocage_lib.ioc_common.check_truthy(
+            _conf['ip_hostname']
+        )
+
         if _conf["ip4_addr"] == "none" and _conf["ip6_addr"] == "none" and \
-           not iocage_lib.ioc_common.check_truthy(_conf['dhcp']):
+           not dhcp_or_hostname:
             iocage_lib.ioc_common.logit(
                 {
                     "level": "ERROR",

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -361,14 +361,9 @@ class IOCPlugin(object):
         path = f"{self.pool}/iocage/jails/{uuid}"
         _conf = iocage_lib.ioc_json.IOCJson(jaildir).json_get_value('all')
 
-        # We do this test again as the user could supply a malformed IP to
+        # We do these tests again as the user could supply a malformed IP to
         # fetch that bypasses the more naive check in cli/fetch
-
-        dhcp_or_hostname = iocage_lib.ioc_common.check_truthy(
-            _conf['dhcp']
-        ) or iocage_lib.ioc_common.check_truthy(
-            _conf['ip_hostname']
-        )
+        dhcp_or_hostname = _conf['dhcp'] or _conf['ip_hostname']
 
         if _conf["ip4_addr"] == "none" and _conf["ip6_addr"] == "none" and \
            not dhcp_or_hostname:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -152,6 +152,7 @@ class IOCStart(object):
             'ip4_addr'].upper() else False
         vnet_interfaces = self.conf["vnet_interfaces"]
         ip6_addr = self.conf["ip6_addr"]
+        ip_hostname = self.conf['ip_hostname']
         prop_missing = False
         prop_missing_msgs = []
 
@@ -392,6 +393,7 @@ class IOCStart(object):
                 'allow.dying',
                 f'exec.consolelog={self.iocroot}/log/ioc-'
                 f'{self.uuid}-console.log',
+                f'ip_hostname={ip_hostname}' if ip_hostname else '',
                 'persist'
             ] if x != '']
 

--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -122,10 +122,10 @@ class IOCStop(object):
                         + exec_stop, None, unjailed=True, decode=True
                     )
                 except iocage_lib.ioc_exceptions.CommandFailed as e:
-
-                    error = str(e)
+                    error = b' '.join(e.message).decode()
                     msg = '  + Stopping services FAILED\n' \
-                        f'ERROR:\n{e}\n\n{failed_message}'
+                        f'ERROR:\n{error}\n\n{failed_message}'
+
                     iocage_lib.ioc_common.logit({
                         'level': 'EXCEPTION',
                         'message': msg

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1005,9 +1005,11 @@ class IOCage(ioc_json.IOCZFS):
 
                 return rel_list
 
-            if not ip and not set(
+            if not ip and (not set(
                 ioc_common.construct_truthy('dhcp')
-            ) & set(props):
+            ) & set(props) and not set(
+                ioc_common.construct_truthy('ip_hostname')
+            ) & set(props)):
                 ioc_common.logit(
                     {
                         "level":


### PR DESCRIPTION
If a user sets their DNS records up and they match the jail name, this bool will allow the user to skip configuring the IP manually, as jail(8) will grab the IP from the resolver.

FreeNAS Ticket: #73740