### PR TITLE
tkt-78546: Don't die on plugin upgrade if snapshot exists

### DIFF
--- a/iocage_lib/ioc_exceptions.py
+++ b/iocage_lib/ioc_exceptions.py
@@ -75,6 +75,10 @@ class ValueNotFound(Exception):
     pass
 
 
+class Exists(ExceptionWithMsg):
+    pass
+
+
 @contextmanager
 def ignore_exceptions(*exceptions, clean=None, suppress_exception=True):
     """

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1038,7 +1038,12 @@ fingerprint: {fingerprint}
             _callback=self.callback,
             silent=self.silent)
 
-        self.__snapshot_jail__(name="upgrade")
+        try:
+            self.__snapshot_jail__(name="upgrade")
+        except iocage_lib.ioc_exceptions.Exists:
+            # User may have run upgrade already (so clean) or they created this
+            # snapshot purposely, this is OK
+            pass
 
         iocage_lib.ioc_common.logit(
             {

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -840,7 +840,12 @@ fingerprint: {fingerprint}
             _callback=self.callback,
             silent=self.silent)
 
-        self.__snapshot_jail__(name="update")
+        try:
+            self.__snapshot_jail__(name='update')
+        except iocage_lib.ioc_exceptions.Exists:
+            # User may have run update already (so clean) or they created this
+            # snapshot purposely, this is OK
+            pass
 
         iocage_lib.ioc_common.logit(
             {
@@ -1039,7 +1044,7 @@ fingerprint: {fingerprint}
             silent=self.silent)
 
         try:
-            self.__snapshot_jail__(name="upgrade")
+            self.__snapshot_jail__(name='upgrade')
         except iocage_lib.ioc_exceptions.Exists:
             # User may have run upgrade already (so clean) or they created this
             # snapshot purposely, this is OK

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -80,8 +80,6 @@ class IOCUpgrade(iocage_lib.ioc_json.IOCZFS):
         }
 
         self.callback = callback
-        # Work around for https://github.com/freebsd/freebsd/commit/bffa924f
-        os.environ['UNAME_r'] = self.jail_release
 
     def upgrade_jail(self):
         tmp_dataset = self.zfs_get_dataset_name('/tmp')

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1761,11 +1761,13 @@ class IOCage(ioc_json.IOCZFS):
             if err.code == libzfs.Error.EXISTS:
                 ioc_common.logit(
                     {
-                        "level": "EXCEPTION",
-                        "message": "Snapshot already exists!"
+                        'level': 'EXCEPTION',
+                        'message': 'Snapshot already exists!',
+                        'force_raise': True
                     },
                     _callback=self.callback,
-                    silent=self.silent)
+                    silent=self.silent,
+                    exception=ioc_exceptions.Exists)
             else:
                 raise ()
 


### PR DESCRIPTION
- Add new class of exception, Exists
- Remove env pollution as upstream has fixed this issue and will cause issues in the FreeNAS middleware
- Raise the new exception on snapshotting when appropriate

FreeNAS Ticket: #78546