### PR TITLE
fix #1202

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -861,8 +861,6 @@ class IOCFetch:
                 _callback=self.callback,
                 silent=self.silent)
 
-        shutil.copy("/etc/resolv.conf", f"{mount_root}/etc/resolv.conf")
-
         path = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:'\
                '/usr/local/bin:/root/bin'
         fetch_env = {


### PR DESCRIPTION
This PR just removes a forced blind copy of host's resolv.conf.

This way jail's config is respected (and not overriden without warning on iocage update)

This fixes #1202 for us