### PR TITLE
NAS-102772 / 11.3 / Improve ability to guess plugin name for old plugin jails

### DIFF
--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -930,7 +930,19 @@ class IOCConfiguration(IOCZFS):
                         pass
                     else:
                         if plugin_data.get('name'):
-                            conf['plugin_name'] = plugin_data['name']
+                            conf['plugin_name'] = plugin_data['name'].lower()
+                            # If this happens, we want to rename the
+                            # json file so it can be detected by iocage
+                            if plugin_data['name'] != json_files[0].rstrip(
+                                '.json'
+                            ):
+                                shutil.move(
+                                    os.path.join(jail_path, json_files[0]),
+                                    os.path.join(
+                                        jail_path,
+                                        f'{plugin_data["name"].lower()}.json'
+                                    )
+                                )
 
             # This is our last resort - if above strategy didn't work,
             # let's use host_hostuuid in this case


### PR DESCRIPTION
This PR improves ability to guess plugin name for an old plugin jail when we did not had an explicit property to determine which plugin jail maps to which plugin.