### PR TITLE
Update CI image to a FreeBSD 11-STABLE snapshot

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-11-2-release-amd64
+  image_family: freebsd-11-3-snap
 
 iocage_tests_task:
   create_pool_script:


### PR DESCRIPTION
FreeBSD 11.2-RELEASE is EOL, and no longer supported by pkg.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
