### PR TITLE
NAS-103026 / 11.3 / Correctly list admin portal for DHCP/Static IP plugin jails

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -215,6 +215,8 @@ class IOCPlugin(object):
     def retrieve_plugin_json(self):
         if not self.plugin_json_path:
             _json = os.path.join(self.git_destination, f'{self.plugin}.json')
+            if not os.path.exists(self.git_destination):
+                self.pull_clone_git_repo()
         else:
             _json = self.plugin_json_path
 


### PR DESCRIPTION
This commit introduces changes to ensure that for DHCP/Static ip plugin jails, we don't list the host's ip address in the admin portal. For NAT based jails, it also ensures that the correct nat ports are specified for the plugin jail. However, if the nat_forwards haven't been set by the plugin dev or the end user, we only show the system ip then in that case.