### PR TITLE
Add a --server option to iocage update

### DIFF
--- a/iocage.8
+++ b/iocage.8
@@ -1,4 +1,4 @@
-.Dd September 12, 2020
+.Dd February 25, 2021
 .Dt IOCAGE 8
 .Os
 .Sh NAME
@@ -212,6 +212,7 @@
 .\" == UPDATE ==
 .Nm
 .Cm update
+.Op Fl s | -server
 .Ar UUID | NAME
 .\" == UPGRADE ==
 .Nm
@@ -1017,6 +1018,12 @@ Stop the jail identified by the shortened UUID.
 Runs
 .Cm freebsd-update
 to update the specified jail to the latest patch level.
+.Pp
+Options:
+.Bl -tag -width "[-s | --server TEXT]"
+.It Op Fl s | -server Ar TEXT
+Define the server from which to fetch the RELEASE.
+.El
 .Pp
 Example:
 .Pp

--- a/iocage_cli/update.py
+++ b/iocage_cli/update.py
@@ -38,8 +38,12 @@ __rootcmd__ = True
     help='Decide whether or not to update the pkg repositories and '
          'all installed packages in jail( this has no effect for plugins ).'
 )
+@click.option(
+    "--server", "-s", default="download.freebsd.org",
+    help="Server to fetch from."
+)
 @click.argument('jail', required=True)
-def cli(jail, pkgs):
+def cli(jail, **kwargs):
     """Update the supplied jail to the latest patchset"""
     skip_jails = bool(jail != 'ALL')
-    ioc.IOCage(jail=jail, skip_jails=skip_jails).update(pkgs=pkgs)
+    ioc.IOCage(jail=jail, skip_jails=skip_jails).update(**kwargs)

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -1852,7 +1852,7 @@ class IOCage:
             self.jail = jail
             self.update(pkgs)
 
-    def update(self, pkgs=False):
+    def update(self, pkgs=False, server=None):
         """Updates a jail to the latest patchset."""
         if self._all:
             self.update_all(pkgs)
@@ -1975,6 +1975,7 @@ class IOCage:
             try:
                 ioc_fetch.IOCFetch(
                     release,
+                    server,
                     callback=self.callback
                 ).fetch_update(*params)
             finally:


### PR DESCRIPTION
It works just like for iocage fetch

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

This option is needed in order to update a jail that uses a custom FreeBSD release.  It works just like the `--server` option used by `iocage fetch` for the same purpose.