### PR TITLE
Update pkg name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ technologies the FreeBSD operating system has to offer. It is geared for ease
  of use with a simple and easy to understand command syntax.
 
 iocage is in the FreeBSD ports tree as sysutils/py-iocage.
-To install using binary packages, simply run: `pkg install py36-iocage`
+To install using binary packages, simply run: `pkg install py37-iocage`
 
 ## Installation
 
@@ -35,7 +35,7 @@ To install subsequent updates: run `make install` as root.
 
 ### Pkg:
 
-- It is possible to install pre-built packages using pkg(8) if you are using FreeBSD 10 or above: `pkg install py36-iocage`
+- It is possible to install pre-built packages using pkg(8) if you are using FreeBSD 10 or above: `pkg install py37-iocage`
 
 #### Upgrading from `iocage_legacy`:
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -14,7 +14,7 @@ Using binary packages
 
 To install using binary packages on a FreeBSD system, run:
 
-:samp:`sudo pkg install py36-iocage`
+:samp:`sudo pkg install py37-iocage`
 
 Using github
 ++++++++++++
@@ -41,7 +41,7 @@ FreeBSD 10 or above.
 
 To install using pkg(8), run:
 
-:samp:`sudo pkg install py36-iocage`
+:samp:`sudo pkg install py37-iocage`
 
 Building Ports
 ++++++++++++++


### PR DESCRIPTION
I spot checked on FreeBSD 11.4 and 13.0 that the package name on both is `py37-iocage`, not `py36-iocage`.

Fixes #1219 #1146

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
