### PR TITLE
NAS-102442 / 11.3 / Only change jail type if it's a template

### DIFF
--- a/iocage_lib/ioc_image.py
+++ b/iocage_lib/ioc_image.py
@@ -255,12 +255,12 @@ class IOCImage(object):
                 silent=self.silent)
 
         # Templates become jails again once imported, let's make that reality.
-        iocage_lib.ioc_json.IOCJson(
-            f"{self.iocroot}/jails/{uuid}",
-            silent=True).json_set_value("type=jail")
-        iocage_lib.ioc_json.IOCJson(
-            f"{self.iocroot}/jails/{uuid}", silent=True).json_set_value(
-                "template=0", _import=True)
+        jail_json = iocage_lib.ioc_json.IOCJson(
+            f'{self.iocroot}/jails/{uuid}', silent=True
+        )
+        if jail_json.json_get_value('type') == 'template':
+            jail_json.json_set_value('type=jail')
+            jail_json.json_set_value('template=0', _import=True)
 
         msg = f"\nImported: {uuid}"
         iocage_lib.ioc_common.logit(


### PR DESCRIPTION
This commit fixes an issue where we changed the jail type of plugins to a jail when an image of the plugin was imported.
