### PR TITLE
NAS-102686 / 11.3 / Improvements for plugins CLI

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -37,6 +37,7 @@ import shutil
 import subprocess as su
 import requests
 import urllib.parse
+import uuid
 
 import iocage_lib.ioc_common
 import iocage_lib.ioc_create
@@ -897,6 +898,7 @@ fingerprint: {fingerprint}
         self.plugin = self.__fetch_validate_plugin__(
             self.plugin.lower(), plugins_ordered_dict
         )
+        self.jail = f'{self.plugin}_{str(uuid.uuid4())[:4]}'
 
         # We now run the fetch the user requested
         self.fetch_plugin(props, 0, accept_license)

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -212,34 +212,40 @@ class IOCPlugin(object):
 
         return self.fetch_plugin_versions_from_plugin_index(plugin_index)
 
-    def fetch_plugin(self, props, num, accept_license):
-        """Helper to fetch plugins"""
+    def retrieve_plugin_json(self):
         if not self.plugin_json_path:
             _json = os.path.join(self.git_destination, f'{self.plugin}.json')
         else:
             _json = self.plugin_json_path
 
-        plugins = self.fetch_plugin_index(props, index_only=True)
         self.log.debug(f'Plugin json file path: {_json}')
 
         try:
-            with open(_json, "r") as j:
+            with open(_json, 'r') as j:
                 conf = json.load(j)
         except FileNotFoundError:
             iocage_lib.ioc_common.logit(
                 {
-                    "level": "EXCEPTION",
-                    "message": f"{_json} was not found!"
+                    'level': 'EXCEPTION',
+                    'message': f'{_json} was not found!'
                 },
-                _callback=self.callback)
+                _callback=self.callback
+            )
         except json.decoder.JSONDecodeError:
             iocage_lib.ioc_common.logit(
                 {
-                    "level": "EXCEPTION",
-                    "message": "Invalid JSON file supplied, please supply a "
-                    "correctly formatted JSON file."
+                    'level': 'EXCEPTION',
+                    'message': 'Invalid JSON file supplied, please supply a '
+                    'correctly formatted JSON file.'
                 },
-                _callback=self.callback)
+                _callback=self.callback
+            )
+        return conf
+
+    def fetch_plugin(self, props, num, accept_license):
+        """Helper to fetch plugins"""
+        plugins = self.fetch_plugin_index(props, index_only=True)
+        conf = self.retrieve_plugin_json()
 
         if self.hardened:
             conf['release'] = conf['release'].replace("-RELEASE", "-STABLE")

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -71,6 +71,11 @@ class IOCPlugin(object):
         if os.path.exists(plugin or ''):
             self.plugin_json_path = plugin
             plugin = plugin.rsplit('/', 1)[-1].rstrip('.json')
+            if self.plugin_json_path == jail:
+                # If user specified a complete path to plugin json file
+                # jail would be having the same value. We ensure that we don't
+                # do that here.
+                jail = f'{plugin}_{str(uuid.uuid4())[:4]}'
         else:
             self.plugin_json_path = None
         self.plugin = plugin

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1106,8 +1106,18 @@ class IOCage(ioc_json.IOCZFS):
 
                 return
 
+            plugin_obj = ioc_plugin.IOCPlugin(
+                release=release, plugin=plugin_name,
+                branch=branch, silent=self.silent,
+                keep_jail_on_failure=keep_jail_on_failure,
+                callback=self.callback, **kwargs,
+                thickconfig=thick_config,
+            )
+
             i = 1
-            check_jail_name = name or plugin_name
+            check_jail_name = name or plugin_obj.retrieve_plugin_json().get(
+                'name', plugin_name
+            )
             while True:
                 if check_jail_name not in self.jails:
                     jail_name = check_jail_name
@@ -1119,13 +1129,8 @@ class IOCage(ioc_json.IOCZFS):
 
             self.jails[jail_name] = jail_name   # Not a valid value
             if count == 1:
-                ioc_plugin.IOCPlugin(
-                    release=release, jail=jail_name, plugin=plugin_name,
-                    branch=branch, silent=self.silent,
-                    keep_jail_on_failure=keep_jail_on_failure,
-                    callback=self.callback, **kwargs,
-                    thickconfig=thick_config,
-                ).fetch_plugin(props, 0, accept)
+                plugin_obj.jail = jail_name
+                plugin_obj.fetch_plugin(props, 0, accept)
             else:
                 for j in range(1, count + 1):
                     # Repeating this block in case they have gaps in their
@@ -1142,13 +1147,8 @@ class IOCage(ioc_json.IOCZFS):
                         i += 1
 
                     self.jails[jail_name] = jail_name   # Not a valid value
-                    ioc_plugin.IOCPlugin(
-                        release=release, jail=jail_name, plugin=plugin_name,
-                        branch=branch, silent=self.silent,
-                        keep_jail_on_failure=keep_jail_on_failure,
-                        thickconfig=thick_config,
-                        callback=self.callback, **kwargs
-                    ).fetch_plugin(props, j, accept)
+                    plugin_obj.jail = jail_name
+                    plugin_obj.fetch_plugin(props, j, accept)
         else:
             kwargs.pop('git_repository', None)
             kwargs.pop('git_destination', None)


### PR DESCRIPTION
This PR introduces following changes:
1) Adds changes  to ensure plugins can be created with --plugins flag.
2) Fixes a bug where if absolute path to a plugin's json file is specified, we named the jail similarly which was destined to fail as the name was a path.
3) Uses `name` key from plugin's manifest to use for jail name if jail name isn't specified explicitly.

Closes #995 