### PR TITLE
ioc_lib: update freebsd repo urls for the new world

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -891,7 +891,7 @@ class IOCFetch:
 
         su.Popen(cmd).communicate()
         if self.verify:
-            f = "https://raw.githubusercontent.com/freebsd/freebsd" \
+            f = "https://raw.githubusercontent.com/freebsd/freebsd-src" \
                 "/master/usr.sbin/freebsd-update/freebsd-update.sh"
 
             tmp = tempfile.NamedTemporaryFile(delete=False)

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -101,7 +101,7 @@ class IOCUpgrade:
         self.__upgrade_check_conf__()
 
         f_rel = f'{self.new_release.rsplit("-RELEASE")[0]}'
-        f = 'https://raw.githubusercontent.com/freebsd/freebsd' \
+        f = 'https://raw.githubusercontent.com/freebsd/freebsd-src' \
             f'/releng/{f_rel}/usr.sbin/freebsd-update/freebsd-update.sh'
 
         tmp = None


### PR DESCRIPTION
The FreeBSD repository now syncs to freebsd/freebsd-src and the old repo
has been moved to freebsd/freebsd-legacy. freebsd/freebsd redirects to
freebsd/freebsd-src, but let's not rely on that going forward.

Fixes #1237

