### PR TITLE
NAS-103259 / 11.3 / Remove os.chdir usages

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -236,17 +236,6 @@ class IOCFetch:
                     _callback=self.callback,
                     silent=self.silent)
 
-            try:
-                os.chdir(f"{self.root_dir}/{self.release}")
-            except OSError as err:
-                iocage_lib.ioc_common.logit(
-                    {
-                        "level": "EXCEPTION",
-                        "message": err
-                    },
-                    _callback=self.callback,
-                    silent=self.silent)
-
             dataset = f"{self.iocroot}/download/{self.release}"
             pool_dataset = f"{self.pool}/iocage/download/{self.release}"
 
@@ -258,7 +247,8 @@ class IOCFetch:
                 })
 
             for f in self.files:
-                if not os.path.isfile(f):
+                file_path = os.path.join(self.root_dir, self.release, f)
+                if not os.path.isfile(file_path):
 
                     ds = Dataset(pool_dataset)
                     ds.destroy(recursive=True, force=True)
@@ -287,7 +277,7 @@ class IOCFetch:
                     },
                     _callback=self.callback,
                     silent=self.silent)
-                shutil.copy(f, dataset)
+                shutil.copy(file_path, dataset)
 
                 if f != "MANIFEST":
                     iocage_lib.ioc_common.logit(

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -514,22 +514,25 @@ class IOCFetch:
         files_left = self.files_left.copy()
 
         if os.path.isdir(f"{self.iocroot}/download/{self.release}"):
-            os.chdir(f"{self.iocroot}/download/{self.release}")
+            release_download_path = os.path.join(
+                self.iocroot, 'download', self.release
+            )
 
-            for _, _, files in os.walk("."):
-                if "MANIFEST" not in files:
-                    if self.server == "https://download.freebsd.org":
-                        iocage_lib.ioc_common.logit(
-                            {
-                                'level': 'INFO',
-                                'message': 'MANIFEST missing, downloading one'
-                            },
-                            _callback=self.callback,
-                            silent=self.silent)
-                        self.fetch_download(['MANIFEST'], missing=True)
+            if 'MANIFEST' not in os.listdir(release_download_path) and \
+                    self.server == 'https://download.freebsd.org':
+                iocage_lib.ioc_common.logit(
+                    {
+                        'level': 'INFO',
+                        'message': 'MANIFEST missing, downloading one'
+                    },
+                    _callback=self.callback,
+                    silent=self.silent)
+                self.fetch_download(['MANIFEST'], missing=True)
 
             try:
-                with open("MANIFEST", "r") as _manifest:
+                with open(
+                    os.path.join(release_download_path, 'MANIFEST'), 'r'
+                ) as _manifest:
                     for line in _manifest:
                         col = line.split("\t")
                         hashes[col[0]] = col[1]
@@ -548,7 +551,9 @@ class IOCFetch:
                         silent=self.silent)
 
                 self.fetch_download(['MANIFEST'], missing=True)
-                with open("MANIFEST", "r") as _manifest:
+                with open(
+                    os.path.join(release_download_path, 'MANIFEST'), 'r'
+                ) as _manifest:
                     for line in _manifest:
                         col = line.split("\t")
                         hashes[col[0]] = col[1]
@@ -568,7 +573,9 @@ class IOCFetch:
 
                 if f in _list:
                     try:
-                        with open(f, "rb") as txz:
+                        with open(
+                            os.path.join(release_download_path, f), 'rb'
+                        ) as txz:
                             buf = txz.read(hash_block)
 
                             while len(buf) > 0:
@@ -654,7 +661,9 @@ class IOCFetch:
                 ds.mount()
 
         if missing or fresh:
-            os.chdir(f"{self.iocroot}/download/{self.release}")
+            release_download_path = os.path.join(
+                self.iocroot, 'download', self.release
+            )
 
             for f in _list:
                 if self.hardened:
@@ -688,7 +697,7 @@ class IOCFetch:
                 if not status:
                     r.raise_for_status()
 
-                with open(f, "wb") as txz:
+                with open(os.path.join(release_download_path, f), 'wb') as txz:
                     file_size = int(r.headers['Content-Length'])
                     chunk_size = 1024 * 1024
                     total = file_size / chunk_size

--- a/iocage_lib/ioc_image.py
+++ b/iocage_lib/ioc_image.py
@@ -119,20 +119,20 @@ class IOCImage(object):
             self.callback,
             silent=self.silent)
 
-        os.chdir(images)
+        final_image_path = os.path.join(images, f'{image}.{extension}')
         if compression_algo == 'zip':
             with zipfile.ZipFile(
-                f'{image}.{extension}', 'w',
+                final_image_path, 'w',
                 compression=zipfile.ZIP_DEFLATED, allowZip64=True
             ) as final:
                 for jail in jail_list:
                     final.write(jail)
         else:
-            with tarfile.open(f'{image}.{extension}', mode='w:xz') as f:
+            with tarfile.open(final_image_path, mode='w:xz') as f:
                 for jail in jail_list:
                     f.add(jail)
 
-        with open(f'{image}.{extension}', 'rb') as import_image:
+        with open(final_image_path, 'rb') as import_image:
             digest = hashlib.sha256()
             chunk_size = 10 * 1024 * 1024
 
@@ -146,7 +146,7 @@ class IOCImage(object):
 
             image_checksum = digest.hexdigest()
 
-        with open(f"{image}.sha256", "w") as checksum:
+        with open(os.path.join(images, f'{image}.sha256'), 'w') as checksum:
             checksum.write(image_checksum)
 
         # Cleanup our mess.


### PR DESCRIPTION
This PR aims to remove `os.chdir` usages in the api as any library using iocage's api, will have mis-configured `cwd` which is unexpected behavior. 