### PR TITLE
Clarify using iocage with VNET and VLANs

### DIFF
--- a/doc/source/networking.rst
+++ b/doc/source/networking.rst
@@ -164,8 +164,11 @@ Be sure the default gateway knows the route back to the VNET subnets.
 
 **Using VLANs**
 
-If using VLAN interfaces for the jail host, add the VLAN interface AND
-parent interface of the VLAN as bridge members.
+To assign a jail's traffic to a VLAN, add the VLAN interface as a bridge
+member, but not the VLAN's parent.
+
+If using VLAN interfaces for the jail host, on the other hand, add the parent
+as a bridge member, but not the VLAN interface.
 
 .. index:: Configure Network Interfaces
 .. _Configuring Network Interfaces:


### PR DESCRIPTION
The original wording dates from
3f441b72430c1cb9e1fa993f70ea14d6cf9629e2.  I think it refers to putting
the jail host on a VLAN, but not the individual jails.  But this wording
has confused multiple people, since it's also common to put an
individual jail on a VLAN.

Fixes #901

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
