### PR TITLE
NAS-101507 / 11.3 / Improve jail updates

### DIFF
--- a/iocage_cli/pkg.py
+++ b/iocage_cli/pkg.py
@@ -37,4 +37,5 @@ __rootcmd__ = True
 @click.argument("command", nargs=-1, type=click.UNPROCESSED)
 def cli(command, jail):
     """Runs pkg with the command given inside the specified jail."""
-    ioc.IOCage(jail=jail).exec(command, unjailed=True)
+    skip_jails = jail != 'ALL'
+    ioc.IOCage(jail=jail, skip_jails=skip_jails).exec(command, unjailed=True)

--- a/iocage_cli/update.py
+++ b/iocage_cli/update.py
@@ -29,11 +29,17 @@ __rootcmd__ = True
 
 
 @click.command(
-    name="update",
-    help="Run freebsd-update to update a specified "
-    "jail to the latest patch level.")
-@click.argument("jail", required=True)
-def cli(jail):
+    name='update',
+    help='Run freebsd-update to update a specified '
+    'jail to the latest patch level.'
+)
+@click.option(
+    '--pkgs', '-P', default=False, is_flag=True,
+    help='Decide whether or not to update the pkg repositories and '
+         'all installed packages in jail( this has no effect for plugins ).'
+)
+@click.argument('jail', required=True)
+def cli(jail, pkgs):
     """Update the supplied jail to the latest patchset"""
     skip_jails = bool(jail != 'ALL')
-    ioc.IOCage(jail=jail, skip_jails=skip_jails).update()
+    ioc.IOCage(jail=jail, skip_jails=skip_jails).update(pkgs=pkgs)


### PR DESCRIPTION
This commit introduces following changes:
1) A flag to update pkg repositories in the jail and then upgrade all existing pkgs in the jail.
2) Ability to update jail itself instead of only the software inside them for plugins.
3) Allow running pkg/exec for ALL jails.

Ticket: #NAS-101507