### PR TITLE
NAS-101270 / 11.3 / Replace old fstab locations 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv-*/
 *~
 
 nvim\.core
+/tags

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -221,7 +221,6 @@ class IOCFstab(object):
                             silent=self.silent)
                         source = src
 
-
             if not source.is_absolute():
                 if fstype == 'nullfs':
                     verrors.append(

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -45,7 +45,7 @@ class IOCFstab(object):
     def __init__(self, uuid, action, source='', destination='', fstype='',
                  fsoptions='', fsdump='', fspass='', index=None, silent=False,
                  callback=None, header=False, _fstab_list=None
-    ):
+                 ):
         self.pool = iocage_lib.ioc_json.IOCJson().json_get_value("pool")
         self.iocroot = iocage_lib.ioc_json.IOCJson(
             self.pool).json_get_value("iocroot")

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -182,6 +182,8 @@ class IOCFstab(object):
                         dst = str(dest).split('/iocage')[1]
                         dst = pathlib.Path(f'{self.iocroot}/{dst}')
 
+                    # If the correct iocroot + dir still does not exist, let's
+                    # prompt them about their original desination
                     if not dst.is_dir():
                         verrors.append(
                             f'Destination: {destination} does not include '
@@ -207,6 +209,8 @@ class IOCFstab(object):
                         src = str(source).split('/iocage')[1]
                         src = pathlib.Path(f'{self.iocroot}/{src}')
 
+                    # If the correct iocroot + dir still does not exist, let's
+                    # prompt them about their original source
                     if not src.is_dir():
                         verrors.append(f'Source: {source} does not exist!')
                     else:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -182,7 +182,7 @@ class IOCStart(object):
 
         iocage_lib.ioc_fstab.IOCFstab(
             self.uuid,
-            'list', '', '', '', '', '', '',
+            'list'
         ).__validate_fstab__(fstab_list, 'all')
 
         if wants_dhcp:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -174,6 +174,17 @@ class IOCStart(object):
         self.defaultrouter = self.conf['defaultrouter']
         self.defaultrouter6 = self.conf['defaultrouter6']
 
+        fstab_list = []
+        with open(f'{self.iocroot}/jails/{self.uuid}/fstab', 'r') as _fstab:
+            for line in _fstab.readlines():
+                line = line.rsplit("#")[0].rstrip()
+                fstab_list.append(line)
+
+        iocage_lib.ioc_fstab.IOCFstab(
+            self.uuid,
+            'list', '', '', '', '', '', '',
+        ).__validate_fstab__(fstab_list, 'all')
+
         if wants_dhcp:
             if not bpf:
                 prop_missing_msgs.append(


### PR DESCRIPTION
This will replace the old iocage mountpoints (/mnt/iocage or /iocage) with the current structure (/mnt/POOL/iocage or /POOL/iocage) if the new source/destination directory exist.

This also corrects an issue with replacing an index not writing new line endings. We check these during all fstab operations except list, and during start.

NAS-101270