### PR TITLE
NAS-100704 / 11.3 / Add method to retrieve plugin versions

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -1025,3 +1025,17 @@ def get_used_ips():
                     addresses.append(address)
 
     return addresses
+
+
+def parse_package_name(pkg):
+    pkg, version = pkg.rsplit('-', 1)
+    epoch_split = version.rsplit(',', 1)
+    epoch = epoch_split[1] if len(epoch_split) == 2 else '0'
+    revision_split = epoch_split[0].rsplit('_', 1)
+    revision = \
+        revision_split[1] if len(revision_split) == 2 else '0'
+    return {
+        'version': revision_split[0],
+        'revision': revision,
+        'epoch': epoch,
+    }

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -771,35 +771,11 @@ fingerprint: {fingerprint}
             except FileNotFoundError:
                 pass
 
-    def fetch_plugin_index(self,
-                           props,
-                           _list=False,
-                           list_header=False,
-                           list_long=False,
-                           accept_license=False,
-                           icon=False,
-                           official=False,
-                           index_only=False):
-
-        if self.server == "download.freebsd.org":
-            git_server = "https://github.com/freenas/iocage-ix-plugins.git"
-        else:
-            git_server = self.server
-
-        git_working_dir = f"{self.iocroot}/.plugin_index"
-
-        # list --plugins won't often be root.
-
-        if os.geteuid() == 0:
-            try:
-                self.__clone_repo(git_server, git_working_dir)
-            except Exception as err:
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level": "EXCEPTION",
-                        "message": err
-                    },
-                    _callback=self.callback)
+    def fetch_plugin_index(
+        self, props, _list=False, list_header=False, list_long=False,
+        accept_license=False, icon=False, official=False, index_only=False
+    ):
+        self.clone_repo()
 
         with open(f"{self.iocroot}/.plugin_index/INDEX", "r") as plugins:
             plugins = json.load(plugins)

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -84,7 +84,7 @@ class IOCPlugin(object):
             # Backwards compat
             self.branch = 'master'
 
-    def clone_repo(self):
+    def clone_repo(self, depth=None):
         if self.server == "download.freebsd.org":
             git_server = "https://github.com/freenas/iocage-ix-plugins.git"
         else:
@@ -94,7 +94,7 @@ class IOCPlugin(object):
 
         if os.geteuid() == 0:
             try:
-                self.__clone_repo(git_server, git_working_dir)
+                self.__clone_repo(git_server, git_working_dir, depth)
             except Exception as err:
                 iocage_lib.ioc_common.logit(
                     {
@@ -1403,7 +1403,7 @@ fingerprint: {fingerprint}
         fetch_args = {'release': release, 'eol': False}
         iocage_lib.iocage.IOCage(silent=self.silent).fetch(**fetch_args)
 
-    def __clone_repo(self, repo_url, destination):
+    def __clone_repo(self, repo_url, destination, depth=None):
         """
         This is to replicate the functionality of cloning/pulling a repo
         """
@@ -1438,8 +1438,11 @@ fingerprint: {fingerprint}
             except FileNotFoundError:
                 pass
             finally:
+                kwargs = {'env': os.environ.copy(), 'depth': depth}
                 repo = git.Repo.clone_from(
-                    repo_url, destination, env=os.environ.copy()
+                    repo_url, destination, **{
+                        k: v for k, v in kwargs.items() if v
+                    }
                 )
                 origin = repo.remotes.origin
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -112,18 +112,8 @@ class IOCPlugin(object):
                 response.raise_for_status()
 
                 for pkg in re.findall(r'<a.*>\s*(\S+).txz</a>', response.text):
-
-                    pkg, version = pkg.rsplit('-', 1)
-                    epoch_split = version.rsplit(',', 1)
-                    epoch = epoch_split[1] if len(epoch_split) == 2 else '0'
-                    revision_split = epoch_split[0].rsplit('_', 1)
-                    revision = \
-                        revision_split[1] if len(revision_split) == 2 else '0'
-                    package_site_data[pkg] = {
-                        'version': revision_split[0],
-                        'revision': revision,
-                        'epoch': epoch,
-                    }
+                    package_site_data[pkg.rsplit('-', 1)[0]] = \
+                        iocage_lib.ioc_common.parse_package_name(pkg)
             except Exception:
                 pass
 

--- a/tests/unit_tests/1002_lib_pkg_parsing.py
+++ b/tests/unit_tests/1002_lib_pkg_parsing.py
@@ -1,0 +1,22 @@
+from iocage_lib.ioc_common import parse_package_name
+
+
+# Tests for point 1
+def test_01_version_check():
+    assert parse_package_name('ImageMagick7-7.0.8.47')['version'] == '7.0.8.47'
+    assert parse_package_name('ImageMagick7-7.0.8.47')['revision'] == '0'
+
+
+def test_02_revision():
+    assert parse_package_name('ORBit2-2.14.19_2.txz')['revision'] == '2'
+
+
+def test_03_epoch():
+    assert parse_package_name('ap24-mod_perl2-2.0.10,3')['epoch'] == '3'
+
+
+def test_04_version_revision_epoch():
+    data = parse_package_name('dnsmasq-2.80_2,1')
+    assert data['version'] == '2.80'
+    assert data['revision'] == '2'
+    assert data['epoch'] == '0'


### PR DESCRIPTION
This commit adds the ability to retrieve plugin versions via packagesite defined for each plugin. As packagesite can differ for each plugin, the only reliable way to make sure that version is valid is to use packagesite.txz and extract version from there.

For now this isn't exposed to CLI because i don't see a need to the why here ( time to execute one of the main reasons ). If we get a feature request or in the future, we can easily add a flag to expose this in the CLI.