### PR TITLE
Update ioc_exec.py

### DIFF
--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -77,7 +77,8 @@ class IOCExec(object):
         su_env.setdefault('TERM', 'xterm-256color')
         su_env.setdefault('LANG', env_lang)
         su_env.setdefault('LC_ALL', env_lang)
-
+        su_env.setdefault('https_proxy', os.environ.get('https_proxy', '')) # iocage upgrade fails on machines having proxy without these
+        su_env.setdefault('http_proxy', os.environ.get('http_proxy', ''))
         self.su_env = su_env
         self.callback = callback
         self.cmd = self.command


### PR DESCRIPTION
iocage upgrade fails on machines having proxy
The http(s)_proxy environment values were not transmitted by default, at least in csh (FreeBSD)
Please test it on machines with and without proxy.

