### PR TITLE
NAS-107486 / 12.0 / Correctly identify devfs ruleset on stopping jail

### DIFF
--- a/iocage_lib/ioc_stop.py
+++ b/iocage_lib/ioc_stop.py
@@ -67,7 +67,8 @@ class IOCStop(object):
         vnet = self.conf["vnet"]
         dhcp = self.conf["dhcp"]
         exec_fib = self.conf["exec_fib"]
-        devfs_ruleset = self.conf['devfs_ruleset']
+        devfs_ruleset = iocage_lib.ioc_json.IOCJson(
+            self.path, suppress_log=True).json_get_value('devfs_ruleset')
         debug_mode = True if os.environ.get(
             'IOCAGE_DEBUG', 'FALSE') == 'TRUE' else False
         nat = self.conf['nat']


### PR DESCRIPTION
Earlier iocage unconditionally checked cloned devfs ruleset on each jail listing, that behaviour has changed due to performance reasons and now we explicilty get cloned devfs ruleset where desired.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [ ] Explain the feature
- [ ] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
