### PR TITLE
Allow integer as devfs_ruleset

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -769,7 +769,7 @@ def generate_devfs_ruleset(conf, paths=None, includes=None, callback=None,
         if int(configured_ruleset) != 0 and int(configured_ruleset) not in ruleset_list:
             return True, configured_ruleset, '-1'
         rules = su.run(
-            ['devfs', 'rule', '-s', configured_ruleset, 'show'],
+            ['devfs', 'rule', '-s', str(configured_ruleset), 'show'],
             stdout=su.PIPE, universal_newlines=True
         )
         for rule in rules.stdout.splitlines():


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Fix #1262.