### PR TITLE
Add debug option to CLI

### DIFF
--- a/iocage_cli/__init__.py
+++ b/iocage_cli/__init__.py
@@ -90,10 +90,10 @@ class IOCLogger(object):
             # a large duplicate flood of text.
             logger.handlers = []
 
-        logger.setLevel(logging.DEBUG)
         logging.addLevelName(5, "SPAM")
         logging.addLevelName(15, "VERBOSE")
         logging.addLevelName(25, "NOTICE")
+        logger.setLevel('VERBOSE')
 
         default_logging = {
             'version': 1,
@@ -148,6 +148,10 @@ class IOCLogger(object):
             level_styles=cli_colors))
         logger.addHandler(handler)
 
+    def setConsoleLogLevel(self, level):
+        logger = logging.getLogger("iocage")
+        logger.setLevel(level)
+
 
 cmd_folder = os.path.abspath(os.path.dirname(__file__))
 
@@ -201,9 +205,17 @@ class IOCageCLI(click.MultiCommand):
     "-f",
     is_flag=True,
     help="Allow iocage to rename datasets.")
-def cli(version, force):
+@click.option(
+    "--debug",
+    "-D",
+    is_flag=True,
+    help="Log debug output to the console.")
+def cli(version, force, debug):
     """A jail manager."""
-    IOCLogger()
+    logger = IOCLogger()
+    if debug:
+        logger.setConsoleLogLevel(logging.DEBUG)
+
     skip_check = False
     os.environ["IOCAGE_SKIP"] = "FALSE"
     skip_check_cmds = ["--help", "activate", "-v", "--version", "--rc"]


### PR DESCRIPTION
Raises default logging level to VERBOSE (15) from DEBUG (10).
Adds command line option --debug/-D to re-enable debug logging.

Allows adding logging statements through code at level DEBUG or SPAM
that will not be displayed by default.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
