### PR TITLE
NAS-105608 / 12.0 / Make sure we handle ABI in packagesite gracefully

### DIFF
--- a/.travis/flake8.sh
+++ b/.travis/flake8.sh
@@ -2,7 +2,7 @@
 # Run pep8 on all .py files in all subfolders
 
 tmpafter=$(mktemp)
-find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpafter}
+find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --max-line-length=100 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpafter}
 num_errors_after=`cat ${tmpafter} | wc -l`
 echo "Current Error Count: ${num_errors_after}"
 
@@ -15,7 +15,7 @@ echo "Comparing with last stable release: ${last_release}"
 git checkout ${last_release}
 
 tmpbefore=$(mktemp)
-find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpbefore}
+find ./iocage_cli ./iocage_lib -name \*.py -exec flake8 --max-line-length=100 --ignore=E127,E203,W503,F811,W504 {} + > ${tmpbefore}
 num_errors_before=`cat ${tmpbefore} | wc -l`
 echo "${last_release}'s Error Count: ${num_errors_before}"
 

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -198,7 +198,7 @@ class IOCPlugin(object):
         return version_dict
 
     @staticmethod
-    def retrieve_plugin_index_data(plugin_index_path):
+    def retrieve_plugin_index_data(plugin_index_path, expand_abi=True):
         plugin_index = {}
         index_path = os.path.join(plugin_index_path, 'INDEX')
         if not os.path.exists(index_path):
@@ -220,10 +220,9 @@ class IOCPlugin(object):
             if not any(plugin_manifest_data.get(k) for k in ('release', 'packagesite')):
                 continue
 
-            if '${ABI}' in plugin_manifest_data['packagesite']:
-                plugin_manifest_data['packagesite'] = plugin_manifest_data['packagesite'].replace(
-                    '${ABI}',
-                    f'FreeBSD:{plugin_manifest_data["release"].split("-")[0].split(".")[0]}:amd64'
+            if expand_abi and '${ABI}' in plugin_manifest_data['packagesite']:
+                plugin_manifest_data['packagesite'] = IOCPlugin.expand_abi_with_specified_release(
+                    plugin_manifest_data['packagesite'], plugin_manifest_data['release']
                 )
 
             plugin_index[plugin] = {
@@ -233,6 +232,12 @@ class IOCPlugin(object):
             }
 
         return plugin_index
+
+    @staticmethod
+    def expand_abi_with_specified_release(packagesite, release):
+        return packagesite.replace(
+            '${ABI}', f'FreeBSD:{release.split("-")[0].split(".")[0]}:amd64'
+        )
 
     def fetch_plugin_versions(self):
         self.pull_clone_git_repo()
@@ -1354,10 +1359,11 @@ fingerprint: {fingerprint}
 
     def _plugin_json_file(self):
         plugin_name = self.plugin.rsplit('_', 1)[0]
+        jail_name = self.jail or plugin_name
         try:
             with open(
                 os.path.join(
-                    self.iocroot, 'jails', plugin_name, f'{plugin_name}.json'
+                    self.iocroot, 'jails', jail_name, f'{plugin_name}.json'
                 ), 'r'
             ) as f:
                 manifest = json.loads(f.read())
@@ -1365,7 +1371,7 @@ fingerprint: {fingerprint}
             iocage_lib.ioc_common.logit(
                 {
                     'level': 'EXCEPTION',
-                    'message': f'Failed retrieving {plugin_name} json'
+                    'message': f'Failed retrieving {jail_name} json'
                 },
                 _callback=self.callback
             )


### PR DESCRIPTION
This PR introduces changes to ensure that if we have `ABI` provided in the plugin manifest's packagesite, we expand it keeping in line with the `release` plugin is using.