### PR TITLE
NAS-102674 / 11.3 / Bug fix for nat forwards prop validation

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -2500,12 +2500,11 @@ class IOCJson(IOCConfiguration):
 
                     if value != 'none':
                         regex = re.compile(
-                            r'(^tcp|^udp|^tcp\/udp)\(\d{1,5}((:|-?)'
-                            r'(\d{1,5}))\)'
+                            r'^(tcp|udp|tcp\/udp)\(\d{1,5}((:|-?)(\d{1,5}))\)'
                         )
                         for fwd in value.split(','):
                             # We assume TCP for simpler inputs
-                            fwd = f'tcp({fwd})'
+                            fwd = f'tcp({fwd})' if fwd.isdigit() else fwd
                             new_value.append(fwd)
 
                             match = regex.match(fwd)


### PR DESCRIPTION
This PR fixes a bug in nat forwards prop validation where we did not take into consideration the protocol specified by the user and only considered the prop to contain numeric values.