### PR TITLE
set correct default values

### DIFF
--- a/iocage.8
+++ b/iocage.8
@@ -1561,7 +1561,7 @@ Ignored in
 .Fx
 10.3 and earlier.
 .Pp
-Default: disable
+Default: new
 .Pp
 Source:
 .Xr jail 8
@@ -1572,7 +1572,7 @@ Ignored in
 .Fx
 10.3 and earlier.
 .Pp
-Default: disable
+Default: new
 .Pp
 Source:
 .Xr jail 8
@@ -1583,7 +1583,7 @@ Ignored in
 .Fx 10.3
 and earlier.
 .Pp
-Default: disable
+Default: new
 .Pp
 Source:
 .Xr jail 8


### PR DESCRIPTION
sysvmsg, sysvshm, and sysvsem were disabled.  Now new.

fixes #1073