### PR TITLE
Change default open to io.open to handle unicode in freebsd-version

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -896,7 +896,9 @@ def get_jail_freebsd_version(path, release):
         # 9.3-RELEASE and under don't actually have this binary
         new_release = release
     else:
-        with io.open(f'{path}/bin/freebsd-version', mode='r', encoding='utf-8') as r:
+        with io.open(
+            f'{path}/bin/freebsd-version', mode='r', encoding='utf-8'
+        ) as r:
             for line in r:
                 if line.startswith('USERLAND_VERSION'):
                     new_release = line.rstrip().partition('=')[

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -37,7 +37,6 @@ import datetime as dt
 import re
 import shlex
 import glob
-import io
 
 import iocage_lib.ioc_exceptions
 import iocage_lib.ioc_exec

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -896,7 +896,7 @@ def get_jail_freebsd_version(path, release):
         # 9.3-RELEASE and under don't actually have this binary
         new_release = release
     else:
-        with io.open(
+        with open(
             f'{path}/bin/freebsd-version', mode='r', encoding='utf-8'
         ) as r:
             for line in r:

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -37,6 +37,7 @@ import datetime as dt
 import re
 import shlex
 import glob
+import io
 
 import iocage_lib.ioc_exceptions
 import iocage_lib.ioc_exec
@@ -895,7 +896,7 @@ def get_jail_freebsd_version(path, release):
         # 9.3-RELEASE and under don't actually have this binary
         new_release = release
     else:
-        with open(f'{path}/bin/freebsd-version', 'r') as r:
+        with io.open(f'{path}/bin/freebsd-version', mode='r', encoding='utf-8') as r:
             for line in r:
                 if line.startswith('USERLAND_VERSION'):
                     new_release = line.rstrip().partition('=')[

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1123,7 +1123,9 @@ class IOCConfiguration(IOCZFS):
             pass
         else:
             try:
-                with open(freebsd_version, 'r') as r:
+                with open(
+                    freebsd_version, mode='r', encoding='utf-8'
+                ) as r:
                     for line in r:
                         if line.startswith('USERLAND_VERSION'):
                             release = line.rstrip().partition('=')[2]

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -305,7 +305,9 @@ class IOCPlugin(object):
                 self.release, self.callback, self.silent)
 
             try:
-                with open(freebsd_version, "r") as r:
+                with open(
+                    freebsd_version, mode='r', encoding='utf-8'
+                ) as r:
                     for line in r:
                         if line.startswith("USERLAND_VERSION"):
                             release = line.rstrip().partition("=")[2].strip(
@@ -323,7 +325,9 @@ class IOCPlugin(object):
                 self.__fetch_release__(self.release)
 
                 # We still want this.
-                with open(freebsd_version, "r") as r:
+                with open(
+                    freebsd_version, mode='r', encoding='utf-8'
+                ) as r:
                     for line in r:
                         if line.startswith("USERLAND_VERSION"):
                             release = line.rstrip().partition("=")[2].strip(


### PR DESCRIPTION
The file `bin/freebsd-version` in each Jail contains a maintainer-line, which for 12.0 is
```
# Copyright (c) 2013 Dag-Erling Smørgrav
```
which contains a Unicode character that trips the `startswith` in https://github.com/iocage/iocage/blob/1e5339376f376945c365c7d2e5be045aee4b0ff9/iocage_lib/ioc_common.py#L898-L902

This fix changes `open` to `io.open` including setting the correct character set, allowing the code to finish without exception.