### PR TITLE
NAS-103827 / 11.3 / Allow users to use higher minor version number jails

### DIFF
--- a/iocage_cli/create.py
+++ b/iocage_cli/create.py
@@ -164,7 +164,7 @@ def cli(
 
     if release:
         try:
-            ioc_common.check_release_newer(release)
+            ioc_common.check_release_newer(release, major_only=True)
         except ValueError:
             # We're assuming they understand the implications of a custom
             # scheme
@@ -173,7 +173,7 @@ def cli(
             _release = ioc_common.get_jail_freebsd_version(path, release)
 
             try:
-                ioc_common.check_release_newer(_release)
+                ioc_common.check_release_newer(_release, major_only=True)
             except ValueError:
                 # We tried
                 pass

--- a/iocage_cli/fetch.py
+++ b/iocage_cli/fetch.py
@@ -176,6 +176,6 @@ def cli(**kwargs):
             })
 
         if not _file:
-            ioc_common.check_release_newer(release)
+            ioc_common.check_release_newer(release, major_only=True)
 
     ioc.IOCage().fetch(**kwargs)

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -710,7 +710,7 @@ def get_host_release():
 
 
 def check_release_newer(
-    release, callback=None, silent=False, raise_error=True
+    release, callback=None, silent=False, raise_error=True, major_only=False
 ):
     """Checks if the host RELEASE is greater than the target release"""
     host_release = get_host_release()
@@ -718,8 +718,8 @@ def check_release_newer(
     if host_release == "Not a RELEASE":
         return
 
-    h_float = float(str(host_release).rsplit("-")[0])
-    r_float = float(str(release).rsplit("-")[0])
+    h_float = float(str(host_release).rsplit('.' if major_only else '-')[0])
+    r_float = float(str(release).rsplit('.' if major_only else '-')[0])
 
     if h_float < r_float and raise_error:
         logit(

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -174,7 +174,7 @@ class IOCFetch:
         try:
             self.release = releases[int(self.release)]
             iocage_lib.ioc_common.check_release_newer(
-                self.release, self.callback, self.silent)
+                self.release, self.callback, self.silent, major_only=True)
         except IndexError:
             # Time to print the list again
             self.release = self.__fetch_validate_release__(releases)
@@ -209,7 +209,8 @@ class IOCFetch:
 
             if self.release:
                 iocage_lib.ioc_common.check_release_newer(
-                    self.release, callback=self.callback, silent=self.silent
+                    self.release, callback=self.callback, silent=self.silent,
+                    major_only=True,
                 )
             rel = self.fetch_http_release(eol, _list=_list)
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -448,7 +448,7 @@ class IOCPlugin(object):
 
             if not os.path.isdir(f"{self.iocroot}/releases/{self.release}"):
                 iocage_lib.ioc_common.check_release_newer(
-                    self.release, self.callback, self.silent)
+                    self.release, self.callback, self.silent, major_only=True)
                 self.__fetch_release__(self.release)
 
         if conf["release"][:4].endswith("-"):
@@ -456,7 +456,7 @@ class IOCPlugin(object):
             release = conf["release"]
         else:
             iocage_lib.ioc_common.check_release_newer(
-                self.release, self.callback, self.silent)
+                self.release, self.callback, self.silent, major_only=True)
 
             try:
                 with open(
@@ -1241,7 +1241,7 @@ fingerprint: {fingerprint}
         self.__check_manifest__(plugin_conf)
         plugin_release = plugin_conf["release"]
         iocage_lib.ioc_common.check_release_newer(
-            plugin_release, self.callback, self.silent)
+            plugin_release, self.callback, self.silent, major_only=True)
 
         # We want the new json to live with the jail
         plugin_name = self.plugin.rsplit('_', 1)[0]

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1751,24 +1751,11 @@ class IOCage:
             uuid, path = self.__check_jail_existence__()
             conf = ioc_json.IOCJson(path, silent=self.silent).json_get_value(
                 'all')
-            host_release = float(os.uname()[2].rsplit("-", 1)[0].rsplit("-",
-                                                                        1)[0])
             release = conf["release"]
 
             if release != "EMPTY":
                 release = float(release.rsplit("-", 1)[0].rsplit("-", 1)[0])
-
-                if host_release < release:
-                    ioc_common.logit(
-                        {
-                            "level":
-                            "EXCEPTION",
-                            "message":
-                            f"\nHost: {host_release} is not greater than"
-                            f" jail: {release}\nThis is unsupported."
-                        },
-                        _callback=self.callback,
-                        silent=self.silent)
+                ioc_common.check_release_newer(release, major_only=True)
 
             err, msg = self.__check_jail_type__(conf["type"], uuid)
             depends = conf["depends"].split()
@@ -1987,20 +1974,8 @@ class IOCage:
             return
 
         if release is not None:
-            host_release = float(os.uname()[2].rsplit("-", 1)[0].rsplit(
-                "-", 1)[0])
             _release = release.rsplit("-", 1)[0].rsplit("-", 1)[0]
-            _release = float(_release)
-
-            if host_release < _release:
-                ioc_common.logit({
-                    "level":
-                    "EXCEPTION",
-                    "message":
-                    f"\nHost: {host_release} is not greater than"
-                    f" target: {_release}\nThis is unsupported."
-                },
-                    _callback=self.callback)
+            ioc_common.check_release_newer(_release, major_only=True)
 
         uuid, path = self.__check_jail_existence__()
         root_path = f"{path}/root"

--- a/iocage_lib/release.py
+++ b/iocage_lib/release.py
@@ -58,7 +58,9 @@ class ListableReleases(IocageListableResource):
             for release in filter(
                 lambda r: (
                     r if not self.eol_check else r not in self.eol_list
-                ) and not check_release_newer(r, raise_error=False),
+                ) and not check_release_newer(
+                    r, raise_error=False, major_only=True
+                ),
                 re.findall(
                     r'href="(\d.*RELEASE)/"', req.content.decode('utf-8')
                 )


### PR DESCRIPTION
This PR introduces changes which allow user to use higher minor version number jails. This is allowed by FreeBSD and is okay to do so.