### PR TITLE
tkt-77574: Add assign_localhost prop

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -906,7 +906,7 @@ def get_jail_freebsd_version(path, release):
 
 def check_truthy(value):
     """Checks if the given value is 'True'"""
-    if str(value).lower() in ('1', 'on', 'yes', 'true', 'True'):
+    if str(value).lower() in ('1', 'on', 'yes', 'true'):
         return 1
 
     return 0
@@ -928,3 +928,7 @@ def is_tty():
         is_tty = False
 
     return is_tty
+
+
+def lowercase_set(values):
+    return set([v.lower() for v in values])

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -906,7 +906,7 @@ def get_jail_freebsd_version(path, release):
 
 def check_truthy(value):
     """Checks if the given value is 'True'"""
-    if str(value) in ('1', 'on', 'yes', 'true'):
+    if str(value).lower() in ('1', 'on', 'yes', 'true', 'True'):
         return 1
 
     return 0

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -528,7 +528,12 @@ class IOCCreate(object):
 
                     for line in _etc_hosts.readlines():
                         if line.startswith("127.0.0.1"):
-                            line = f"{line.rstrip()} {jail_uuid_short}\n"
+                            if config.get('assign_localhost'):
+                                line = '127.0.1.1\t\tlocalhost' \
+                                       ' localhost.my.domain' \
+                                       f' {jail_uuid_short}\n'
+                            else:
+                                line = f'{line.rstrip()} {jail_uuid_short}\n'
 
                         etc_hosts.write(line)
                     else:

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -406,11 +406,11 @@ class IOCCreate(object):
                 is_template = True
             elif key == 'ip6_addr':
                 if 'accept_rtadv' in value:
-                    if not set(
+                    if not iocage_lib.ioc_common.lowercase_set(
                         iocage_lib.ioc_common.construct_truthy(
                             'vnet'
                         )
-                    ) & set(self.props):
+                    ) & iocage_lib.ioc_common.lowercase_set(self.props):
                         iocage_lib.ioc_common.logit({
                             'level': 'WARNING',
                             'message': 'accept_rtadv requires vnet,'
@@ -424,11 +424,11 @@ class IOCCreate(object):
             elif (key == 'dhcp' and is_true) or (
                 key == 'ip4_addr' and 'DHCP' in value.upper()
             ):
-                if not set(
+                if not iocage_lib.ioc_common.lowercase_set(
                     iocage_lib.ioc_common.construct_truthy(
                         'vnet'
                     )
-                ) & set(self.props):
+                ) & iocage_lib.ioc_common.lowercase_set(self.props):
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
                         'message': 'dhcp requires vnet, enabling!'
@@ -436,11 +436,11 @@ class IOCCreate(object):
                         _callback=self.callback,
                         silent=self.silent)
                     config['vnet'] = 1
-                if not set(
+                if not iocage_lib.ioc_common.lowercase_set(
                     iocage_lib.ioc_common.construct_truthy(
                         'bpf'
                     )
-                ) & set(self.props):
+                ) & iocage_lib.ioc_common.lowercase_set(self.props):
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
                         'message': 'dhcp requires bpf, enabling!'
@@ -449,11 +449,11 @@ class IOCCreate(object):
                         silent=self.silent)
                     config['bpf'] = 1
             elif key == 'bpf' and is_true:
-                if not set(
+                if not iocage_lib.ioc_common.lowercase_set(
                     iocage_lib.ioc_common.construct_truthy(
                         'vnet'
                     )
-                ) & set(self.props):
+                ) & iocage_lib.ioc_common.lowercase_set(self.props):
                     iocage_lib.ioc_common.logit({
                         'level': 'WARNING',
                         'message': 'bpf requires vnet, enabling!'

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1018,6 +1018,10 @@ class IOCConfiguration(IOCZFS):
         if not conf.get('exec_created'):
             conf['exec_created'] = '/usr/bin/true'
 
+        # Version 21 keys
+        if not conf.get('assign_localhost'):
+            conf['assign_localhost'] = 0
+
         if not default:
             conf.update(jail_conf)
 
@@ -1336,7 +1340,8 @@ class IOCConfiguration(IOCZFS):
             'depends': 'none',
             'vnet_interfaces': 'none',
             'rtsold': 0,
-            'ip_hostname': 0
+            'ip_hostname': 0,
+            'assign_localhost': 0
         }
 
         try:
@@ -1435,7 +1440,8 @@ class IOCJson(IOCConfiguration):
             'mount_devfs',
             'ip6_saddrsel',
             'ip4_saddrsel',
-            'ip_hostname'
+            'ip_hostname',
+            'assign_localhost'
         ]
         super().__init__(location, checking_datasets, silent, callback)
 
@@ -2243,7 +2249,8 @@ class IOCJson(IOCConfiguration):
             "depends": ("string", ),
             "allow_tun": truth_variations,
             'rtsold': truth_variations,
-            'ip_hostname': truth_variations
+            'ip_hostname': truth_variations,
+            'assign_localhost': truth_variations
         }
 
         zfs_props = {
@@ -2291,7 +2298,7 @@ class IOCJson(IOCConfiguration):
             # Either it contains what we expect, or it's a string.
 
             for k in props[key]:
-                if k in value:
+                if k in value.lower():
                     return value, conf
 
             if props[key][0] == 'string':

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -673,7 +673,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '20'
+        version = '21'
 
         return version
 

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -289,23 +289,27 @@ class IOCStart(object):
             ip6 = self.conf['ip6']
             net = []
 
-            if ip4_addr != 'none':
-                ip4_addr = self.check_aliases(ip4_addr, '4')
-
-                net.append(f'ip4.addr={ip4_addr}')
-
-            if ip6_addr != 'none':
-                ip6_addr = self.check_aliases(ip6_addr, '6')
-
-                net.append(f'ip6.addr={ip6_addr}')
-
             if assign_localhost:
                 # Make sure this exists, jail(8) will tear it down if we don't
                 # manually do this.
                 if self.check_aliases('127.0.1.1', '4') != '127.0.1.1':
                     su.run(['ifconfig', 'lo0', 'alias', '127.0.1.1/32'])
 
-                net.append(f'ip4.addr=127.0.1.1')
+            if ip4_addr != 'none':
+                ip4_addr = self.check_aliases(ip4_addr, '4')
+
+                if assign_localhost:
+                    net.append(f'ip4.addr={ip4_addr},127.0.1.1')
+                else:
+                    net.append(f'ip4.addr={ip4_addr}')
+            else:
+                if assign_localhost:
+                    net.append(f'ip4.addr=127.0.1.1')
+
+            if ip6_addr != 'none':
+                ip6_addr = self.check_aliases(ip6_addr, '6')
+
+                net.append(f'ip6.addr={ip6_addr}')
 
             net += [
                 f'ip4.saddrsel={ip4_saddrsel}',

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -158,6 +158,7 @@ class IOCStart(object):
         prop_missing_msgs = []
         debug_mode = True if os.environ.get(
             'IOCAGE_DEBUG', 'FALSE') == 'TRUE' else False
+        assign_localhost = self.conf['assign_localhost']
 
         if wants_dhcp:
             if not bpf:
@@ -297,6 +298,14 @@ class IOCStart(object):
                 ip6_addr = self.check_aliases(ip6_addr, '6')
 
                 net.append(f'ip6.addr={ip6_addr}')
+
+            if assign_localhost:
+                # Make sure this exists, jail(8) will tear it down if we don't
+                # manually do this.
+                if self.check_aliases('127.0.1.1', '4') != '127.0.1.1':
+                    su.run(['ifconfig', 'lo0', 'alias', '127.0.1.1/32'])
+
+                net.append(f'ip4.addr=127.0.1.1')
 
             net += [
                 f'ip4.saddrsel={ip4_saddrsel}',

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -295,16 +295,15 @@ class IOCStart(object):
                 if self.check_aliases('127.0.1.1', '4') != '127.0.1.1':
                     su.run(['ifconfig', 'lo0', 'alias', '127.0.1.1/32'])
 
+                if ip4_addr == 'none':
+                    ip4_addr = '127.0.1.1'
+                else:
+                    ip4_addr += ',127.0.1.1'
+
             if ip4_addr != 'none':
                 ip4_addr = self.check_aliases(ip4_addr, '4')
 
-                if assign_localhost:
-                    net.append(f'ip4.addr={ip4_addr},127.0.1.1')
-                else:
-                    net.append(f'ip4.addr={ip4_addr}')
-            else:
-                if assign_localhost:
-                    net.append(f'ip4.addr=127.0.1.1')
+                net.append(f'ip4.addr={ip4_addr}')
 
             if ip6_addr != 'none':
                 ip6_addr = self.check_aliases(ip6_addr, '6')

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1039,11 +1039,12 @@ class IOCage(ioc_json.IOCZFS):
 
                 return rel_list
 
-            if not ip and (not set(
+            if not ip and (not ioc_common.lowercase_set(
                 ioc_common.construct_truthy('dhcp')
-            ) & set(props) and not set(
-                ioc_common.construct_truthy('ip_hostname')
-            ) & set(props)):
+            ) & ioc_common.lowercase_set(
+                props) and not ioc_common.lowercase_set(
+                    ioc_common.construct_truthy('ip_hostname')
+            ) & ioc_common.lowercase_set(props)):
                 ioc_common.logit(
                     {
                         "level":


### PR DESCRIPTION
This property will assign a localhost of 127.0.1.1 to all jails that have this property enabled. It will also change the /etc/hosts entry to reflect this change if you set it during creation, otherwise it is manual.

- Also allow True/False for truthy props.

FreeNAS Ticket: #77574