### PR TITLE
NAS-101815 / 11.3 / Bug fixes for setting RELEASE property

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -956,7 +956,9 @@ class IOCFetch(iocage_lib.ioc_json.IOCZFS):
                 _json = iocage_lib.ioc_json.IOCJson(path)
                 props = _json.json_get_value('all')
 
-                if props['basejail'] and props['release'] == self.release:
+                if props['basejail'] and self.release.rsplit(
+                    '-', 1
+                ) in props['release']:
                     props['release'] = new_release
                     _json.json_write(props)
 

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -2072,20 +2072,13 @@ class IOCage(ioc_json.IOCZFS):
                 'level': 'INFO',
                 'message': 'Updating jail...'
             })
-            if not ioc_common.check_truthy(conf['basejail']):
-                new_release = ioc_fetch.IOCFetch(
-                    release,
-                    callback=self.callback
-                ).fetch_update(True, uuid)
 
-                conf['release'] = new_release
-                ioc_json.IOCJson(path).json_write(conf)
-            else:
-                # Basejails only need their RELEASE updated
-                ioc_fetch.IOCFetch(
-                    release,
-                    callback=self.callback
-                ).fetch_update()
+            is_basejail = ioc_common.check_truthy(conf['basejail'])
+            params = [] if is_basejail else [True, uuid]
+            ioc_fetch.IOCFetch(
+                release,
+                callback=self.callback
+            ).fetch_update(*params)
 
             ioc_common.logit({
                 'level': 'INFO',


### PR DESCRIPTION
This PR fixes following issues:
1) We didn't update the release property of a base jail when we updated it if the property in config did not match the supplied one when updating. How this is an issue is
that the first time we get a release which has not been updated will have the release as 11.2-RELEASE. First time we create a jail and update it to say 11.2-RELEASE-p4, it would be reflected as desired
because the release passed on to update was 11.2-RELEASE which matched with the jail's prop. Moving on the release specified to update would always be 11.2-RELEASE but the prop's value has changed so it would
not match and hence the property would not be updated.

2) It is possible the release got updated but still returned a non-zero status for some other minor issue. This ensures that even in case of an exception, we check the jail's release to ensure that release property correctly reflects the new jail release.

Ticket: #NAS-101815