### PR TITLE
Update DF command in faq.rst

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -50,7 +50,7 @@ FAQ
     of this documentation for more details.
 
 **Is there a way to display resource consumption?**
-    Yes - :command:`iocage df [UUID | NAME]`
+    Yes - :command:`iocage df`
 
 **Is NAT supported for jails?**
     Yes. NAT is built into FreeBSD. Treat your server as a core


### PR DESCRIPTION
Changed the display resource consumption command from
`iocage df [UUID | NAME]`  to `iocage df` 
since that's how it works in iocage v1.1 stable.


$ iocage df test-jail

Usage: iocage df [OPTIONS]
Try "iocage df --help" for help.
Error: Got unexpected extra argument (test-jail)
