### PR TITLE
Use .replace('.', '_') here as well?

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1536,7 +1536,7 @@ class IOCJson(IOCConfiguration):
         if state:
             ruleset = su.check_output(
                 [
-                    "jls", "-j", f"ioc-{conf['host_hostuuid'].replace('.', '_')}",
+                    "jls", "-j", f'ioc-{conf["host_hostuuid"].replace(".", "_")}',
                     'devfs_ruleset'
                 ]
             ).decode().rstrip()

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1536,7 +1536,7 @@ class IOCJson(IOCConfiguration):
         if state:
             ruleset = su.check_output(
                 [
-                    'jls', '-j', f'ioc-{conf["host_hostuuid"]}',
+                    "jls", "-j", f"ioc-{conf['host_hostuuid'].replace('.', '_')}",
                     'devfs_ruleset'
                 ]
             ).decode().rstrip()

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1536,7 +1536,7 @@ class IOCJson(IOCConfiguration):
         if state:
             ruleset = su.check_output(
                 [
-                    "jls", "-j", f'ioc-{conf["host_hostuuid"].replace(".", "_")}',
+                    'jls', '-j', f'ioc-{conf["host_hostuuid"].replace(".", "_")}',
                     'devfs_ruleset'
                 ]
             ).decode().rstrip()

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1536,7 +1536,8 @@ class IOCJson(IOCConfiguration):
         if state:
             ruleset = su.check_output(
                 [
-                    'jls', '-j', f'ioc-{conf["host_hostuuid"].replace(".", "_")}',
+                    'jls', '-j',
+                    f'ioc-{conf["host_hostuuid"].replace(".", "_")}',
                     'devfs_ruleset'
                 ]
             ).decode().rstrip()


### PR DESCRIPTION
I believe we should replace . with _ here as well as we do in list_get_jid ioc_list.py?
This unborked my jails (named www_test_com) after upgrading from iocage 1.1 to master.