### PR TITLE
NAS-103095 / 11.3 / Ensure new packagesite is registered by plugins

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -720,11 +720,14 @@ class IOCCreate(object):
         Takes a list of pkg's to install into the target jail. The resolver
         property is required for pkg to have network access.
         """
+        started = False
         status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(jail_uuid)
 
         if not status:
             iocage_lib.ioc_start.IOCStart(jail_uuid, location, silent=True)
-            status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(jail_uuid)
+            started, jid = iocage_lib.ioc_list.IOCList().list_get_jid(
+                jail_uuid
+            )
 
         if repo:
             r = re.match('(https?(://)?)?([^/]+)', repo)
@@ -966,9 +969,7 @@ class IOCCreate(object):
                         pkg_err_list.append(pkg_err_msg)
                     break
 
-        os.remove(f"{location}/root/etc/resolv.conf")
-
-        if status:
+        if started:
             iocage_lib.ioc_stop.IOCStop(jail_uuid, location, silent=True)
 
         if self.plugin and pkg_err_list:

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -671,7 +671,9 @@ fingerprint: {fingerprint}
 
     def __fetch_plugin_post_install__(self, conf, _conf, jaildir):
         """Fetches the users artifact and runs the post install"""
-        iocage_lib.ioc_start.IOCStart(self.jail, jaildir, silent=True)
+        status, jid = iocage_lib.ioc_list.IOCList().list_get_jid(self.jail)
+        if not status:
+            iocage_lib.ioc_start.IOCStart(self.jail, jaildir, silent=True)
 
         ip4 = _conf['ip4_addr']
         ip6 = _conf['ip6_addr']

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -579,12 +579,6 @@ class IOCPlugin(object):
                     },
                     _callback=self.callback)
 
-        try:
-            os.makedirs(f"{jaildir}/root/usr/local/etc/pkg/repos", 0o755)
-        except OSError:
-            # Same as below, it exists and we're OK with that.
-            pass
-
         freebsd_conf = """\
 FreeBSD: { enabled: no }
 """

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1160,10 +1160,22 @@ fingerprint: {fingerprint}
         """Installs all pkgs listed in the plugins configuration"""
         path = f"{self.iocroot}/jails/{self.jail}"
 
-        self.__fetch_plugin_install_packages__(
-            path, plugin_conf, plugin_conf['fingerprints'], [],
-            os.path.join(path, 'root/usr/local/etc/pkg/repos')
-        )
+        try:
+            self.__fetch_plugin_install_packages__(
+                path, plugin_conf, plugin_conf['fingerprints'], [],
+                os.path.join(path, 'root/usr/local/etc/pkg/repos')
+            )
+        except (Exception, SystemExit):
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'ERROR',
+                    'message': 'PKG error, update failed! '
+                               'Rolling back snapshot.\n'
+                },
+                _callback=self.callback
+            )
+            self.__rollback_jail__(name='update')
+            raise
 
     def upgrade(self, jid):
         iocage_lib.ioc_common.logit(

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1161,8 +1161,6 @@ fingerprint: {fingerprint}
     def __update_pkg_install__(self, plugin_conf):
         """Installs all pkgs listed in the plugins configuration"""
         path = f"{self.iocroot}/jails/{self.jail}"
-        conf, write = iocage_lib.ioc_json.IOCJson(
-            location=path).json_load()
 
         secure = True if "https://" in plugin_conf["packagesite"] else False
         pkg_repos = plugin_conf["fingerprints"]
@@ -1219,9 +1217,6 @@ fingerprint: {fingerprint}
                         "message": msg
                     },
                     _callback=self.callback)
-
-        if write:
-            self.json_write(conf)
 
     def upgrade(self, jid):
         iocage_lib.ioc_common.logit(

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1064,6 +1064,10 @@ fingerprint: {fingerprint}
         self.__update_pkg_install__(plugin_conf)
 
         if plugin_conf["artifact"]:
+            # We need to do this again to ensure that if some files
+            # were removed when we removed pkgs and the overlay directory
+            # is supposed to bring them back, this does that
+            self.__update_pull_plugin_artifact__(plugin_conf)
             post_update_hook = os.path.join(
                 self.iocroot, 'jails', self.jail, 'plugin/post_update.sh'
             )


### PR DESCRIPTION
This PR introduces following changes:
1) Makes sure if packagesite is changed in a plugin's manifest, it is correctly reflected in the jail by iocage.
2) Bug fix for ensuring we don't stop jails implicitly when updating plugins or installing packages
3) Bug fix for non-existent function call