### PR TITLE
NAS-102205 / 11.3 / Prop for plugin jails

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -700,7 +700,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '23'
+        version = '24'
 
         return version
 
@@ -1382,7 +1382,8 @@ class IOCConfiguration(IOCZFS):
             'nat_prefix': '172.16',
             'nat_interface': 'none',
             'nat_backend': 'ipfw',
-            'nat_forwards': 'none'
+            'nat_forwards': 'none',
+            'plugin_name': 'none',
         }
 
         try:
@@ -2306,7 +2307,8 @@ class IOCJson(IOCConfiguration):
             'nat_prefix': ('string', ),
             'nat_interface': ('string', ),
             'nat_backend': ('pf', 'ipfw'),
-            'nat_forwards': ('string', )
+            'nat_forwards': ('string', ),
+            'plugin_name': ('string', ),
         }
 
         zfs_props = {

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -53,6 +53,8 @@ class IOCPlugin(object):
     includes creation, updating and upgrading.
     """
 
+    PLUGIN_VERSION = '2'
+
     def __init__(self, release=None, jail=None, plugin=None, branch=None,
                  keep_jail_on_failure=False, callback=None, silent=False,
                  **kwargs):
@@ -435,12 +437,21 @@ class IOCPlugin(object):
 
         # We set our properties that we need, and then iterate over the user
         # supplied properties replacing ours.
-        create_props = [f'release={release}', 'type=pluginv2', 'boot=on',
-                        'vnet=1']
+        create_props = [
+            f'release={release}', 'boot=on', 'vnet=1'
+        ]
 
         create_props = create_props + [
             f"{k}={v}" for k, v in (p.split("=") for p in props)
         ]
+
+        # These properties are not user configurable
+
+        for prop in (
+            f'type=pluginv{self.PLUGIN_VERSION}',
+            f'plugin_name={self.plugin}'
+        ):
+            create_props.append(prop)
 
         return create_props, pkg_repos
 


### PR DESCRIPTION
This PR introduces a property which will keep track of which plugin a jail represents even after it has been renamed.