### PR TITLE
NAS-102662 / 11.3 / Disallow running jails using same system ports

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -1078,3 +1078,21 @@ def get_host_gateways():
             gateways[af_mapping[af]]['interface'] = \
                 default_route[0]['interface-name']
     return gateways
+
+
+def get_jails_with_config(filters=None, mapping_func=None):
+    # FIXME: Due to how api is structured, there is no good place to put this
+    #  so when we move on with restructuring the api, let's remove this as well
+    #  importing iocage_lib.iocage above gives us a circular dep due to how
+    #  iocage designates iocage_lib.iocage at top and imports everything else
+    #  within.
+    import iocage_lib.iocage
+    return {
+        j['host_hostuuid']: j if not mapping_func else mapping_func(j)
+        for j in map(
+            lambda v: list(v.values())[0],
+            iocage_lib.iocage.IOCage(jail=None).get(
+                'all', recursive=True
+            )
+        ) if not filters or filters(j)
+    }

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1880,7 +1880,7 @@ class IOCage(ioc_json.IOCZFS):
                 _callback=self.callback,
                 silent=self.silent)
 
-    def start(self, jail=None, ignore_exception=False):
+    def start(self, jail=None, ignore_exception=False, used_ports=None):
         """Checks jails type and existence, then starts the jail"""
         if self.rc or self._all:
             if not jail:
@@ -1930,7 +1930,8 @@ class IOCage(ioc_json.IOCZFS):
                     silent=self.silent,
                     callback=self.callback,
                     is_depend=self.is_depend,
-                    suppress_exception=ignore_exception
+                    suppress_exception=ignore_exception,
+                    used_ports=used_ports,
                 )
 
                 return False, None


### PR DESCRIPTION
This commit disallows running a jail with NAT which wants to consume a system port which is already in use by another jail/entity.