### PR TITLE
NAS-102274 / 11.3 / Update default json file

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -700,7 +700,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '24'
+        version = '24.1'
 
         return version
 
@@ -1070,6 +1070,10 @@ class IOCConfiguration(IOCZFS):
             conf['nat_backend'] = 'ipfw'
         if not conf.get('nat_forwards'):
             conf['nat_forwards'] = 'none'
+
+        # Version 24 key
+        if not conf.get('plugin_name'):
+            conf['plugin_name'] = 'none'
 
         if not default:
             conf.update(jail_conf)


### PR DESCRIPTION
This commit fixes a regression when which was introduced when we brought in plugin_name as a key in json configuration. The default json file was not updated previously which resulted in non plugin jails not being able to retrieve that prop at all.