### PR TITLE
NAS-101560 / 11.3 / Warn users for bad perms

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -897,7 +897,19 @@ class IOCage(ioc_json.IOCZFS):
             login_flags = self.get('login_flags').split()
             console_cmd = ['login', '-p'] + login_flags
 
-            ioc_exec.InteractiveExec(console_cmd, path, uuid=uuid)
+            try:
+                ioc_exec.InteractiveExec(console_cmd, path, uuid=uuid)
+            except BaseException as e:
+                ioc_common.logit(
+                    {
+                        'level': 'ERROR',
+                        'message': 'Console failed!\nThe cause could be bad '
+                                   f'permissions for {path}/root/usr/lib.'
+                    },
+                    _callback=self.callback,
+                    silent=False
+                )
+                raise e
             return
 
         if interactive:


### PR DESCRIPTION
This commit adds a warning for users who have accidentally/deliberately changed ownership/permissions for /usr/lib inside jail. The warning appears when the user tries iocage console, we don't error out but just give the user a friendly notice that there is a good chance login(1) is not going to like the changed perms and so he/she should have that corrected.
Ticket: #NAS-101560
