### PR TITLE
Docs: add an example of VLAN configuration

### DIFF
--- a/doc/source/networking.rst
+++ b/doc/source/networking.rst
@@ -165,10 +165,25 @@ Be sure the default gateway knows the route back to the VNET subnets.
 **Using VLANs**
 
 To assign a jail's traffic to a VLAN, add the VLAN interface as a bridge
-member, but not the VLAN's parent.
+member, but not the VLAN's parent.  For example:
 
-If using VLAN interfaces for the jail host, on the other hand, add the parent
-as a bridge member, but not the VLAN interface.
+.. code-block:: none
+
+   sysrc vlans_em0="666"
+   sysrc ifconfig_em0_666="up"
+   iocage set vnet_default_interface="em0.666" examplejail
+   iocage set interfaces="vnet1:bridge1" examplejail
+
+
+If using VLAN interfaces for the jail host only, on the other hand, add the
+parent as a bridge member, but not the VLAN interface.
+
+.. code-block:: none
+
+   sysrc vlans_em0="666"
+   sysrc ifconfig_em0_666="1.2.3.4/24"
+   iocage set vnet_default_interface="auto" examplejail # "em0" would also work
+   iocage set interfaces="vnet1:bridge1" examplejail
 
 .. index:: Configure Network Interfaces
 .. _Configuring Network Interfaces:


### PR DESCRIPTION
Add an example configuration for using a jail on a VLAN.  I recently shot myself in the foot because I didn't know to set `vnet_default_interface`.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
