### PR TITLE
fix for #1159 (https://github.com/iocage/iocage/issues/1159)

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -866,6 +866,10 @@ class IOCFetch:
         path = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:'\
                '/usr/local/bin:/root/bin'
         fetch_env = {
+            **{
+                k: os.environ.get(k)
+                for k in ['HTTP_PROXY', 'HTTP_PROXY_AUTH', 'HTTP_TIMEOUT'] if os.environ.get(k)
+            },
             'UNAME_r': self.release,
             'PAGER': '/bin/cat',
             'PATH': path,

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -73,6 +73,10 @@ class IOCUpgrade:
         path = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:'\
                '/usr/local/bin:/root/bin'
         self.upgrade_env = {
+            **{
+                k: os.environ.get(k)
+                for k in ['HTTP_PROXY', 'HTTP_PROXY_AUTH', 'HTTP_TIMEOUT'] if os.environ.get(k)
+            },
             'PAGER': '/bin/cat',
             'PATH': path,
             'PWD': '/',


### PR DESCRIPTION
  - added HTTP_PROXY, HTTP_PROXY_AUTH, HTTP_TIMEOUT to environment
    of freebsd-update command in order to make use of a proxy.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
