### PR TITLE
Support passing data file to be used by post_install.sh

### DIFF
--- a/iocage_cli/fetch.py
+++ b/iocage_cli/fetch.py
@@ -150,6 +150,10 @@ def validate_count(ctx, param, value):
     '--proxy', '-S', default=None,
     help='Provide proxy to use for creating jail'
 )
+@click.option(
+    '--pass-data', default=None,
+    help='Data file passed to plugin environment'
+)
 def cli(**kwargs):
     """CLI command that calls fetch_release()"""
     release = kwargs.get("release", None)

--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -97,6 +97,7 @@ class IOCPlugin(object):
         self.jail = jail
         self.http = kwargs.pop("http", True)
         self.hardened = kwargs.pop("hardened", False)
+        self.pass_data = kwargs.pop("pass_data", None)
         self.date = datetime.datetime.utcnow().strftime("%F")
         self.branch = branch
         self.silent = silent
@@ -807,6 +808,19 @@ fingerprint: {fingerprint}
             try:
                 shutil.copy(f"{jaildir}/plugin/post_install.sh",
                             f"{jaildir}/root/root")
+
+                if self.pass_data is not None:
+                    if os.path.exists(self.pass_data):
+                        shutil.copy(f"{self.pass_data}",
+                                    f"{jaildir}/root/root")
+                    else:
+                        iocage_lib.ioc_common.logit(
+                            {
+                                "level": "WARNING",
+                                "message": f"\n{self.pass_data} does not exist!"
+                            },
+                            _callback=self.callback,
+                            silent=self.silent)
 
                 iocage_lib.ioc_common.logit(
                     {

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1091,6 +1091,7 @@ class IOCage:
         else:
             kwargs.pop('git_repository', None)
             kwargs.pop('git_destination', None)
+            kwargs.pop('pass_data', None)
 
             if _list:
                 if remote:


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

When we use iocage to fetch a plugin,sometimes we may need to  configure plugin with some confidential information which is not suitable to be put in plugin repository. This pull request will enable us to put this information into a file and it will be copied to plugin jail which can be used by post_install script.