### PR TITLE
tkt-75468: Require --force (-f) to start a jail when doing exec/console

### DIFF
--- a/iocage_cli/console.py
+++ b/iocage_cli/console.py
@@ -30,12 +30,20 @@ import iocage_lib.iocage as ioc
 __rootcmd__ = True
 
 
-@click.command(name="console", help="Login to a jail.")
-@click.argument("jail")
-def cli(jail):
+@click.command(name='console', help='Login to a jail.')
+@click.argument('jail')
+@click.option('--force', '-f', default=False, is_flag=True,
+              help='Start the jail if it\'s not running.')
+def cli(jail, force):
     """
     Runs jexec to login into the specified jail.
     """
     # Command is empty since this command is hardcoded later on.
-    ioc.IOCage(jail=jail,
-               silent=True).exec("", console=True)
+    ioc.IOCage(
+        jail=jail,
+        silent=True
+    ).exec(
+        None,
+        console=True,
+        start_jail=force
+    )

--- a/iocage_cli/exec.py
+++ b/iocage_cli/exec.py
@@ -38,7 +38,9 @@ __rootcmd__ = True
 @click.option("--jail_user", "-U", help="The jail user to use.")
 @click.argument("jail", required=True, nargs=1)
 @click.argument("command", nargs=-1, type=click.UNPROCESSED)
-def cli(command, jail, host_user, jail_user):
+@click.option('--force', '-f', default=False, is_flag=True,
+              help='Start the jail if it\'s not running.')
+def cli(command, jail, host_user, jail_user, force):
     """Runs the command given inside the specified jail as the supplied
     user."""
     # We may be getting ';', '&&' and so forth. Adding the shell for safety.
@@ -60,7 +62,12 @@ def cli(command, jail, host_user, jail_user):
 
     try:
         ioc.IOCage(jail=jail).exec(
-            command, host_user, jail_user, interactive=True)
+            command,
+            host_user,
+            jail_user,
+            interactive=True,
+            start_jail=force
+        )
     except KeyboardInterrupt:
         pass
     except Exception as e:

--- a/tests/functional_tests/0008_exec_test.py
+++ b/tests/functional_tests/0008_exec_test.py
@@ -39,7 +39,7 @@ def test_01_exec_on_jail(resource_selector, skip_test, invoke_cli):
 
     jail = jails[0]
     invoke_cli(
-        ['exec', jail.name, 'touch', '/tmp/testing_file']
+        ['exec', '-f', jail.name, 'touch', '/tmp/testing_file']
     )
 
     assert jail.running is True
@@ -58,15 +58,16 @@ def test_02_exec_jail_user_on_jail(resource_selector, skip_test, invoke_cli):
     jail = jails[0]
     invoke_cli(
         [
-            'exec', jail.name, 'pw', 'useradd', '-n', 'foo', '-s', '/bin/sh',
-            '-m'
+            'exec', '-f', jail.name, 'pw', 'useradd', '-n', 'foo', '-s',
+            '/bin/sh', '-m'
         ]
     )
 
-    result = invoke_cli(['exec', '-U', 'foo', jail.name, 'whoami'])
+    result = invoke_cli(['exec', '-f', '-U', 'foo', jail.name, 'whoami'])
     assert jail.running is True
 
-    output = result.output.rstrip()
+    # If the jail is started, lots of output we don't care about
+    output = result.output.split()[-1].strip()
 
     assert output == 'foo', f'Jail user "foo" does not match output: {output}'
 
@@ -79,11 +80,12 @@ def test_03_exec_host_user_on_jail(resource_selector, skip_test, invoke_cli):
 
     jail = jails[0]
     result = invoke_cli(
-        ['exec', '-u', 'nobody', jail.name, 'whoami']
+        ['exec', '-f', '-u', 'nobody', jail.name, 'whoami']
     )
     assert jail.running is True
 
-    output = result.output.rstrip()
+    # If the jail is started, lots of output we don't care about
+    output = result.output.split()[-1].strip()
 
     assert output == 'nobody', \
         f'Host user "nobody" does not match output: {output}'

--- a/tests/functional_tests/0014_console_test.py
+++ b/tests/functional_tests/0014_console_test.py
@@ -48,7 +48,7 @@ def test_01_jail_console(invoke_cli, resource_selector, skip_test):
     failed = False
     try:
         console = subprocess.Popen(
-            ['iocage', 'console', jail.name],
+            ['iocage', 'console', '-f', jail.name],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE
         )
         console.communicate('touch console_test_file'.encode())


### PR DESCRIPTION
Restores old behavior before the commands were folded into the lib.

Closes #856
FreeNAS Ticket: #75468