### PR TITLE
Cirrus test fixes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-11-3-snap
+  image_family: freebsd-12-2-snap
 
 iocage_tests_task:
   create_pool_script:

--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -185,6 +185,8 @@ def ioc_sort(caller, s_type, data=None):
 def get_natural_sortkey(text):
     # attempt to convert str to int to facilitate simplified natural sorting
     # integers will be ranked before alphanumerical values
+    if text is None:
+        return 30, None
     try:
         return 10, int(text)
     except ValueError:

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1441,6 +1441,7 @@ class IOCStart(object):
 
         rc_conf_path = os.path.join(self.path, 'root/etc/rc.conf')
         if not os.path.exists(rc_conf_path):
+            os.makedirs(os.path.dirname(rc_conf_path), exist_ok=True)
             open(rc_conf_path, 'w').close()
             entries = {}
         else:

--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -125,7 +125,7 @@ class IOCage:
                 self.stop(j, ignore_exception=ignore_exception)
             elif action == 'start':
                 if not status:
-                    err, msg = self.start(j, ignore_exception=ignore_exception)
+                    err, msg = self.start(j, ignore_exception=True)
 
                     if err:
                         ioc_common.logit(

--- a/iocage_lib/resource.py
+++ b/iocage_lib/resource.py
@@ -19,7 +19,7 @@ class Resource:
     @property
     def properties(self):
         if not self._properties:
-            if self.cache:
+            if self.cache and self.resource_name in iocage_cache.datasets:
                 self._properties = iocage_cache.datasets[self.resource_name]
             if not self._properties:
                 # For cases where we are using this for datasets which are not under

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,13 @@
+[pytest]
+addopts = -vvv -rs --ignore=setup.py --pep8 --cov-report term-missing --cov=./iocage_lib --cov=./iocage_cli tests
+pep8maxlinelength = 80
+pep8ignore = * ALL
+markers =
+    require_zpool
+    require_root
+    require_dhcp
+    require_jail_ip
+    require_networking
+    require_nat
+    require_upgrade
+    require_image

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[tool:pytest]
-addopts = -vv -rs --ignore=setup.py --pep8 --cov-report term-missing --cov=iocage tests
-pep8maxlinelength = 80
-pep8ignore = * ALL
-[aliases]
-test=pytest

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'GitPython>=2.1.11',
         'netifaces>=0.10.8',
         'dnspython>=1.15.0',
+        'six>=1.15.0',
     ],
     setup_requires=['pytest-runner'],
     entry_points={'console_scripts': ['iocage = iocage_lib:cli']},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def pytest_addoption(parser):
         help='Specify a zpool to use.'
     )
     parser.addoption(
-        '--release', action='store', default='11.3-RELEASE',
+        '--release', action='store', default='12.2-RELEASE',
         help='Specify a RELEASE to use.'
     )
     parser.addoption(

--- a/tests/functional_tests/0016_restart_test.py
+++ b/tests/functional_tests/0016_restart_test.py
@@ -23,6 +23,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import time
+
 import pytest
 import uuid
 
@@ -90,14 +92,21 @@ def common_restart_all_jails(invoke_cli, resource_selector, skip_test, command):
 
     command.append('ALL')
     result = invoke_cli(
-        command, assert_returncode=False
+        command
     )
 
     for jail in jails:
         if '* Starting empty_jail' in result.output:
             continue
 
-        assert jail.running is True
+        jail_running = False
+        for i in range(0, 5):
+            if jail.running:
+                jail_running = True
+                break
+            time.sleep(10)
+
+        assert jail_running is True
 
     for jail in resource_selector.running_jails:
         invoke_cli(
@@ -128,6 +137,8 @@ def test_02_soft_restart_jail(invoke_cli, resource_selector, skip_test, write_fi
 @require_zpool
 def test_03_restart_all_jails(invoke_cli, resource_selector, skip_test):
     common_restart_all_jails(invoke_cli, resource_selector, skip_test, ['restart'])
+
+
 
 
 @require_root

--- a/tests/functional_tests/0017_fstab_test.py
+++ b/tests/functional_tests/0017_fstab_test.py
@@ -77,7 +77,7 @@ def test_01_add_fstab_entry(invoke_cli, resource_selector, skip_test):
 
     invoke_cli([
         'fstab', '-a', jail.name, SOURCE_DIR, DESTINATION_DIR,
-        'none', 0, 0, 0
+        'nullfs', 'rw', 0, 0
     ])
 
     assert any(destination_dir_absolute in s for s in jail.fstab) is True


### PR DESCRIPTION
Attempt to fix the broken cirrus test check. Changes/fixes include:

* Add `six` to the `iocage_cli` package (this was the main reason tests were not started)
* Bug fix not being able to listing jails with `jid` sort when some jails are down with `None` jid values
* Bug fix for starting jail with no `rc.conf` file and no parent `/etc` folder
* Bug fix for trying to get not yet cached dataset value 
* Ignore start exceptions in `__all__` function. This is a fix for a bug while running `iocage restart ALL` and having an empty jail which didn't start (as expected) but made all the following jails being skipped
* Bump the test FreeBSD version and cirrus version to `12.2`
* Restart jail test fix where tests weren't waiting for all jails to get (sequentially) restarted
* `fstab` test fix having invalid params
* Change the upgrade test to a more hardcoded/simple version (these tests are still not run in the cirrus CI as it takes a lot of time and slows down the tests to about twice the execution time)
* Coverage fix not printing any of the covered files

Note that these fixes solves some of the issues and make the tests green again although there is still some flakiness where jails are started but missing the `/dev` mount which makes the `jexec` command for stopping services fail. See e.g. run: https://cirrus-ci.com/task/5140373442920448 (leaving this for other PRs/issues/fixes in order to not make this grow any further).


----

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
