### PR TITLE
NAS-103568 / 11.3 / Bug fixes for fstab

### DIFF
--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -439,7 +439,8 @@ class IOCFstab(object):
                             _callback=self.callback,
                             silent=self.silent)
                     else:
-                        fstab.write(f'{line}\n')
+                        is_list = isinstance(line, list)
+                        fstab.write(f'{line[1] if is_list else line}\n')
 
             if not matched:
                 iocage_lib.ioc_common.logit({

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -201,8 +201,11 @@ class IOCFstab(object):
                     )
             else:
                 if jail_root not in destination:
-                    if pathlib.Path('/mnt/iocage') in dest.parents or \
-                            pathlib.Path('/iocage') in dest.parents:
+                    if any(
+                        pathlib.Path(i) in dest.parents for i in (
+                            '/mnt/mnt', '/mnt/iocage', '/iocage'
+                        )
+                    ):
                         dst = str(dest).split('/iocage')[1]
                         dst = pathlib.Path(f'{self.iocroot}/{dst}')
 
@@ -228,8 +231,11 @@ class IOCFstab(object):
 
             if not source.is_dir():
                 if fstype == 'nullfs':
-                    if pathlib.Path('/mnt/iocage') in source.parents or \
-                            pathlib.Path('/iocage') in source.parents:
+                    if any(
+                        pathlib.Path(i) in source.parents for i in (
+                            '/mnt/mnt', '/mnt/iocage', '/iocage'
+                        )
+                    ):
                         src = str(source).split('/iocage')[1]
                         src = pathlib.Path(f'{self.iocroot}/{src}')
 

--- a/iocage_lib/ioc_fstab.py
+++ b/iocage_lib/ioc_fstab.py
@@ -200,7 +200,7 @@ class IOCFstab(object):
                         'or is not a directory.'
                     )
             else:
-                if jail_root not in destination:
+                if not destination.startswith(jail_root):
                     if any(
                         pathlib.Path(i) in dest.parents for i in (
                             '/mnt/mnt', '/mnt/iocage', '/iocage'


### PR DESCRIPTION
This PR fixes following bugs:

1) Iocage did not judge destinations correctly when attempting to correct malformed fstab
2) Iocage wrote python list to fstab if fstab file's contents were changed during validation.
3) Add `/mnt/mnt` to list of malformed mount points for fstab correction.