### PR TITLE
NAS-104026 / 11.3 / Bug fixes for basejail upgrades

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1277,8 +1277,10 @@ fingerprint: {fingerprint}
             silent=self.silent)
 
         new_release = iocage_lib.ioc_upgrade.IOCUpgrade(
-            plugin_release, path, silent=True).upgrade_basejail(
-                snapshot=False)
+            plugin_release, path, silent=True
+        ).upgrade_basejail(
+            snapshot=False, snap_name=f'ioc_plugin_upgrade_{self.date}'
+        )
 
         self.silent = True
         self.update(jid)

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -200,7 +200,7 @@ class IOCUpgrade:
 
         return new_release
 
-    def upgrade_basejail(self, snapshot=True):
+    def upgrade_basejail(self, snapshot=True, snap_name=None):
         if "HBSD" in self.freebsd_version:
             # TODO: Not supported yet
             msg = "Upgrading basejails on HardenedBSD is not supported yet."
@@ -268,7 +268,7 @@ class IOCUpgrade:
             )
         except iocage_lib.ioc_exceptions.CommandFailed:
             msg = "Mounting src into jail failed! Rolling back snapshot."
-            self.__rollback_jail__()
+            self.__rollback_jail__(name=snap_name)
 
             iocage_lib.ioc_common.logit(
                 {
@@ -293,7 +293,7 @@ class IOCUpgrade:
             # These are now the result of a failed merge, nuking and putting
             # the backup back
             msg = "etcupdate failed! Rolling back snapshot."
-            self.__rollback_jail__()
+            self.__rollback_jail__(name=snap_name)
 
             su.Popen([
                 "umount", "-f", f"{self.path}/iocage_upgrade"
@@ -396,9 +396,9 @@ class IOCUpgrade:
         name = f"ioc_upgrade_{self.date}"
         ioc.IOCage(jail=self.uuid, skip_jails=True, silent=True).snapshot(name)
 
-    def __rollback_jail__(self):
+    def __rollback_jail__(self, name=None):
         import iocage_lib.iocage as ioc  # Avoids dep issues
-        name = f"ioc_upgrade_{self.date}"
+        name = name if name else f'ioc_upgrade_{self.date}'
         iocage = ioc.IOCage(jail=self.uuid, skip_jails=True, silent=True)
         iocage.stop()
         iocage.rollback(name)

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -2056,6 +2056,7 @@ class IOCage:
                 ioc_start.IOCStart(uuid, path, silent=True)
                 started = True
 
+            status, jid = self.list('jid', uuid=uuid)
             new_release = ioc_plugin.IOCPlugin(
                 jail=uuid,
                 plugin=conf['plugin_name'],

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1487,7 +1487,7 @@ class IOCage:
         snap = Snapshot(f'{dataset.name}@{name}')
         if not snap.exists:
             ioc_common.logit(
-                {'level': 'EXCEPTION', 'message': f'{target} does not exist'},
+                {'level': 'EXCEPTION', 'message': f'{snap} does not exist'},
                 _callback=self.callback, silent=self.silent
             )
 


### PR DESCRIPTION
This PR introduces following changes:
1) Fixes an issue where jid was not properly passed when upgrading plugins
2) Fixes an issue where wrong name for snapshot was used when trying to rollback during upgrade failure
3) Fixes an issue where iocage did not correctly log that a particular snapshot doesn't exist during rollback