### PR TITLE
Plugin jails with placeholders in the PORTALADMIN may start automatically…

### DIFF
--- a/iocage_lib/ioc_list.py
+++ b/iocage_lib/ioc_list.py
@@ -314,13 +314,16 @@ class IOCList(object):
 
                         try:
                             ph = ui_data["adminportal_placeholders"].items()
-                            for placeholder, prop in ph:
-                                admin_portal = admin_portal.replace(
-                                    placeholder,
-                                    iocage_lib.ioc_json.IOCJson(
-                                        mountpoint).json_plugin_get_value(
-                                        prop.split("."))
-                                )
+                            if ph and not status:
+                                admin_portal = f"{uuid} is not running!"
+                            else:
+                                for placeholder, prop in ph:
+                                    admin_portal = admin_portal.replace(
+                                        placeholder,
+                                        iocage_lib.ioc_json.IOCJson(
+                                            mountpoint).json_plugin_get_value(
+                                            prop.split("."))
+                                    )
                         except KeyError:
                             pass
                         except iocage_lib.ioc_exceptions.CommandNeedsRoot:


### PR DESCRIPTION
…when executing 'iocage list -P' as root.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

This is a follow-up to #878 (FreeNAS Ticket: #77421) ;  when executing `iocage list -P` as root, for plugins that have a complex URL (i.e. with placeholders) , it will call method json_plugin_get_value that may automatically and unintentionally start up that jail when it's not running.
```
➜  iocage git:(list_starts_jail) iocage list -P
+-----+--------+------+-------+----------+-----------------+------------------------+-----+----------+--------------------------------+
| JID |  NAME  | BOOT | STATE |   TYPE   |     RELEASE     |          IP4           | IP6 | TEMPLATE |             PORTAL             |
+=====+========+======+=======+==========+=================+========================+=====+==========+================================+
| -   | mineos | on   | down  | pluginv2 | 11.2-RELEASE-p9 | wlan0|192.168.0.210/24 | -   | -        | Admin Portal requires root     |
+-----+--------+------+-------+----------+-----------------+------------------------+-----+----------+--------------------------------+
| -   | plex   | on   | down  | pluginv2 | 11.2-RELEASE-p9 | wlan0|192.168.0.211/24 | -   | -        | http://192.168.0.211:32400/web |
+-----+--------+------+-------+----------+-----------------+------------------------+-----+----------+--------------------------------+
➜  iocage git:(list_starts_jail) sudo iocage list -P

Command output:
+-----+--------+------+-------+----------+-----------------+------------------------+-----+----------+--------------------------------+
| JID |  NAME  | BOOT | STATE |   TYPE   |     RELEASE     |          IP4           | IP6 | TEMPLATE |             PORTAL             |
+=====+========+======+=======+==========+=================+========================+=====+==========+================================+
| -   | mineos | on   | down  | pluginv2 | 11.2-RELEASE-p9 | wlan0|192.168.0.210/24 | -   | -        | http://192.168.0.210:8443      |
+-----+--------+------+-------+----------+-----------------+------------------------+-----+----------+--------------------------------+
| -   | plex   | on   | down  | pluginv2 | 11.2-RELEASE-p9 | wlan0|192.168.0.211/24 | -   | -        | http://192.168.0.211:32400/web |
+-----+--------+------+-------+----------+-----------------+------------------------+-----+----------+--------------------------------+
➜  iocage git:(list_starts_jail) iocage list    
+-----+--------+-------+--------------+---------------+
| JID |  NAME  | STATE |   RELEASE    |      IP4      |
+=====+========+=======+==============+===============+
| 9   | mineos | up    | 11.2-RELEASE | 192.168.0.210 |
+-----+--------+-------+--------------+---------------+
| -   | plex   | down  | 11.2-RELEASE | 192.168.0.211 |
+-----+--------+-------+--------------+---------------+
| -   | test   | down  | 11.2-RELEASE | DHCP          |
+-----+--------+-------+--------------+---------------+

```
This PR fixes this behavior.




