### PR TITLE
Traceback when issuing invalid command

### DIFF
--- a/iocage_cli/__init__.py
+++ b/iocage_cli/__init__.py
@@ -179,8 +179,13 @@ class IOCageCLI(click.MultiCommand):
         return rv
 
     def get_command(self, ctx, name):
-        mod = __import__(f"iocage_cli.{name}", None, None, ["cli"])
-        mod_name = mod.__name__.replace("iocage_cli.", "")
+
+        try:
+            mod = __import__(f"iocage_cli.{name}", None, None, ["cli"])
+            mod_name = mod.__name__.replace("iocage_cli.", "")
+        except ImportError:
+            # No such command
+            return
 
         try:
             if mod.__rootcmd__ and sys.argv[-1] not in ("help", "--help"):


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

This fixes a small regression, see traceback below:
```python
➜  iocage foo                                    
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1132, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1171, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
  File "/usr/local/lib/python3.6/site-packages/iocage_cli/__init__.py", line 182, in get_command
    mod = __import__(f"iocage_cli.{name}", None, None, ["cli"])
ModuleNotFoundError: No module named 'iocage_cli.foo'

➜  iocage foo help
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1132, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1171, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
  File "/usr/local/lib/python3.6/site-packages/iocage_cli/__init__.py", line 182, in get_command
    mod = __import__(f"iocage_cli.{name}", None, None, ["cli"])
ModuleNotFoundError: No module named 'iocage_cli.foo'
```