### PR TITLE
NAS-103127 / 11.3 / Automatically toggle network properties for plugins

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -963,6 +963,20 @@ def lowercase_set(values):
     return set([v.lower() for v in values])
 
 
+def boolean_prop_exists(supplied_props, props_to_check):
+    # supplied_props is a list i.e ["dhcp=1"]
+    # props_to_check is a list of props i.e ["dhcp", "nat"]
+    check_set = set()
+    for check_prop in props_to_check:
+        check_set.update(
+            iocage_lib.ioc_common.lowercase_set(
+                iocage_lib.ioc_common.construct_truthy(check_prop)
+            )
+        )
+
+    return iocage_lib.ioc_common.lowercase_set(supplied_props) & check_set
+
+
 def gen_unused_lo_ip():
     """Best effort to try to allocate a localhost IP for a jail"""
     interface_addrs = netifaces.ifaddresses('lo0')

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -928,9 +928,17 @@ def get_jail_freebsd_version(path, release):
     return new_release
 
 
+def truthy_values():
+    return '1', 'on', 'yes', 'true', True, 1
+
+
+def truthy_inverse_values():
+    return '0', 'off', 'no', 'false', 0, False, None
+
+
 def check_truthy(value):
     """Checks if the given value is 'True'"""
-    if str(value).lower() in ('1', 'on', 'yes', 'true'):
+    if str(value).lower() in truthy_values():
         return 1
 
     return 0
@@ -938,10 +946,11 @@ def check_truthy(value):
 
 def construct_truthy(item, inverse=False):
     """Will return an iterable with all truthy variations"""
-    if inverse:
-        return (f'{item}=off', f'{item}=no', f'{item}=0', f'{item}=false')
-
-    return (f'{item}=on', f'{item}=yes', f'{item}=1', f'{item}=true')
+    return (
+        f'{item}={v}' for v in (
+            truthy_inverse_values() if inverse else truthy_values()
+        )
+    )
 
 
 def set_interactive(interactive):

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -254,8 +254,8 @@ class IOCPlugin(object):
             conf['release'] = re.sub(r"\W\w.", "-", conf['release'])
 
         self.release = conf['release']
-        self.__fetch_plugin_inform__(conf, num, plugins, accept_license)
         props, pkg = self.__fetch_plugin_props__(conf, props, num)
+        self.__fetch_plugin_inform__(conf, num, plugins, accept_license)
         location = f"{self.iocroot}/jails/{self.jail}"
 
         try:
@@ -413,16 +413,33 @@ class IOCPlugin(object):
         freebsd_version = f"{self.iocroot}/releases/{conf['release']}" \
             "/root/bin/freebsd-version"
         json_props = conf.get("properties", {})
-        props = list(props)
+        truthy_inverse = iocage_lib.ioc_common.truthy_inverse_values()
+        props = {p.split('=')[0]: p.split('=')[1] for p in list(props)}
+        network_props = {
+            'nat': truthy_inverse, 'dhcp': truthy_inverse,
+            'ip4_addr': ('none',), 'ip6_addr=': ('none',)
+        }
 
         for p, v in json_props.items():
             # The JSON properties are going to be treated as user entered
             # ones on the command line. If the users prop exists on the
             # command line, we will skip the JSON one.
-            _p = f"{p}={v}"
+            if p not in props:
+                if p in network_props and v not in network_props[p]:
+                    # This means that "p" is enabled in the plugin manifest
+                    # We should now ensure that we don't have any other
+                    # connectivity option enabled
+                    network_props.pop(p)
+                    if any(
+                        nk in props and props[nk] not in nv
+                        for nk, nv in network_props.items()
+                    ):
+                        # This means that some other network option has
+                        # been specified which is enabled and we don't want
+                        # to add the plugin manifest default
+                        continue
 
-            if p not in [_prop.split("=")[0] for _prop in props]:
-                props.append(_p)
+                props[p] = v
 
             if not os.path.isdir(f"{self.iocroot}/releases/{self.release}"):
                 iocage_lib.ioc_common.check_release_newer(
@@ -469,11 +486,31 @@ class IOCPlugin(object):
         # supplied properties replacing ours.
         create_props = [
             f'release={release}', 'boot=on', 'vnet=1'
+        ] + [
+            f'{k}={v}' for k, v in props.items()
         ]
 
-        create_props = create_props + [
-            f"{k}={v}" for k, v in (p.split("=") for p in props)
-        ]
+        if all(
+            props.get(k, 'none') == 'none'
+            for k in ('ip4_addr', 'ip6_addr')
+        ) and (not iocage_lib.ioc_common.lowercase_set(
+                iocage_lib.ioc_common.construct_truthy('dhcp')
+        ) & iocage_lib.ioc_common.lowercase_set(
+            create_props) and not iocage_lib.ioc_common.lowercase_set(
+            iocage_lib.ioc_common.construct_truthy('ip_hostname')
+        ) & iocage_lib.ioc_common.lowercase_set(
+            create_props) and not iocage_lib.ioc_common.lowercase_set(
+            iocage_lib.ioc_common.construct_truthy('nat')
+        ) & iocage_lib.ioc_common.lowercase_set(create_props)):
+            iocage_lib.ioc_common.logit(
+                {
+                    'level': 'EXCEPTION',
+                    'message': 'Network connectivity is required to fetch a '
+                               'plugin. Please enable dhcp/nat or supply'
+                               ' a valid ip address.'
+                },
+                _callback=self.callback,
+                silent=self.silent)
 
         # These properties are not user configurable
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -493,15 +493,9 @@ class IOCPlugin(object):
         if all(
             props.get(k, 'none') == 'none'
             for k in ('ip4_addr', 'ip6_addr')
-        ) and (not iocage_lib.ioc_common.lowercase_set(
-                iocage_lib.ioc_common.construct_truthy('dhcp')
-        ) & iocage_lib.ioc_common.lowercase_set(
-            create_props) and not iocage_lib.ioc_common.lowercase_set(
-            iocage_lib.ioc_common.construct_truthy('ip_hostname')
-        ) & iocage_lib.ioc_common.lowercase_set(
-            create_props) and not iocage_lib.ioc_common.lowercase_set(
-            iocage_lib.ioc_common.construct_truthy('nat')
-        ) & iocage_lib.ioc_common.lowercase_set(create_props)):
+        ) and not iocage_lib.ioc_common.boolean_prop_exists(
+            create_props, ['dhcp', 'nat', 'ip_hostname']
+        ):
             iocage_lib.ioc_common.logit(
                 {
                     'level': 'EXCEPTION',

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1056,12 +1056,6 @@ class IOCage(ioc_json.IOCZFS):
                 kwargs["hardened"] = False
 
         if plugins or plugin_name:
-            ip = [
-                x for x in props
-
-                if x.startswith("ip4_addr") or x.startswith("ip6_addr")
-            ]
-
             if _list:
                 rel_list = ioc_plugin.IOCPlugin(
                     branch=branch,
@@ -1073,27 +1067,6 @@ class IOCage(ioc_json.IOCZFS):
                 )
 
                 return rel_list
-
-            if not ip and (not ioc_common.lowercase_set(
-                ioc_common.construct_truthy('dhcp')
-            ) & ioc_common.lowercase_set(
-                props) and not ioc_common.lowercase_set(
-                    ioc_common.construct_truthy('ip_hostname')
-            ) & ioc_common.lowercase_set(
-                props) and not ioc_common.lowercase_set(
-                    ioc_common.construct_truthy('nat')
-            ) & ioc_common.lowercase_set(props)):
-                ioc_common.logit(
-                    {
-                        "level":
-                        "EXCEPTION",
-                        "message":
-                        "An IP address is needed to fetch a plugin!\n"
-                        "Please specify ip(4|6)"
-                        "_addr=\"[INTERFACE|]IPADDRESS\"!"
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
 
             if plugins:
                 ioc_plugin.IOCPlugin(


### PR DESCRIPTION
This commit introduces changes where if user supplies a network prop which they would like to use for plugin connectivity, we disable the default network prop supplied by plugin manifest if any.