### PR TITLE
tkt-73560: RCTL for Iocage

### DIFF
--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -87,6 +87,23 @@ class IOCStop(object):
             _callback=self.callback,
             silent=self.silent)
 
+        rctl_jail = iocage_lib.ioc_json.IOCRCTL(self.uuid)
+        if rctl_jail.rctl_rules_exist():
+            failed = rctl_jail.remove_rctl_rules()
+            if failed:
+                msg = 'Failed to remove'
+            else:
+                msg = 'Successfully removed'
+
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'ERROR' if failed else 'INFO',
+                    'message': f'  + {msg} RCTL rules for {self.uuid}'
+                },
+                _callback=self.callback,
+                silent=self.silent
+            )
+
         failed_message = 'Please use --force flag to force stop jail'
         if not self.force:
             prestop_success, prestop_error = iocage_lib.ioc_common.runscript(


### PR DESCRIPTION
This commit introduces following changes:
1) A class to manage RCTL related operations which are:
	a) Validate RCTL props
	b) Set RCTL rules
	c) Remove RCTL rules
	d) Check for existing RCTL rules
2) Ability to set RCTL props in the format 'action=amount'.
3) Setting RCTL rules after other start related operations are complete for a jail
4) Removing RCTL rules for a jail before we start any stopping operation for a jail when a jail stop is desired
5) The motivation behind 3 and 4 is that we should make sure start/stop behaviour is not affected by any RCTL rules at least for now as it can possibly affect the start/stop operations.
6) Allow setting/removing of RCTL rules for a jail which is running
7) There could be potentially more actions related to a single resource in RCTL rules, for now we only allow one. We can introduce support for multiple actions later gauging user reaction/usage.

Ticket: #73560