### PR TITLE
NAS-106037 / 12.0 / Make MTU of VNet interfaces configurable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-11-2-release-amd64
+  image: freebsd-11-3-release-amd64
 
 iocage_tests_task:
   create_pool_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-11-3-release-amd64
+  image: freebsd-11-3-stable-amd64-v20200402
 
 iocage_tests_task:
   create_pool_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-11-3-release-amd64
+  image: freebsd-11-3-snap
 
 iocage_tests_task:
   create_pool_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-11-3-stable-amd64-v20200402
+  image_family: freebsd-11-3-snap
 
 iocage_tests_task:
   create_pool_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-11-3-snap
+  image: freebsd-11-3-release-amd64
 
 iocage_tests_task:
   create_pool_script:

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -895,8 +895,8 @@ class IOCConfiguration:
         for x in range(0, 4):
             if not conf.get(f"vnet{x}_mtu"):
                 conf[f"vnet{x}_mtu"] = 'auto'
-        if not conf.get(f"vnet_default_mtu"):
-            conf[f"vnet_default_mtu"] = '1500'
+        if not conf.get("vnet_default_mtu"):
+            conf["vnet_default_mtu"] = '1500'
 
         if not default:
             conf.update(jail_conf)

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -863,7 +863,7 @@ class IOCConfiguration:
                 conf[option] = 'auto'
 
         # Version 27 keys
-        for x in range(0,4):
+        for x in range(0, 4):
             if not conf.get(f"vnet{x}_mtu"):
                 conf[f"vnet{x}_mtu"] = 'auto'
         if not conf.get(f"vnet_default_mtu"):

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -863,11 +863,11 @@ class IOCConfiguration:
         for option in ('defaultrouter', 'defaultrouter6'):
             if conf.get(option) == 'none':
                 conf[option] = 'auto'
-        
+
         # Version 27 key
         if not conf.get('min_dyn_devfs_ruleset'):
             conf['min_dyn_devfs_ruleset'] = '1000'
-        
+
         # Version 28 keys
         for x in range(0, 4):
             if not conf.get(f"vnet{x}_mtu"):

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -433,7 +433,7 @@ class IOCConfiguration:
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '26'
+        version = '27'
 
         return version
 
@@ -862,6 +862,13 @@ class IOCConfiguration:
             if conf.get(option) == 'none':
                 conf[option] = 'auto'
 
+        # Version 27 keys
+        for x in range(0,4):
+            if not conf.get(f"vnet{x}_mtu"):
+                conf[f"vnet{x}_mtu"] = 'auto'
+        if not conf.get(f"vnet_default_mtu"):
+            conf[f"vnet_default_mtu"] = '1500'
+
         if not default:
             conf.update(jail_conf)
 
@@ -1190,6 +1197,11 @@ class IOCConfiguration:
             'nat_forwards': 'none',
             'plugin_name': 'none',
             'plugin_repository': 'none',
+            'vnet0_mtu': 'auto',
+            'vnet1_mtu': 'auto',
+            'vnet2_mtu': 'auto',
+            'vnet3_mtu': 'auto',
+            'vnet_default_mtu': '1500',
         }
 
     def check_default_config(self):
@@ -2093,6 +2105,11 @@ class IOCJson(IOCConfiguration):
             'nat_forwards': ('string', ),
             'plugin_name': ('string', ),
             'plugin_repository': ('string', ),
+            "vnet0_mtu": ("string", ),
+            "vnet1_mtu": ("string", ),
+            "vnet2_mtu": ("string", ),
+            "vnet3_mtu": ("string", ),
+            "vnet_default_mtu": ("string", ),
         }
 
         zfs_props = {

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1474,6 +1474,8 @@ class IOCStart(object):
 
         memberif = self.get_bridge_members(bridge)
         if not memberif:
+            if self.unit_test:
+                return "1500"
             return self.get('vnet_default_mtu')
 
         membermtu = iocage_lib.ioc_common.checkoutput(

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1066,10 +1066,12 @@ class IOCStart(object):
             nic, bridge = nic_def.split(":")
 
             try:
-                if not nat_addr:
+                if self.get(f"{nic}_mtu") != 'auto':
+                    membermtu = self.get(f"{nic}_mtu")
+                elif not nat_addr:
                     membermtu = self.find_bridge_mtu(bridge)
                 else:
-                    membermtu = '1500'
+                    membermtu = self.get('vnet_default_mtu')
 
                 dhcp = self.get('dhcp')
 
@@ -1450,7 +1452,7 @@ class IOCStart(object):
 
         memberif = self.get_bridge_members(bridge)
         if not memberif:
-            return '1500'
+            return self.get('vnet_default_mtu')
 
         membermtu = iocage_lib.ioc_common.checkoutput(
             ["ifconfig", memberif[0]]

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1555,8 +1555,6 @@ class IOCStart(object):
 
         memberif = self.get_bridge_members(bridge)
         if not memberif:
-            if self.unit_test:
-                return "1500"
             return self.get('vnet_default_mtu')
 
         membermtu = iocage_lib.ioc_common.checkoutput(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def pytest_addoption(parser):
         help='Specify a zpool to use.'
     )
     parser.addoption(
-        '--release', action='store', default='11.2-RELEASE',
+        '--release', action='store', default='11.3-RELEASE',
         help='Specify a RELEASE to use.'
     )
     parser.addoption(

--- a/tests/unit_tests/1000_lib_start_test.py
+++ b/tests/unit_tests/1000_lib_start_test.py
@@ -52,7 +52,16 @@ def test_should_return_default_mtu_if_no_members(mock_checkoutput):
     mock_checkoutput.side_effect = [bridge_with_no_members_if_config,
                                     member_if_config]
 
-    mtu = ioc_start.IOCStart("", "", unit_test=True).find_bridge_mtu('bridge0')
+    # IOCStart.get() is not implemented in test mode. We need it for this test.
+    # So provide a dummy implementation which gives us the default MTU.
+    def _mock_iocstart_get(prop):
+        if prop=='vnet_default_mtu':
+            return "1500"
+        raise AttributeError(prop)
+
+    iocs = ioc_start.IOCStart("", "", unit_test=True)
+    iocs.get = _mock_iocstart_get
+    mtu = iocs.find_bridge_mtu('bridge0')
     assert mtu == '1500'
     mock_checkoutput.called_with(["ifconfig", "bridge0"])
 


### PR DESCRIPTION
This patch adds five new configuration parameters, with the default behaviour being identical to the pre-existing behaviour (copy the MTU value from the bridge, or 1500 if there is no existing bridge). We add:

* vnet[0-3]_mtu - default to "auto" (ie. existing behaviour). If set to a value, it will take top precedence in creating the device (ie. it will ignore the value the bridge has)
* vnet_default_mtu - replaces the hardcoded "1500" value in the code with a configurable variable (but the variable defaults to "1500").

The use case we have for this where a bridge (say bridge0) has an IP address, and we bring it up on boot with that address (but no bridged NIC attached). if_bridge(4) says that you can't set the MTU on bridge0 with ifconfig - it is configured from the first attached device to the bridge. In our case, the VNet device ends up being the first attached, and this is hardcoded to 1500 (the VPS provider the machine runs on requires it to be 1450). Using one of the two above options (it seemed sensible to provide either a global or per-interface configuration) covers this situation.