### PR TITLE
Create zfs snapshot for updates without space

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1988,8 +1988,9 @@ class IOCage(ioc_json.IOCZFS):
             "jail", "clonejail", "pluginv2") else False
 
         if updateable:
+            date = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             self.snapshot(
-                f'ioc_update_{conf["release"]}_{datetime.datetime.now()}'
+                f'ioc_update_{conf["release"]}_{date}'
             )
 
             if not status:


### PR DESCRIPTION
<blockquote class="twitter-tweet"><p lang="en" dir="ltr">You’re right! File an enhancement request please.</p>&mdash; Brandon Schneider (@bschneider_89) <a href="https://twitter.com/bschneider_89/status/1155230058543484928?ref_src=twsrc%5Etfw">July 27, 2019</a></blockquote>

Datetime to string contains a space by default:
f'{datetime.datetime.now()}'
'2019-07-28 10:02:59.375857'

The new format is this:
f'{datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}'
'2019-07-28_10-03-59'

Which will then create snapshots without a space.

Signed-off-by: fliiiix <hi@l33t.name>

As far as I could tell this is the only place where something needs to be changed 
but feel free to update this pr if something else needs to be updated as well.