### PR TITLE
NAS-103568 / 11.3 / Inherit mount point from parent

### DIFF
--- a/iocage_lib/ioc_check.py
+++ b/iocage_lib/ioc_check.py
@@ -71,11 +71,7 @@ class IOCCheck(object):
         if not self.iocage_dataset.path.startswith(
             self.pool_root_dataset.path
         ):
-            self.iocage_dataset.set_property(
-                'mountpoint', os.path.join(
-                    self.pool_root_dataset.path, 'iocage'
-                )
-            )
+            self.iocage_dataset.inherit_property('mountpoint')
 
     def __check_datasets__(self):
         """

--- a/iocage_lib/resource.py
+++ b/iocage_lib/resource.py
@@ -3,7 +3,7 @@ import collections.abc
 from iocage_lib.cache import cache as iocage_cache
 from iocage_lib.zfs import (
     properties, get_dependents, set_property,
-    iocage_activated_dataset
+    iocage_activated_dataset, inherit_property
 )
 
 
@@ -27,6 +27,10 @@ class Resource:
     def set_property(self, prop, value):
         iocage_cache.reset()
         set_property(self.resource_name, prop, value, self.zfs_resource)
+
+    def inherit_property(self, prop):
+        iocage_cache.reset()
+        inherit_property(self.resource_name, prop)
 
     def __bool__(self):
         return self.exists

--- a/iocage_lib/zfs.py
+++ b/iocage_lib/zfs.py
@@ -223,3 +223,7 @@ def clone_snapshot(snapshot, dataset):
 
 def promote_dataset(dataset):
     return run(['zfs', 'promote', dataset]).returncode == 0
+
+
+def inherit_property(dataset, ds_property):
+    return run(['zfs', 'inherit', ds_property, dataset]).returncode == 0


### PR DESCRIPTION
This commit fixes an issue where we set the mount point as that of the parent if iocage's mount point didn't start with it. But if altroots are involved, they are added automatically to the mount point resulting in a misconfigured mount point.
