### PR TITLE
Replace kFreeBSD instructions with modern Debian.

### DIFF
--- a/doc/source/debian.rst
+++ b/doc/source/debian.rst
@@ -1,12 +1,10 @@
-.. index:: Create Debian Squeeze Jail
-.. _Create a Debian Squeeze Jail:
+.. index:: Create Debian Jail
+.. _Create a Debian Jail:
 
-Create a Debian Squeeze Jail (GNU/kFreeBSD)
+Create a Debian Buster Jail (native Linux)
 ===========================================
 
-This section shows the process to set up a Debian (GNU/kFreeBSD) jail.
-GNU/kFreeBSD is a Debian userland tailored for the FreeBSD kernel.
-
+This section shows the process to set up a Debian Linux jail.
 The examples in this section use a jail with the custom name
 **debjail**. Remember to replace **debjail** with your jail's UUID or
 NAME!
@@ -14,24 +12,31 @@ NAME!
 .. warning:: This is not recommended for production use. The intention
    is to show :command:`iocage` can do almost anything with jails.
 
-**Create an empty jail with Linux specifics:**
+**Create an empty jail:**
 
 .. code-block:: none
 
- # iocage create -e -n debjail exec_start="/etc/init.d/rc 3" exec_stop="/etc/init.d/rc 0"
+ # iocage create -e -n debjail exec_start="/bin/true" exec_stop="/bin/true"
 
 **Install debootstrap on the host:**
 
 :samp:`# pkg install debootstrap`
 
+**Enable linux(4):**
+
+:samp:`# sysrc linux_enable="YES"`
+:samp:`# sysrc linux_mounts_enable="NO"`
+:samp:`# service linux start`
+
 **Grab the mountpoint for the empty jail, append /root/ to it, and run**
-**`debootstrap <https://www.freebsd.org/cgi/man.cgi?query=debootstrap>`_:**
+**debootstrap(8):**
 
 :samp:`# iocage get mountpoint debjail`
 
-:samp:`# debootstrap squeeze /iocage/jails/debjail/root/`
+:samp:`# debootstrap buster /iocage/jails/debjail/root/`
 
-Replace *squeeze* with *wheezy*, if needed.
+Apart from Debian releases, like *buster* or *testing*, you can
+also use Ubuntu releases, eg *bionic*.
 
 **Add lines to the jail** :file:`fstab` **file:**
 
@@ -40,9 +45,11 @@ file of *debjail* directly. Add these lines to the file:
 
 .. code-block:: none
 
- linsys   /iocage/jails/debjail/root/sys         linsysfs  rw          0 0
+ devfs    /iocage/jails/debjail/root/dev         devfs     rw          0 0
+ tmpfs    /iocage/jails/debjail/root/dev/shm     tmpfs     rw,size=1g,mode=1777 0 0
+ fdescfs  /iocage/jails/debjail/root/dev/fd      fdescfs   rw,linrdlnk 0 0
  linproc  /iocage/jails/debjail/root/proc        linprocfs rw          0 0
- tmpfs    /iocage/jails/debjail/root/lib/init/rw tmpfs     rw,mode=777 0 0
+ linsys   /iocage/jails/debjail/root/sys         linsysfs  rw          0 0
 
 **Start the jail and attach to it:**
 
@@ -50,7 +57,4 @@ file of *debjail* directly. Add these lines to the file:
 
 :samp:`# iocage console debjail`
 
-The result is a 64bit Debian Linux userland.
-
-To install a Linux only Debian jail, follow this tutorial:
-`debian-linux-freebsd-jail-zfs <http://devil-detail.blogspot.co.nz/2013/08/debian-linux-freebsd-jail-zfs.html>`_
+The result is a 64-bit Debian Linux userland.


### PR DESCRIPTION
Provide documentation for using modern Debian or Ubuntu jails. This could be done in addition to the old kFreeBSD instructions, but it looks like kFreeBSD seems to have stalled; the existing docs no longer work anyway.

This is largely based on: https://hackacad.net/post/2021-01-23-create-a-ubuntu-linux-jail-on-freebsd/