### PR TITLE
NAS-101249 / 11.3 / Bug fix for spaces in path names for fstab

### DIFF
--- a/iocage_cli/fstab.py
+++ b/iocage_cli/fstab.py
@@ -133,7 +133,8 @@ def cli(action, fstab_string, jail, header, replace):
             })
         else:
             for f in fstab:
+                line = '\t'.join(f[1])
                 ioc_common.logit({
                     "level": "INFO",
-                    "message": f'{f[0]}\t{f[1]}'
+                    "message": f'{f[0]}\t{line}'
                 })

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -463,7 +463,8 @@ class IOCFstab(object):
         """Returns list of lists, or a table"""
         flat_fstab = [
             (
-                i, self.__fstab_decode__(f)
+                i, [self.__fstab_decode__(v) for v in f.split()]
+                if not self.header else self.__fstab_decode__(f)
             ) for (i, f) in self.fstab
         ]
 


### PR DESCRIPTION
This commit fixes an issue where if spaces were defined in src/destination paths, we could not cleanly interpret where to split.