### PR TITLE
Fix fstab corruption issue

### DIFF
--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -333,7 +333,7 @@ class IOCFstab(object):
                             _callback=self.callback,
                             silent=self.silent)
                     else:
-                        fstab.write(line)
+                        fstab.write(f'{line}\n')
 
             if not matched:
                 iocage_lib.ioc_common.logit({


### PR DESCRIPTION
Fix issue of fstab getting corrupted on editing because of missing newlines when writing.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
