### PR TITLE
NAS-102448 / 11.3 / Allow file URI's for plugin artifacts

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -36,6 +36,7 @@ import re
 import shutil
 import subprocess as su
 import requests
+import urllib.parse
 
 import iocage_lib.ioc_common
 import iocage_lib.ioc_create
@@ -1029,10 +1030,29 @@ fingerprint: {fingerprint}
         path = f"{self.iocroot}/jails/{self.jail}"
 
         shutil.rmtree(f"{path}/plugin", ignore_errors=True)
-        self._clone_repo(
-            self.branch, plugin_conf['artifact'],
-            f'{path}/plugin', callback=self.callback
-        )
+
+        uri = urllib.parse.urlparse(plugin_conf['artifact'])
+        if uri.scheme == 'file':
+            artifact_path = urllib.parse.unquote(uri.path)
+            if not os.path.exists(artifact_path):
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'EXCEPTION',
+                        'message': f'{artifact_path} does not exist!'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent
+                )
+
+            distutils.dir_util.copy_tree(
+                artifact_path,
+                os.path.join(path, 'plugin')
+            )
+        else:
+            self._clone_repo(
+                self.branch, plugin_conf['artifact'],
+                f'{path}/plugin', callback=self.callback
+            )
 
         try:
             distutils.dir_util.copy_tree(

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -712,24 +712,12 @@ fingerprint: {fingerprint}
                 _callback=self.callback,
                 silent=self.silent)
 
-            self._clone_repo(
-                self.branch, conf['artifact'],
-                f'{jaildir}/plugin', callback=self.callback
-            )
+            self.__update_pull_plugin_artifact__(conf)
 
             with open(
                 f"{jaildir}/{self.plugin}.json", "w"
             ) as f:
                 f.write(json.dumps(conf, indent=4, sort_keys=True))
-
-            try:
-                distutils.dir_util.copy_tree(
-                    f"{jaildir}/plugin/overlay/",
-                    f"{jaildir}/root",
-                    preserve_symlinks=True)
-            except distutils.errors.DistutilsFileError:
-                # It just doesn't exist
-                pass
 
             try:
                 shutil.copy(f"{jaildir}/plugin/post_install.sh",


### PR DESCRIPTION
This PR introduces a change to allow file URI's instead of git urls we used for plugin artifact key. It facilitates local development of a plugin.