### PR TITLE
NAS-102099 / 11.3 / IP4 address is wrong for NAT jails

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -343,6 +343,8 @@ class IOCStart(object):
                     self.conf['nat_prefix']
                 )
                 self.ip4_addr = f'{nat_interface}|{ip4_addr}'
+                # Make this reality for list
+                self.set(f'ip4_addr={self.ip4_addr}')
                 self.log.debug(f'Received ip4_addr: {self.ip4_addr}')
             else:
                 self.log.debug('VNET is True')
@@ -355,7 +357,11 @@ class IOCStart(object):
                         self.conf['nat_prefix']
                     )
                 self.ip4_addr = f'vnet0|{ip4_addr}/30'
+                # Make this reality for list
+                self.set(f'ip4_addr={self.ip4_addr}')
                 nat = self.defaultrouter
+                # Make this reality for list
+                self.set(f'defaultrouter={self.defaultrouter}')
                 self.log.debug(f'Received default_router: {nat}')
                 self.log.debug(f'Received ip4_addr: {self.ip4_addr}')
 


### PR DESCRIPTION
Currently ip4_addr and defaultrouter are not properly reflected when using NAT. So the admin portal is wrong, along with the information in the list output.

NAS-102099

Signed-off-by: Brandon Schneider <github@bschneider.email>