### PR TITLE
tkt-72323: Drop dulwich dependency, add docurl support to ui.json for plugins

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1338,7 +1338,7 @@ fingerprint: {fingerprint}
                 },
                 _callback=self.callback)
 
-        if f'origin/{self.branch}' not in repo.refs:
+        if f'origin/{ref}' not in repo.refs:
             ref = 'master'
             msgs = [
                 f'\nBranch {self.branch} does not exist at {repo_url}!',

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -33,7 +33,7 @@ import shutil
 import subprocess as su
 
 import requests
-from dulwich import porcelain
+import git
 
 import iocage_lib.ioc_common
 import iocage_lib.ioc_create
@@ -44,7 +44,6 @@ import iocage_lib.ioc_upgrade
 import iocage_lib.ioc_exceptions
 import libzfs
 import texttable
-import dulwich.client
 
 
 class IOCPlugin(object):
@@ -620,31 +619,47 @@ fingerprint: {fingerprint}
                 try:
                     with open(ui_json, "r") as u:
                         ui_data = json.load(u)
-                        admin_portal = ui_data["adminportal"]
-                        admin_portal = admin_portal.replace("%%IP%%",
-                                                            ip.rsplit(',')[0])
+                        admin_portal = ui_data.get('adminportal', None)
+                        doc_url = ui_data.get('docurl', None)
 
-                        try:
-                            ph = ui_data["adminportal_placeholders"].items()
-                            for placeholder, prop in ph:
-                                admin_portal = admin_portal.replace(
-                                    placeholder,
-                                    iocage_lib.ioc_json.IOCJson(
-                                        jaildir).json_plugin_get_value(
-                                        prop.split("."))
-                                )
-                        except KeyError:
-                            pass
+                        if admin_portal is not None:
+                            admin_portal = admin_portal.replace(
+                                '%%IP%%', ip.rsplit(',')[0]
+                            )
 
-                        iocage_lib.ioc_common.logit(
-                            {
-                                "level": "INFO",
-                                "message": f"\nAdmin Portal:\n{admin_portal}"
-                            },
-                            _callback=self.callback,
-                            silent=self.silent)
+                            try:
+                                ph = ui_data[
+                                    'adminportal_placeholders'
+                                ].items()
+                                for placeholder, prop in ph:
+                                    admin_portal = admin_portal.replace(
+                                        placeholder,
+                                        iocage_lib.ioc_json.IOCJson(
+                                            jaildir).json_plugin_get_value(
+                                            prop.split('.'))
+                                    )
+                            except KeyError:
+                                pass
+
+                            iocage_lib.ioc_common.logit(
+                                {
+                                    'level': 'INFO',
+                                    'message': '\nAdmin Portal:\n'
+                                               f'{admin_portal}'
+                                },
+                                _callback=self.callback,
+                                silent=self.silent)
+
+                        if doc_url is not None:
+                            iocage_lib.ioc_common.logit(
+                                {
+                                    'level': 'INFO',
+                                    'message': f'\nDoc URL:\n{doc_url}'
+                                },
+                                _callback=self.callback,
+                                silent=self.silent)
                 except FileNotFoundError:
-                    # They just didn't set a admin portal.
+                    # They just didn't set a admin portal or doc url.
                     pass
             except FileNotFoundError:
                 pass
@@ -1298,24 +1313,33 @@ fingerprint: {fingerprint}
         """
         This is to replicate the functionality of cloning/pulling a repo
         """
-        try:
-            with open('/dev/null', 'wb') as devnull:
-                porcelain.pull(destination, repo_url, outstream=devnull,
-                               errstream=devnull)
-                repo = porcelain.open_repo(destination)
-        except dulwich.errors.NotGitRepository:
-            with open('/dev/null', 'wb') as devnull:
-                repo = porcelain.clone(
-                    repo_url, destination, outstream=devnull, errstream=devnull
-                )
-
-        remote_refs = porcelain.fetch(repo, repo_url)
-        ref = f'refs/heads/{self.branch}'.encode()
+        ref = self.branch
+        os.makedirs(destination, exist_ok=True)
 
         try:
-            repo[ref] = remote_refs[ref]
-        except KeyError:
-            ref = b'refs/heads/master'
+            # "Pull"
+            repo = git.Repo(destination)
+            origin = repo.remotes.origin
+        except git.exc.InvalidGitRepositoryError:
+            # Clone
+            repo = git.Repo.init(destination)
+            origin = repo.create_remote('origin', repo_url)
+            origin.fetch()
+
+            repo.create_head('master', origin.refs.master)
+            repo.heads.master.set_tracking_branch(origin.refs.master)
+            repo.heads.master.checkout()
+
+        if not origin.exists():
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'EXCEPTION',
+                    'message': f'Origin: {origin.url} does not exist!'
+                },
+                _callback=self.callback)
+
+        if f'origin/{self.branch}' not in repo.refs:
+            ref = 'master'
             msgs = [
                 f'\nBranch {self.branch} does not exist at {repo_url}!',
                 'Using "master" branch for plugin, this may not work '
@@ -1330,10 +1354,6 @@ fingerprint: {fingerprint}
                     },
                     _callback=self.callback)
 
-            repo[ref] = remote_refs[ref]
-
-        tree = repo[ref].tree
-
-        # Let git reflect reality
-        repo.reset_index(tree)
-        repo.refs.set_symbolic_ref(b'HEAD', ref)
+        # Time to make this reality
+        repo.head.reference = f'origin/{ref}'
+        repo.head.reset(index=True, working_tree=True)

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -920,17 +920,7 @@ fingerprint: {fingerprint}
 
         git_working_dir = f"{self.iocroot}/.plugin_index"
 
-        try:
-            with open("/dev/null", "wb") as devnull:
-                porcelain.pull(git_working_dir, git_server,
-                               outstream=devnull, errstream=devnull)
-        except Exception as err:
-            iocage_lib.ioc_common.logit(
-                {
-                    "level": "EXCEPTION",
-                    "message": err
-                },
-                _callback=self.callback)
+        self.__clone_repo(git_server, git_working_dir)
 
     def __update_pull_plugin_artifact__(self, plugin_conf):
         """Pull the latest artifact to be sure we're up to date"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ click>=6.7
 texttable>=1.2.1
 requests>=2.18.4
 coloredlogs>=9.0
-dulwich>=0.18.6
 netifaces>=0.10.8
+GitPython>=2.1.11
 dnspython>=1.15.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'dulwich>=0.18.6',
+        'GitPython>=2.1.11',
         'netifaces>=0.10.8',
         'dnspython>=1.15.0',
         'libzfs'


### PR DESCRIPTION
- Replace Dulwich with GitPython
We were experiencing bad attribute usage with Dulwich, and while upstream has a commit to fix this, it didn't solve for our situation. Since we've had a couple problems with Dulwich in the past, let's try switching libraries to something that has been around longer.

- Also added docurl support to ui.json, this allows a plugin author to additionally specify where a user might be able to view documentation from the program authors themselves.

FreeNAS Ticket: #72323