### PR TITLE
NAS-102804 / 11.3 / Ensure NAT rules aren't missed

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1610,7 +1610,10 @@ class IOCStart(object):
                     )
 
             if rules[1].endswith(nat_interface):
-                # They don't have any port-forwards
+                # They don't have any port-forwards or the file is empty
+                if rdrs:
+                    nat_rule += rdrs
+
                 rules.insert(1, nat_rule)
                 self.log.debug(f'Inserted: {nat_rule} into rules at index 1')
 


### PR DESCRIPTION
This PR introduces following changes:
1) For ipfw based nat backend, if ipfw file did not exist before, nat forwards rule would not be added to the conf file.
2) Adds locking mechanism to ensure that multiple iocage processes starting jails don't result in a misconfigured ipfw/pf conf file.