### PR TITLE
tkt-75450: Add exec_created property

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -673,7 +673,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '19'
+        version = '20'
 
         return version
 
@@ -1014,6 +1014,10 @@ class IOCConfiguration(IOCZFS):
             {k: 'off' for k in IOCRCTL.types if not conf.get(k)}
         )
 
+        # Version 20 keys
+        if not conf.get('exec_created'):
+            conf['exec_created'] = '/usr/bin/true'
+
         if not default:
             conf.update(jail_conf)
 
@@ -1238,6 +1242,7 @@ class IOCConfiguration(IOCZFS):
             'exec_poststart': '/usr/bin/true',
             'exec_prestop': '/usr/bin/true',
             'exec_poststop': '/usr/bin/true',
+            'exec_created': '/usr/bin/true',
             'exec_clean': 1,
             'exec_timeout': '60',
             'stop_timeout': '30',
@@ -2157,6 +2162,7 @@ class IOCJson(IOCConfiguration):
             "exec_prestop": ("string", ),
             "exec_poststop": ("string", ),
             "exec_clean": truth_variations,
+            "exec_created": ("string", ),
             "exec_timeout": ("string", ),
             "stop_timeout": ("string", ),
             "exec_jail_user": ("string", ),

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -138,6 +138,7 @@ class IOCStart(object):
         exec_prestart = self.conf["exec_prestart"]
         exec_poststart = self.conf["exec_poststart"]
         exec_clean = self.conf["exec_clean"]
+        exec_created = self.conf["exec_created"]
         exec_timeout = self.conf["exec_timeout"]
         stop_timeout = self.conf["stop_timeout"]
         mount_devfs = self.conf["mount_devfs"]
@@ -269,13 +270,15 @@ class IOCStart(object):
         # FreeBSD before 12.0 does not support this.
 
         if userland_version < 12.0:
-            _allow_mlock = ""
-            _allow_mount_fusefs = ""
-            _allow_vmm = ""
+            _allow_mlock = ''
+            _allow_mount_fusefs = ''
+            _allow_vmm = ''
+            _exec_created = ''
         else:
             _allow_mlock = f"allow.mlock={allow_mlock}"
             _allow_mount_fusefs = f"allow.mount.fusefs={allow_mount_fusefs}"
             _allow_vmm = f"allow.vmm={allow_vmm}"
+            _exec_created = f'exec.created={exec_created}'
 
         if not self.conf['vnet']:
             ip4_addr = self.conf['ip4_addr']
@@ -379,6 +382,7 @@ class IOCStart(object):
                 _sysvmsg,
                 _sysvsem,
                 _sysvshm,
+                _exec_created,
                 f'host.domainname={host_domainname}',
                 f'host.hostname={host_hostname}',
                 f'path={self.path}/root',


### PR DESCRIPTION
Description of the property:
exec.created
     Command(s) to run in the system environment right after a jail
     has been created, but before commands (or services) get executed
     in the jail.

Closes #855
FreeNAS Ticket: #75450