### PR TITLE
NAS-102286 / 11.3 / Multiple Repository support for plugins

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -933,10 +933,13 @@ class IOCConfiguration(IOCZFS):
             if p in self.truthy_props:
                 conf[p] = 1 if iocage_lib.ioc_common.check_truthy(v) else 0
 
-        if conf.get('type') in ('plugin', 'pluginv2') \
-                and conf.get('plugin_repository', 'none') == 'none':
-            conf['plugin_repository'] = \
-                'https://github.com/freenas/iocage-ix-plugins.git'
+        if conf.get('type') in ('plugin', 'pluginv2'):
+            if conf.get('plugin_repository', 'none') == 'none':
+                conf['plugin_repository'] = \
+                    'https://github.com/freenas/iocage-ix-plugins.git'
+
+            if conf.get('host_hostuuid') and conf.get('plugin_name') == 'none':
+                conf['plugin_name'] = conf['host_hostuuid']
 
         return True if original_conf != conf else False
 

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -700,7 +700,7 @@ class IOCConfiguration(IOCZFS):
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '24.1'
+        version = '25'
 
         return version
 
@@ -933,6 +933,11 @@ class IOCConfiguration(IOCZFS):
             if p in self.truthy_props:
                 conf[p] = 1 if iocage_lib.ioc_common.check_truthy(v) else 0
 
+        if conf.get('type') in ('plugin', 'pluginv2') \
+                and conf.get('plugin_repository', 'none') == 'none':
+            conf['plugin_repository'] = \
+                'https://github.com/freenas/iocage-ix-plugins.git'
+
         return True if original_conf != conf else False
 
     def check_config(self, conf, default=False):
@@ -1074,6 +1079,10 @@ class IOCConfiguration(IOCZFS):
         # Version 24 key
         if not conf.get('plugin_name'):
             conf['plugin_name'] = 'none'
+
+        # Version 25 key
+        if not conf.get('plugin_repository'):
+            conf['plugin_repository'] = 'none'
 
         if not default:
             conf.update(jail_conf)
@@ -1388,6 +1397,7 @@ class IOCConfiguration(IOCZFS):
             'nat_backend': 'ipfw',
             'nat_forwards': 'none',
             'plugin_name': 'none',
+            'plugin_repository': 'none',
         }
 
         try:
@@ -2316,6 +2326,7 @@ class IOCJson(IOCConfiguration):
             'nat_backend': ('pf', 'ipfw'),
             'nat_forwards': ('string', ),
             'plugin_name': ('string', ),
+            'plugin_repository': ('string', ),
         }
 
         zfs_props = {

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -459,7 +459,8 @@ class IOCPlugin(object):
 
         for prop in (
             f'type=pluginv{self.PLUGIN_VERSION}',
-            f'plugin_name={self.plugin}'
+            f'plugin_name={self.plugin}',
+            f'plugin_repository={self.git_repository}',
         ):
             create_props.append(prop)
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -77,6 +77,15 @@ class IOCPlugin(object):
         self.keep_jail_on_failure = keep_jail_on_failure
         self.thickconfig = kwargs.pop('thickconfig', False)
         self.log = logging.getLogger('iocage')
+
+        # If we have a jail which exists for this plugin, we will like to
+        # enforce the plugin to respect the github repository it was
+        # created from for updates/upgrades etc. If for some reason, this
+        # is not desired, the user is free to change it via "set" manually
+        # on his own.
+        # TODO: For a lack of ability to do this efficiently/correctly here,
+        #  the above should be enforced by the caller of IOCPlugin
+
         self.git_repository = kwargs.get(
             'git_repository'
         ) or 'https://github.com/freenas/iocage-ix-plugins.git'

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -2063,7 +2063,7 @@ class IOCage(ioc_json.IOCZFS):
                 })
                 ioc_plugin.IOCPlugin(
                     jail=uuid,
-                    plugin=uuid,
+                    plugin=conf['plugin_name'],
                     callback=self.callback
                 ).update(jid)
                 ioc_common.logit({
@@ -2212,7 +2212,7 @@ class IOCage(ioc_json.IOCZFS):
 
             new_release = ioc_plugin.IOCPlugin(
                 jail=uuid,
-                plugin=uuid,
+                plugin=conf['plugin_name'],
                 callback=self.callback
             ).upgrade(jid)
             plugin = True

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -2064,6 +2064,7 @@ class IOCage(ioc_json.IOCZFS):
                 ioc_plugin.IOCPlugin(
                     jail=uuid,
                     plugin=conf['plugin_name'],
+                    git_repository=conf['plugin_repository'],
                     callback=self.callback
                 ).update(jid)
                 ioc_common.logit({
@@ -2213,6 +2214,7 @@ class IOCage(ioc_json.IOCZFS):
             new_release = ioc_plugin.IOCPlugin(
                 jail=uuid,
                 plugin=conf['plugin_name'],
+                git_repository=conf['plugin_repository'],
                 callback=self.callback
             ).upgrade(jid)
             plugin = True


### PR DESCRIPTION
This PR introduces the following changes:
1) Adds a prop so we can track which repository does a plugin belong to.
2) Fixes a bug where renamed plugin jails won't update/upgrade ( it's a best effort because we have no way of correctly determining which plugin does the jail belong to ).
