### PR TITLE
NAS-103581 / 11.3 / Introduce locks for iocage cache

### DIFF
--- a/iocage_lib/cache.py
+++ b/iocage_lib/cache.py
@@ -1,34 +1,31 @@
 from iocage_lib.zfs import all_properties
 
-import fcntl
+import threading
 
 
 class Cache:
 
-    lock_file = '/tmp/iocage_cache_lock'
+    cache_lock = threading.Lock()
 
     def __init__(self):
         self.dataset_data = self.pool_data = None
 
     @property
     def datasets(self):
-        with open(self.lock_file, 'w') as f:
-            fcntl.flock(f, fcntl.LOCK_EX)
+        with self.cache_lock:
             if not self.dataset_data:
                 self.dataset_data = all_properties()
             return self.dataset_data
 
     @property
     def pools(self):
-        with open(self.lock_file, 'w') as f:
-            fcntl.flock(f, fcntl.LOCK_EX)
+        with self.cache_lock:
             if not self.pool_data:
                 self.pool_data = all_properties(resource_type='zpool')
             return self.pool_data
 
     def reset(self):
-        with open(self.lock_file, 'w') as f:
-            fcntl.flock(f, fcntl.LOCK_EX)
+        with self.cache_lock:
             self.dataset_data = self.pool_data = None
 
 


### PR DESCRIPTION
This commit introduces locks for iocage cache which ensure that when iocage's api is being used, it's safe from cache.reset and cache.datasets/pools simultaneous calls
