### PR TITLE
NAS-103669 / 11.3 / Native zfs encryption support

### DIFF
--- a/iocage_lib/dataset.py
+++ b/iocage_lib/dataset.py
@@ -82,6 +82,13 @@ class Dataset(Resource):
         for d in get_dependents(self.resource_name, depth):
             yield Dataset(d, cache=cache)
 
+    @property
+    def locked(self):
+        return not self.mounted or (
+            self.properties.get('encryption', 'off') != 'off'
+            and self.properties.get('keystatus', 'available') != 'available'
+        )
+
     def destroy(self, recursive=False, force=False):
         cache.reset()
         return destroy_zfs_resource(self.resource_name, recursive, force)

--- a/iocage_lib/dataset.py
+++ b/iocage_lib/dataset.py
@@ -80,7 +80,10 @@ class Dataset(Resource):
 
     def get_dependents(self, depth=1, cache=True):
         for d in get_dependents(self.resource_name, depth):
-            yield Dataset(d, cache=cache)
+            ds = Dataset(d, cache=cache)
+            if ds.locked:
+                continue
+            yield ds
 
     @property
     def locked(self):


### PR DESCRIPTION
If we have any dataset which is not mounted or is ZFS encrypted and doesn't have it's keys loaded, we skip it. Iocage handles creation/destruction of datasets itself and ideally the user should not manipulate these datasets on his/her own.