### PR TITLE
NAS-104930 / 12.0 / Donot cache snapshots for iocage

### DIFF
--- a/iocage_lib/cache.py
+++ b/iocage_lib/cache.py
@@ -23,7 +23,8 @@ class Cache:
                 if ioc_pool:
                     ds = os.path.join(ioc_pool, 'iocage')
                 self.dataset_data = all_properties(
-                    ds if ds and dataset_exists(ds) else '', recursive=True
+                    ds if ds and dataset_exists(ds) else '', recursive=True,
+                    types=['filesystem']
                 )
             return self.dataset_data
 

--- a/iocage_lib/zfs.py
+++ b/iocage_lib/zfs.py
@@ -57,12 +57,16 @@ def properties(dataset, resource_type='zfs'):
     }
 
 
-def all_properties(path='', resource_type='zfs', depth=None, recursive=False):
+def all_properties(
+    path='', resource_type='zfs', depth=None, recursive=False, types=None
+):
     flags = []
     if depth:
         flags.extend(['-d', str(depth)])
     if recursive:
         flags.append('-r')
+    if types:
+        flags.extend(['-t', ','.join(types)])
 
     data = run(list(filter(
         bool, [


### PR DESCRIPTION
This commit fixes an issue where we used to cache snapshots which resulted in exteremly slow iocage operation times.

Closes #1114
