### PR TITLE
Set default route only if it is configured

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -947,7 +947,7 @@ class IOCStart(object):
             wants_dhcp = dhcp or 'DHCP' in self.ip4_addr.upper()
             if not wants_dhcp and 'accept_rtadv' not in self.ip6_addr.lower():
                 for ip, default_route, ipv6 in filter(
-                    lambda v: v[0] != 'none',
+                    lambda v: v[0] != 'none' and v[1] != 'none',
                     net_configs
                 ):
                     try:


### PR DESCRIPTION
We have setups where it is valid to have no `defaultrouter6`.

`(host) inet0 <=> vnet0.29 <=> (jail) epair0b`
`(host) priv0 <=> vnet1.29 <=> (jail) epair1b`

Let's say `inet0` is IPv4 only. So no `defaultrouter6` is
needed. Nevertheless we want to communicate between the jails through
a host only network via IPv6. Then current `iocage` fails with
```
root@testhost:~ # iocage start testjail1
* Starting testjail1
  + Started OK
  + Using devfs_ruleset: 15
  + Configuring VNET FAILED
  route: writing to routing socket: Invalid argument
add net default fib 0: Invalid argument

Stopped testjail1 due to VNET failure
```
This is due the missing IP argument for `route`:
```
['setfib', '0', 'jexec', 'ioc-testjail1', 'route', 'add', 'default', 'AAA.BBB.CCC.DDD']
['setfib', '0', 'jexec', 'ioc-testjail1', 'route', 'add', '-6', 'default']
```
iocage 1.0 worked as expected, but the current version doesn't.

This PR does not take care of the fact that a jail with a common
network setup needs at least one default route to communicate with the
outside world.
