### PR TITLE
NAS-103587 / 11.3 / Correctly raise exception for failed jail start

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -587,9 +587,11 @@ class IOCStart(object):
             "IOCAGE_NAME": f"ioc-{self.uuid}",
         }
 
-        start = su.Popen(start_cmd, stderr=su.PIPE if not debug_mode else None,
-                         stdout=su.PIPE if not debug_mode else None,
-                         env=start_env)
+        start = su.Popen(
+            start_cmd, stderr=su.PIPE,
+            stdout=su.PIPE if not debug_mode else None,
+            env=start_env
+        )
 
         stdout_data, stderr_data = start.communicate()
 


### PR DESCRIPTION
This commit fixes an issue where stderr could be null if debug mode was enabled and we would try to decode it.

