### PR TITLE
NAS-102032 / 11.3 / Properly remove plugin index directory

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1361,7 +1361,7 @@ fingerprint: {fingerprint}
         ):
             # Clone
             try:
-                os.rmdir(destination)
+                shutil.rmtree(destination)
             except FileNotFoundError:
                 pass
             finally:


### PR DESCRIPTION
os.rmdir will fail to remove directory if it is not empty.
Ticket: #NAS-102032