### PR TITLE
NAS-102036 / 11.3 / Allow running pkg with nat

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -878,8 +878,11 @@ class IOCage(ioc_json.IOCZFS):
             ip4_addr = self.get("ip4_addr")
             ip6_addr = self.get("ip6_addr")
             dhcp = self.get("dhcp")
+            nat = self.get('nat')
 
-            if ip4_addr == "none" and ip6_addr == "none" and not dhcp:
+            if (
+                ip4_addr == ip6_addr == "none" and not dhcp and not nat
+            ):
                 ioc_common.logit(
                     {
                         "level":


### PR DESCRIPTION
This commit fixes an issue where if a jail was confifgured to run with nat, is unable to use pkg interface as we don't check nat when checking for network.
