### PR TITLE
You must set vnet=on to use VNET

### DIFF
--- a/doc/source/networking.rst
+++ b/doc/source/networking.rst
@@ -126,6 +126,10 @@ Add these tunables to :file:`/etc/sysctl.conf`:
    net.link.bridge.pfil_bridge=0  # Packet filter on the bridge interface
    net.link.bridge.pfil_member=0  # Packet filter on the member interface
 
+**Enable vnet for the jail**
+
+:samp:`# iocage set vnet=on examplejail`
+
 **Configure jail's default gateway**
 
 :samp:`# iocage set defaultrouter=10.1.1.254 examplejail`


### PR DESCRIPTION
The "legacy" network documentation tells to disable vnet if it is enabled, but if you skip directly to the VNET section, here is no indication of this setting.

Add a section telling this must be enabled.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
