### PR TITLE
Do not fetch/install lib32 for i386

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -536,7 +536,7 @@ class IOCage:
 
             arch = os.uname()[4]
 
-            if arch == 'arm64':
+            if arch in {'i386', 'arm64'}:
                 files = ['MANIFEST', 'base.txz', 'src.txz']
             else:
                 files = ['MANIFEST', 'base.txz', 'lib32.txz', 'src.txz']
@@ -998,7 +998,7 @@ class IOCage:
 
         if not _list:
             if not kwargs.get('files', None):
-                if arch == 'arm64':
+                if arch in {'i386', 'arm64'}:
                     kwargs['files'] = ['MANIFEST', 'base.txz', 'src.txz']
                 else:
                     kwargs['files'] = ['MANIFEST', 'base.txz', 'lib32.txz',


### PR DESCRIPTION
`i386` is a 32-bit architecture therefore lacks a separate `lib32` tarball.  `iocage fetch` fails on `i386` platform when it tries to fetch the non-existent `lib32` tarball.

The same check is already performed for `arm64`; extend the `if` clause to check for `i386` as well.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
