### PR TITLE
Fix regression: "iocage fetch --plugins" broken

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -94,7 +94,7 @@ class IOCPlugin(object):
                 plugins = json.load(plugins)
         except FileNotFoundError:
             # Fresh dataset, time to fetch fresh INDEX
-            plugins = self.fetch_plugin_index(props)
+            plugins = self.fetch_plugin_index(props, index_only=True)
 
         try:
             with open(_json, "r") as j:
@@ -679,7 +679,8 @@ fingerprint: {fingerprint}
                            list_long=False,
                            accept_license=False,
                            icon=False,
-                           official=False):
+                           official=False,
+                           index_only=False):
 
         if self.server == "download.freebsd.org":
             git_server = "https://github.com/freenas/iocage-ix-plugins.git"
@@ -704,12 +705,12 @@ fingerprint: {fingerprint}
         with open(f"{self.iocroot}/.plugin_index/INDEX", "r") as plugins:
             plugins = json.load(plugins)
 
-        if self.plugin is not None:
+        if index_only:
             return plugins
 
         _plugins = self.__fetch_sort_plugin__(plugins, official=official)
 
-        if not _list:
+        if self.plugin is None and not _list:
             for p in _plugins:
                 iocage_lib.ioc_common.logit(
                     {
@@ -762,9 +763,15 @@ fingerprint: {fingerprint}
 
                 return table.draw()
 
-        self.plugin = input("\nType the number of the desired"
-                            " plugin\nPress [Enter] or type EXIT to"
-                            " quit: ")
+        if self.plugin is None:
+            self.plugin = input("\nType the number of the desired"
+                                " plugin\nPress [Enter] or type EXIT to"
+                                " quit: ")
+
+        self.plugin = self.__fetch_validate_plugin__(self.plugin.lower(),
+                                                     _plugins)
+        self.fetch_plugin(f"{self.iocroot}/.plugin_index/{self.plugin}.json",
+                          props, 0, accept_license)
 
     def __fetch_validate_plugin__(self, plugin, plugins):
         """


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

This is a follow-up to #899 Some of the code that was removed is still needed, otherwise `iocage fetch --plugins` was no longer functional:

```
➜  iocage git:(fix_regression_899) sudo iocage fetch --plugins -n plex vnet=off ip4_addr="wlan0|192.168.0.220/24"

Branch 12.0-RELEASE does not exist at https://github.com/freenas/iocage-ix-plugins.git!
Using "master" branch for plugin, this may not work with your RELEASE
➜  iocage git:(fix_regression_899) sudo iocage fetch --plugins -n whiskeytangofoxtrot vnet=off ip4_addr="wlan0|192.168.0.220/24"

Branch 12.0-RELEASE does not exist at https://github.com/freenas/iocage-ix-plugins.git!
Using "master" branch for plugin, this may not work with your RELEASE
➜  iocage git:(fix_regression_899) sudo iocage fetch --plugins vnet=off ip4_addr="wlan0|192.168.0.220/24" 

Branch 12.0-RELEASE does not exist at https://github.com/freenas/iocage-ix-plugins.git!
Using "master" branch for plugin, this may not work with your RELEASE
[0] BackupPC - BackupPC is a high-performance, enterprise-grade system for backing up Linux, WinXX and MacOSX PCs and laptops to a server's disk. (backuppc)
[1] Bacula-server - programs to manage backup, recovery, and verification of computer data across a network of computers of different kinds (bacula-server)
[2] BRU Server - BRU Server™ Backup and Recovery Software by TOLIS Group, Inc. (bru-server)
[3] ClamAV - ClamAV® is an open source antivirus engine for detecting trojans, viruses, malware & other malicious threats. (clamav)
(...snip...)
[37] XMRig - XMRig is a high performance Monero (XMR) CPU miner written in C++. (xmrig)
[38] Zoneminder - ZoneMinder is a free, open source Closed-circuit television software application developed for Linux which supports IP, USB and Analog cameras. (zoneminder)

Type the number of the desired plugin
Press [Enter] or type EXIT to quit: 12
➜  iocage git:(fix_regression_899) 
```
This PR restores the functionality and still addresses redmine bug 39653

