### PR TITLE
Use plugin release during artifact clone

### DIFF
--- a/iocage_lib/ioc_plugin.py
+++ b/iocage_lib/ioc_plugin.py
@@ -1191,7 +1191,7 @@ fingerprint: {fingerprint}
             )
         else:
             self._clone_repo(
-                self.branch, plugin_conf['artifact'],
+                plugin_conf['release'], plugin_conf['artifact'],
                 f'{path}/plugin', callback=self.callback
             )
 


### PR DESCRIPTION
This is a small bugfix for an issue where plugins are using the TrueNAS/FreeNAS version during plugin artifact fetching instead of the `release` version specified in the plugin manifest.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
