### PR TITLE
Use streaming reads to avoid blowing memory

### DIFF
--- a/iocage_lib/ioc_image.py
+++ b/iocage_lib/ioc_image.py
@@ -284,12 +284,15 @@ class IOCImage(object):
                         )
                     ], stdin=su.PIPE
                 )
-                if compression_algo == 'zip':
-                    data = f.open(name).read()
-                else:
-                    data = f.extractfile(member).read()
 
-                recv.stdin.write(data)
+                chunk_size = 10 * 1024 * 1024
+
+                with (f.open(name) if compression_algo == 'zip' else f.extractfile(member)) as file:
+                    data = file.read(chunk_size)
+                    while data is not None and len(data) > 0:
+                        recv.stdin.write(data)
+                        data = file.read(chunk_size)
+
                 recv.communicate()
 
         # Cleanup our mess.


### PR DESCRIPTION
Modifies code in ioc_image.py to use buffered io. Previous code used .read() which reads the entire image into a Python bytes object before sending it to zfs. For large images this can cause the system to run out of memory.

NOTE: This is a resubmission of [#1189](https://github.com/iocage/iocage/pull/1189) after a force push severed commit history. See previous PR.

@igalic, @sonicaj, @skarekrow, @jakeswenson