### PR TITLE
NAS-102815 / 11.3 / Rollback specific ipv6 changes

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1360,33 +1360,18 @@ class IOCStart(object):
 
     def get_default_gateway(self, address_family='ipv4'):
         gateway = self.host_gateways[address_family]['gateway']
-        interface = self.host_gateways[address_family]['interface']
-        if gateway and '%' in gateway:
-            interface_bridge_map = self.get_interface_bridge_map()
-            ipv6 = gateway.split('%')[0]
-            if interface in interface_bridge_map:
-                jail_nic = interface_bridge_map[interface][0]
-            else:
-                iocage_lib.ioc_common.logit(
-                    {
-                        'level': 'EXCEPTION',
-                        'message': (f'No bridge for interface {interface}'
-                                    'found in configuration.')
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
-            return f'{ipv6}%{jail_nic.replace("vnet", "epair")}b'
-        elif gateway:
+        if gateway:
             return gateway
         else:
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'WARNING',
+                    'message': 'No default gateway found.'
+                },
+                _callback=self.callback,
+                silent=self.silent
+            )
             return 'none'
-
-    def get_interface_bridge_map(self):
-        interface_bridge_map = {}
-        for interface in self.get('interfaces').split(','):
-            nic, bridge = interface.split(':')
-            interface_bridge_map.setdefault(bridge, []).append(nic)
-        return interface_bridge_map
 
     def get_bridge_members(self, bridge):
         return [

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1392,7 +1392,8 @@ class IOCStart(object):
             iocage_lib.ioc_common.logit(
                 {
                     'level': 'WARNING',
-                    'message': 'No default gateway found.'
+                    'message': 'No default gateway found'
+                    f' for {address_family}.'
                 },
                 _callback=self.callback,
                 silent=self.silent

--- a/tests/unit_tests/1000_lib_start_test.py
+++ b/tests/unit_tests/1000_lib_start_test.py
@@ -97,55 +97,39 @@ def test_should_return_default_interface(mock_logit, test_input, expected):
     ({'host_gateways': {'ipv4': {'gateway': None,
                                  'interface': None},
                         'ipv6': {'gateway': None,
-                                 'interface': None}},
-      'interfaces': {'inet0': ['vnet0']}},
+                                 'interface': None}}},
      {'ipv4': 'none',
       'ipv6': 'none'}),
     ({'host_gateways': {'ipv4': {'gateway': '217.29.43.254',
                                  'interface': 'inet0'},
                         'ipv6': {'gateway': 'fe80::8%inet0',
-                                 'interface': 'inet0'}},
-      'interfaces': {'inet0': ['vnet0']}},
+                                 'interface': 'inet0'}}},
      {'ipv4': '217.29.43.254',
       'ipv6': 'fe80::8%epair0b'}),
     ({'host_gateways': {'ipv4': {'gateway': None,
                                  'interface': None},
                         'ipv6': {'gateway': 'fe80::8%mgmt0',
-                                 'interface': 'mgmt0'}},
-      'interfaces': {'inet0': ['vnet0'], 'mgmt0': ['vnet1']}},
+                                 'interface': 'mgmt0'}}},
      {'ipv4': 'none',
       'ipv6': 'fe80::8%epair1b'}),
     ({'host_gateways': {'ipv4': {'gateway': None,
                                  'interface': None},
                         'ipv6': {'gateway': 'fe80::8%inet0',
-                                 'interface': 'inet0'}},
-      'interfaces': {'inet0': ['vnet0', 'vnet1'], 'mgmt0': ['vnet2']}},
+                                 'interface': 'inet0'}}},
      {'ipv4': 'none',
       'ipv6': 'fe80::8%epair0b'}),
     ({'host_gateways': {'ipv4': {'gateway': None,
                                  'interface': None},
                         'ipv6': {'gateway': 'fe80::8%inet0',
-                                 'interface': 'inet0'}},
-      'interfaces': {'inet0': ['vnet1', 'vnet0'], 'mgmt0': ['vnet2']}},
+                                 'interface': 'inet0'}}},
      {'ipv4': 'none',
       'ipv6': 'fe80::8%epair1b'})])
 def test_should_return_default_gateway(test_input, expected):
     iocstart = ioc_start.IOCStart("", "", unit_test=True)
     iocstart.host_gateways = test_input['host_gateways']
-    iocstart.get_interface_bridge_map = mock.Mock(
-        return_value=test_input['interfaces'])
     assert iocstart.get_default_gateway() == expected['ipv4']
     assert iocstart.get_default_gateway('ipv4') == expected['ipv4']
     assert iocstart.get_default_gateway('ipv6') == expected['ipv6']
-
-
-@pytest.mark.parametrize('interfaces,expected', [
-    ('vnet0:inet0,vnet1:inet0', {'inet0': ['vnet0', 'vnet1']}),
-    ('vnet0:inet0,vnet1:mgmt0', {'inet0': ['vnet0'], 'mgmt0': ['vnet1']})])
-def test_get_interface_bridge_map(interfaces, expected):
-    iocstart = ioc_start.IOCStart("", "", unit_test=True)
-    iocstart.get = mock.Mock(return_value=interfaces)
-    assert iocstart.get_interface_bridge_map() == expected
 
 
 bridge_if_config = """bridge0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500

--- a/tests/unit_tests/1000_lib_start_test.py
+++ b/tests/unit_tests/1000_lib_start_test.py
@@ -105,25 +105,25 @@ def test_should_return_default_interface(mock_logit, test_input, expected):
                         'ipv6': {'gateway': 'fe80::8%inet0',
                                  'interface': 'inet0'}}},
      {'ipv4': '217.29.43.254',
-      'ipv6': 'fe80::8%epair0b'}),
+      'ipv6': 'fe80::8%inet0'}),
     ({'host_gateways': {'ipv4': {'gateway': None,
                                  'interface': None},
                         'ipv6': {'gateway': 'fe80::8%mgmt0',
                                  'interface': 'mgmt0'}}},
      {'ipv4': 'none',
-      'ipv6': 'fe80::8%epair1b'}),
+      'ipv6': 'fe80::8%mgmt0'}),
     ({'host_gateways': {'ipv4': {'gateway': None,
                                  'interface': None},
                         'ipv6': {'gateway': 'fe80::8%inet0',
                                  'interface': 'inet0'}}},
      {'ipv4': 'none',
-      'ipv6': 'fe80::8%epair0b'}),
+      'ipv6': 'fe80::8%inet0'}),
     ({'host_gateways': {'ipv4': {'gateway': None,
                                  'interface': None},
                         'ipv6': {'gateway': 'fe80::8%inet0',
                                  'interface': 'inet0'}}},
      {'ipv4': 'none',
-      'ipv6': 'fe80::8%epair1b'})])
+      'ipv6': 'fe80::8%inet0'})])
 def test_should_return_default_gateway(test_input, expected):
     iocstart = ioc_start.IOCStart("", "", unit_test=True)
     iocstart.host_gateways = test_input['host_gateways']


### PR DESCRIPTION
This commit rollbacks some specific ipv6 changes while retrieving default gateway as they introduce regressions to ipv6 operations while retrieving default gateway.
