### PR TITLE
NAS-102512 / 11.3 / Correctly parse snapshot data

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -449,7 +449,7 @@ class IOCSnapshot(object):
             self.data = self.raw_data
 
         self.__dict__.update({
-            k: v for k, v in zip(self.attr_list, self.data.split())
+            k: v for k, v in zip(self.attr_list, self.data.split('\t'))
         })
 
     def delete(self, recursive=True):


### PR DESCRIPTION
This commit makes sure we parse snapshot data based on tabs instead of spaces as snapshot names may contain spaces.
Closes #974