### PR TITLE
tkt-77574: Add property localhost_ip

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -940,10 +940,11 @@ def gen_unused_lo_ip():
     """Best effort to try to allocate a localhost IP for a jail"""
     interface_addrs = netifaces.ifaddresses('lo0')
     inuse = [ip['addr'] for ips in interface_addrs.values() for ip in ips
-             if ip['addr'].startswith('127.0')]
+             if ip['addr'].startswith('127')]
 
     for ip in ipaddress.IPv4Network('127.0.0.0/8'):
-        ip = ipaddress.ip_address(ip) + 1
+        if str(ip) == '127.0.0.0':
+            continue
 
         if str(ip) not in inuse:
             return str(ip)

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -37,6 +37,8 @@ import datetime as dt
 import re
 import shlex
 import glob
+import netifaces
+import ipaddress
 
 import iocage_lib.ioc_exceptions
 import iocage_lib.ioc_exec
@@ -932,3 +934,16 @@ def is_tty():
 
 def lowercase_set(values):
     return set([v.lower() for v in values])
+
+
+def generate_unused_ip(ip_prefix, interface='lo0'):
+    """Best effort to try to allocate an IP for a jail"""
+    interface_addrs = netifaces.ifaddresses(interface)
+    addresses = [ip['addr'] for ips in interface_addrs.values() for ip in ips
+                 if ip['addr'].startswith(ip_prefix)]
+
+    for ip in addresses:
+        ip = str(ipaddress.ip_address(ip) + 1)
+
+        if ip not in addresses:
+            return ip

--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -567,8 +567,7 @@ class IOCCreate(object):
                             ) and not config.get('vnet'):
                                 l_ip = config.get('localhost_ip', 'none')
                                 l_ip = l_ip if l_ip != 'none' else \
-                                    iocage_lib.ioc_common.generate_unused_ip(
-                                        '127.')
+                                    iocage_lib.ioc_common.gen_unused_lo_ip()
                                 config['localhost_ip'] = l_ip
                                 iocjson.json_write(config)
 

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -709,7 +709,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '21'
+        version = '22'
 
         return version
 
@@ -1058,6 +1058,10 @@ class IOCConfiguration(IOCZFS):
         if not conf.get('assign_localhost'):
             conf['assign_localhost'] = 0
 
+        # Version 22 keys
+        if not conf.get('localhost_ip'):
+            conf['localhost_ip'] = 'none'
+
         if not default:
             conf.update(jail_conf)
 
@@ -1377,7 +1381,8 @@ class IOCConfiguration(IOCZFS):
             'vnet_interfaces': 'none',
             'rtsold': 0,
             'ip_hostname': 0,
-            'assign_localhost': 0
+            'assign_localhost': 0,
+            'localhost_ip': 'none'
         }
 
         try:
@@ -2286,7 +2291,8 @@ class IOCJson(IOCConfiguration):
             "allow_tun": truth_variations,
             'rtsold': truth_variations,
             'ip_hostname': truth_variations,
-            'assign_localhost': truth_variations
+            'assign_localhost': truth_variations,
+            'localhost_ip': ('string', )
         }
 
         zfs_props = {

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -2459,17 +2459,18 @@ class IOCJson(IOCConfiguration):
                 elif key == 'cpuset':
                     IOCCpuset.validate_cpuset_prop(value)
                 elif key == 'localhost_ip':
-                    try:
-                        ipaddress.IPv4Address(value)
-                    except ipaddress.AddressValueError as e:
-                        iocage_lib.ioc_common.logit(
-                            {
-                                'level': 'EXCEPTION',
-                                'message': f'Invalid IPv4 address: {e}'
-                            },
-                            _callback=self.callback,
-                            silent=self.silent
-                        )
+                    if value != 'none':
+                        try:
+                            ipaddress.IPv4Address(value)
+                        except ipaddress.AddressValueError as e:
+                            iocage_lib.ioc_common.logit(
+                                {
+                                    'level': 'EXCEPTION',
+                                    'message': f'Invalid IPv4 address: {e}'
+                                },
+                                _callback=self.callback,
+                                silent=self.silent
+                            )
 
                 return value, conf
             else:

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -2458,6 +2458,18 @@ class IOCJson(IOCConfiguration):
                     IOCRCTL.validate_rctl_props(key, value)
                 elif key == 'cpuset':
                     IOCCpuset.validate_cpuset_prop(value)
+                elif key == 'localhost_ip':
+                    try:
+                        ipaddress.IPv4Address(value)
+                    except ipaddress.AddressValueError as e:
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'EXCEPTION',
+                                'message': f'Invalid IPv4 address: {e}'
+                            },
+                            _callback=self.callback,
+                            silent=self.silent
+                        )
 
                 return value, conf
             else:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -294,8 +294,7 @@ class IOCStart(object):
                 # Make sure this exists, jail(8) will tear it down if we don't
                 # manually do this.
                 if localhost_ip == 'none':
-                    localhost_ip = iocage_lib.ioc_common.generate_unused_ip(
-                        '127.')
+                    localhost_ip = iocage_lib.ioc_common.gen_unused_lo_ip()
                     self.conf['localhost_ip'] = localhost_ip
 
                 if self.check_aliases(localhost_ip, '4') != localhost_ip:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -297,6 +297,18 @@ class IOCStart(object):
                     localhost_ip = iocage_lib.ioc_common.gen_unused_lo_ip()
                     self.set(f'localhost_ip={localhost_ip}')
 
+                with open(
+                        f'{self.path}/root/etc/hosts', 'r'
+                ) as _etc_hosts:
+                    with iocage_lib.ioc_common.open_atomic(
+                            f'{self.path}/root/etc/hosts', 'w') as etc_hosts:
+                        # open_atomic will empty the file, we need these still.
+                        for line in _etc_hosts.readlines():
+                            if line.startswith('127.0.0.1'):
+                                line = line.replace('127.0.0.1', localhost_ip)
+
+                            etc_hosts.write(line)
+
                 if self.check_aliases(localhost_ip, '4') != localhost_ip:
                     su.run(['ifconfig', 'lo0', 'alias', f'{localhost_ip}/32'])
                 else:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -295,7 +295,7 @@ class IOCStart(object):
                 # manually do this.
                 if localhost_ip == 'none':
                     localhost_ip = iocage_lib.ioc_common.gen_unused_lo_ip()
-                    self.conf['localhost_ip'] = localhost_ip
+                    self.set(f'localhost_ip={localhost_ip}')
 
                 if self.check_aliases(localhost_ip, '4') != localhost_ip:
                     su.run(['ifconfig', 'lo0', 'alias', f'{localhost_ip}/32'])

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -306,7 +306,8 @@ class IOCStart(object):
                         capture_output=True
                     ).stdout)['jail-information']['jail']
                     active_jail_ips = [
-                        ip['ip4.addr'] for ip in active_jail_ips]
+                        ip.get('ip4.addr') for ip in active_jail_ips
+                    ]
 
                     if localhost_ip in active_jail_ips:
                         iocage_lib.ioc_common.logit({


### PR DESCRIPTION
This property will allow a user to specify which address to assign during creation if assign_localhost is True and vnet is False.

- Add new method to generate unused IP's
- Alias localhost IP's during creation
- Check for active jail IP's and warn the user if they have a jail already using this IP as it may be fatal

FreeNAS Ticket: #77574