### PR TITLE
Correct typo in error message for iocage set

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1520,7 +1520,7 @@ class IOCage:
             ioc_common.logit(
                 {
                     "level": "EXCEPTION",
-                    "message": f"{prop} is is missing a value!"
+                    "message": f"{prop} is missing a value!"
                 },
                 _callback=self.callback,
                 silent=self.silent)


### PR DESCRIPTION
Fix typo in error message displayed when not providing a value for a
setting during an 'iocage set' operation.
