### PR TITLE
NAS-102924 / 11.3 / Ensure we don't fetch a release greater then host version

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -706,7 +706,9 @@ def get_host_release():
     return release
 
 
-def check_release_newer(release, callback=None, silent=False):
+def check_release_newer(
+    release, callback=None, silent=False, raise_error=True
+):
     """Checks if the host RELEASE is greater than the target release"""
     host_release = get_host_release()
 
@@ -716,7 +718,7 @@ def check_release_newer(release, callback=None, silent=False):
     h_float = float(str(host_release).rsplit("-")[0])
     r_float = float(str(release).rsplit("-")[0])
 
-    if h_float < r_float:
+    if h_float < r_float and raise_error:
         logit(
             {
                 "level": "EXCEPTION",
@@ -725,6 +727,8 @@ def check_release_newer(release, callback=None, silent=False):
             },
             _callback=callback,
             silent=silent)
+
+    return h_float < r_float
 
 
 def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -205,6 +205,10 @@ class IOCFetch(iocage_lib.ioc_json.IOCZFS):
             else:
                 eol = []
 
+            if self.release:
+                iocage_lib.ioc_common.check_release_newer(
+                    self.release, callback=self.callback, silent=self.silent
+                )
             rel = self.fetch_http_release(eol, _list=_list)
 
             if _list:

--- a/iocage_lib/release.py
+++ b/iocage_lib/release.py
@@ -4,6 +4,7 @@ import requests
 
 from iocage_lib.resource import Resource, ListableResource
 from iocage_lib.ioc_fetch import IOCFetch
+from iocage_lib.ioc_common import check_release_newer
 
 
 class Release(Resource):
@@ -45,7 +46,9 @@ class ListableReleases(ListableResource):
             assert req.status_code == 200
 
             for release in filter(
-                lambda r: r if not self.eol_check else r not in self.eol_list,
+                lambda r: (
+                    r if not self.eol_check else r not in self.eol_list
+                ) and not check_release_newer(r, raise_error=False),
                 re.findall(
                     r'href="(\d.*RELEASE)/"', req.content.decode('utf-8')
                 )


### PR DESCRIPTION
This commit introduces a fix where we ensure that we don't list releases which are greater then host and hence cannot be used. Also we fix a bug where we allowed fetching a release greater then the host.