### PR TITLE
Skip export/import tests by default

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -55,6 +55,8 @@ auth
     Authentication method for HTTP fetching. Valid values: basic, digest
 noupdate
     Decide whether or not to update the fetch to the latest patch level.
+image
+    Run the export and import operations.
 ```
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,10 @@ def pytest_addoption(parser):
         '--nat', action='store_true', default=False,
         help='Use NAT for creating jails'
     )
+    parser.addoption(
+        '--image', action='store_true', default=False,
+        help='Run image operations (export/import)'
+    )
 
 
 def pytest_runtest_setup(item):
@@ -135,6 +139,8 @@ def pytest_runtest_setup(item):
         pytest.skip(
             'Need either --dhcp or --jail_ip  or --nat option to run, not all'
         )
+    if 'require_image' in item.keywords and not item.config.getvalue('image'):
+        pytest.skip('Need --image option to run')
 
 
 @pytest.fixture
@@ -246,6 +252,10 @@ def noupdate(request):
     """ Decide whether or not to update the fetch to the latest patch level."""
     return request.config.getoption('--noupdate')
 
+@pytest.fixture
+def image(request):
+    """Run the export and import operations."""
+    return request.config.getoption('--image')
 
 @pytest.fixture
 def invoke_cli():

--- a/tests/data_classes.py
+++ b/tests/data_classes.py
@@ -274,7 +274,7 @@ class ZFS:
     pool_mountpoint = None
 
     def __init__(self):
-        self.set_pool()
+        pass
 
     def set_pool(self):
         if not self.pool:

--- a/tests/functional_tests/0012_export_test.py
+++ b/tests/functional_tests/0012_export_test.py
@@ -30,10 +30,12 @@ import pytest
 
 require_root = pytest.mark.require_root
 require_zpool = pytest.mark.require_zpool
+require_image = pytest.mark.require_image
 
 
 @require_root
 @require_zpool
+@require_image
 def test_01_export_jail(invoke_cli, resource_selector, skip_test):
     jails = resource_selector.stopped_jails
     skip_test(not jails)

--- a/tests/functional_tests/0013_import_test.py
+++ b/tests/functional_tests/0013_import_test.py
@@ -30,10 +30,12 @@ import re
 
 require_root = pytest.mark.require_root
 require_zpool = pytest.mark.require_zpool
+require_image = pytest.mark.require_image
 
 
 @require_root
 @require_zpool
+@require_image
 def test_01_import_jail(invoke_cli, jail, skip_test, remove_file, zfs):
     images_dataset_path = zfs.images_dataset_path
     list_dir = glob.glob(


### PR DESCRIPTION
This behavior can be disabled by specifying the —image flag.

In addition fix activate test when the pool supplied was different than the current activated pool

Signed-off-by: Brandon Schneider <github@bschneider.email>