### PR TITLE
NAS-104777 / 12.0 / Change devfs ruleset handling so that configured rulesets != 4 are

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -49,8 +49,6 @@ INTERACTIVE = False
 # 4 is a magic number for default and doesn't refer
 # to the actual ruleset 4 in devfs.rules(!)
 IOCAGE_DEVFS_RULESET = 4
-# Leave lower devfs_ruleset ids to sysadmin
-MIN_DYNAMIC_DEVFS_RULESET = 1000
 
 
 def callback(_log, callback_exception):
@@ -755,7 +753,7 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
     )
     ruleset_list = [int(i) for i in devfs_rulesets.stdout.splitlines()]
 
-    ruleset = MIN_DYNAMIC_DEVFS_RULESET
+    ruleset = int(conf["min_dyn_devfs_ruleset"])
     while ruleset in ruleset_list:
         ruleset += 1
     ruleset = str(ruleset)

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -740,7 +740,7 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
     Will add a per jail devfs ruleset with the specified rules,
     specifying defaults that equal devfs_ruleset 4
     """
-    ruleset = conf['devfs_ruleset']
+    configured_ruleset = conf['devfs_ruleset']
     devfs_includes = []
     devfs_rulesets = su.run(
         ['devfs', 'rule', 'showsets'],
@@ -748,22 +748,37 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
     )
     ruleset_list = [int(i) for i in devfs_rulesets.stdout.splitlines()]
 
-    if ruleset != '4':
-        if int(ruleset) in ruleset_list:
-            return str(ruleset)
+    # 4 is a magic number for default and doesn't refer to
+    # the actual ruleset 4 in devfs.rules(!)
+    default_ruleset = 4
+    min_dynamic_ruleset = 1000  # leave lower numbers to sysadmin
 
-        logit({
-            "level": "INFO",
-            "message": f'* Ruleset {ruleset} does not exist, using defaults'
-        },
-            _callback=callback,
-            silent=silent)
-
-    ruleset = 5  # 0-4 is always reserved
+    ruleset = min_dynamic_ruleset
     while ruleset in ruleset_list:
         ruleset += 1
     ruleset = str(ruleset)
 
+    # Custom devfs_ruleset configured, clone to dynamic ruleset
+    if int(configured_ruleset) != default_ruleset:
+        if int(configured_ruleset) not in ruleset_list:
+            logit(
+                {
+                    "level": "EXCEPTION",
+                    "message": f"devfs_ruleset {ruleset} doesn't exist"
+                },
+                _callback=callback,
+                silent=silent)
+        rules = su.run(
+            ['devfs', 'rule', '-s', configured_ruleset, 'show'],
+            stdout=su.PIPE, universal_newlines=True
+        )
+        for rule in rules.stdout.splitlines():
+            su.run(['devfs', 'rule', '-s', ruleset, 'add'] +
+                   rule.split(' ')[1:], stdout=su.PIPE)
+
+        return ruleset
+
+    # Create default ruleset
     devfs_dict = dict((dev, None) for dev in (
         'hide', 'null', 'zero', 'crypto', 'random', 'urandom', 'ptyp*',
         'ptyq*', 'ptyr*', 'ptys*', 'ptyP*', 'ptyQ*', 'ptyR*', 'ptyS*', 'ptyl*',

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -1088,7 +1088,7 @@ class IOCConfiguration:
             'vnet2_mac': 'none',
             'vnet3_mac': 'none',
             'vnet_default_interface': 'auto',
-            'devfs_ruleset': '4',
+            'devfs_ruleset': str(iocage_lib.ioc_common.IOCAGE_DEVFS_RULESET),
             'exec_start': '/bin/sh /etc/rc',
             'exec_stop': '/bin/sh /etc/rc.shutdown',
             'exec_prestart': '/usr/bin/true',

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -2396,6 +2396,22 @@ class IOCJson(IOCConfiguration):
                                 silent=self.silent,
                                 exception=ioc_exceptions.ValidationFailed
                             )
+                elif key in ('devfs_ruleset', 'min_dyn_devfs_ruleset'):
+                    try:
+                        intval = int(value)
+                        if intval <= 0:
+                            raise ValueError()
+                        conf[key] = str(intval)
+                    except ValueError:
+                        iocage_lib.ioc_common.logit(
+                            {
+                                'level': 'EXCEPTION',
+                                'message': f'Invalid {key} value: {value}'
+                            },
+                            _callback=self.callback,
+                            silent=self.silent,
+                            exception=ioc_exceptions.ValidationFailed
+                        )
 
                 return value, conf
             else:

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -433,7 +433,7 @@ class IOCConfiguration:
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '26'
+        version = '27'
 
         return version
 
@@ -864,6 +864,10 @@ class IOCConfiguration:
             if conf.get(option) == 'none':
                 conf[option] = 'auto'
 
+        # Version 27 key
+        if not conf.get('min_dyn_devfs_ruleset'):
+            conf['min_dyn_devfs_ruleset'] = '1000'
+
         if not default:
             conf.update(jail_conf)
 
@@ -1201,6 +1205,7 @@ class IOCConfiguration:
             'nat_forwards': 'none',
             'plugin_name': 'none',
             'plugin_repository': 'none',
+            'min_dyn_devfs_ruleset': '1000',
         }
 
     def check_default_config(self):
@@ -2110,6 +2115,7 @@ class IOCJson(IOCConfiguration):
             'nat_forwards': ('string', ),
             'plugin_name': ('string', ),
             'plugin_repository': ('string', ),
+            'min_dyn_devfs_ruleset': ('string', ),
         }
 
         zfs_props = {

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -145,7 +145,6 @@ class IOCStart(object):
         allow_quotas = self.conf["allow_quotas"]
         allow_socket_af = self.conf["allow_socket_af"]
         allow_vmm = self.conf["allow_vmm"]
-        devfs_ruleset = iocage_lib.ioc_common.generate_devfs_ruleset(self.conf)
         exec_prestart = self.conf["exec_prestart"]
         exec_poststart = self.conf["exec_poststart"]
         exec_clean = self.conf["exec_clean"]
@@ -489,16 +488,8 @@ class IOCStart(object):
             _callback=self.callback,
             silent=self.silent)
 
-        if wants_dhcp and self.conf['type'] != 'pluginv2' \
-                and self.conf['devfs_ruleset'] != '4':
-            iocage_lib.ioc_common.logit({
-                "level": "WARNING",
-                "message": f"  {self.uuid} is not using the devfs_ruleset"
-                           f" of 4, not generating a ruleset for the jail,"
-                           " DHCP may not work."
-            },
-                _callback=self.callback,
-                silent=self.silent)
+        devfs_paths = None
+        devfs_includes = None
 
         if self.conf['type'] == 'pluginv2' and os.path.isfile(
             os.path.join(self.path, f'{self.conf["plugin_name"]}.json')
@@ -512,17 +503,49 @@ class IOCStart(object):
                     plugin_name = self.conf['plugin_name']
                     plugin_devfs = devfs_json[
                         "devfs_ruleset"][f"plugin_{plugin_name}"]
-                    plugin_devfs_paths = plugin_devfs['paths']
-
-                    plugin_devfs_includes = None if 'includes' not in \
+                    devfs_paths = plugin_devfs['paths']
+                    devfs_includes = None if 'includes' not in \
                         plugin_devfs else plugin_devfs['includes']
 
-                    devfs_ruleset = \
-                        iocage_lib.ioc_common.generate_devfs_ruleset(
-                            self.conf,
-                            paths=plugin_devfs_paths,
-                            includes=plugin_devfs_includes
-                        )
+        # Generate dynamic devfs ruleset from configured one
+        (manual_devfs_config, configured_devfs_ruleset, devfs_ruleset) \
+            = iocage_lib.ioc_common.generate_devfs_ruleset(
+                self.conf, devfs_paths, devfs_includes)
+
+        if int(devfs_ruleset) <= 0:
+            iocage_lib.ioc_common.logit({
+                "level": "ERROR",
+                "message": f"{self.uuid} devfs_ruleset"
+                           f" {configured_devfs_ruleset} doesnt_exit!"
+                           " - Not starting jail"
+                }, _callback=self.callback, silent=self.silent)
+            return
+
+        # Manually configured devfs_ruleset don't support all iocage features
+        if manual_devfs_config:
+            if devfs_paths is not None or devfs_includes is not None:
+                iocage_lib.ioc_common.logit({
+                    "level": "WARNING",
+                    "message": f"  {self.uuid} is not using the devfs_ruleset"
+                               " of "
+                               f"{iocage_lib.ioc_common.IOCAGE_DEVFS_RULESET}"
+                               ", devices and includes from plugin not added"
+                               ", some features of the plugin may not work."
+                },
+                    _callback=self.callback,
+                    silent=self.silent)
+
+            if wants_dhcp and self.conf['type'] != 'pluginv2':
+                iocage_lib.ioc_common.logit({
+                    "level": "WARNING",
+                    "message": f"  {self.uuid} is not using the devfs_ruleset"
+                               " of "
+                               f"{iocage_lib.ioc_common.IOCAGE_DEVFS_RULESET}"
+                               ", not generating a ruleset for the jail,"
+                               " DHCP may not work."
+                },
+                    _callback=self.callback,
+                    silent=self.silent)
 
         parameters = [
             fdescfs, _allow_mlock, tmpfs,
@@ -620,6 +643,22 @@ class IOCStart(object):
             },
                 _callback=self.callback,
                 silent=self.silent)
+
+        if manual_devfs_config:
+            iocage_lib.ioc_common.logit({
+                'level': 'INFO',
+                'message': '  + Cloning devfs_ruleset'
+                           f' {configured_devfs_ruleset}'
+            },
+                    _callback=self.callback,
+                    silent=self.silent)
+        else:
+            iocage_lib.ioc_common.logit({
+                'level': 'INFO',
+                'message': '  + Generating dynamic devfs_ruleset'
+            },
+                    _callback=self.callback,
+                    silent=self.silent)
 
         iocage_lib.ioc_common.logit({
             'level': 'INFO',

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -646,25 +646,12 @@ class IOCStart(object):
                 _callback=self.callback,
                 silent=self.silent)
 
-        if manual_devfs_config:
-            iocage_lib.ioc_common.logit({
-                'level': 'INFO',
-                'message': '  + Cloning devfs_ruleset'
-                           f' {configured_devfs_ruleset}'
-            },
-                _callback=self.callback,
-                silent=self.silent)
-        else:
-            iocage_lib.ioc_common.logit({
-                'level': 'INFO',
-                'message': '  + Generating dynamic devfs_ruleset'
-            },
-                _callback=self.callback,
-                silent=self.silent)
-
         iocage_lib.ioc_common.logit({
             'level': 'INFO',
             'message': f'  + Using devfs_ruleset: {devfs_ruleset}'
+                       + (' (cloned from devfs_ruleset '
+                          f'{configured_devfs_ruleset})' if manual_devfs_config
+                          else ' (iocage generated default)')
         },
             _callback=self.callback,
             silent=self.silent)


### PR DESCRIPTION
cloned/copied into dynamic ones.  This makes devfs rule handling more
symmetrical to what is done when the default ruleset 4 is configured (which
in fact never applies devfs ruleset 4, but creates an iocage specific
dynamic ruleset instead - which can be quite confusing).

As a result, this addresses the problem of non-dynamic rulesets being
removed on `iocage stop` raised in https://github.com/iocage/iocage/issues/952.

This also makes iocage fail to start a jail if the configured devfs ruleset
is not available - beforehand it would start with a default ruleset in this
case, which can have severe unwanted side effects.

Finally, this sets the minimum dynamically assigned devfs rule id to 1000 to
reserve the lower ids for static configuration by the admin in devfs.rules
(this is mostly for convenience).

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
