### PR TITLE
fix for missing proxy variables in subprocesses (#1212)

### DIFF
--- a/iocage_lib/ioc_exec.py
+++ b/iocage_lib/ioc_exec.py
@@ -77,6 +77,9 @@ class IOCExec(object):
         su_env.setdefault('TERM', 'xterm-256color')
         su_env.setdefault('LANG', env_lang)
         su_env.setdefault('LC_ALL', env_lang)
+        su_env.setdefault('HTTP_PROXY', os.environ.get('HTTP_PROXY', ''))
+        su_env.setdefault('HTTP_PROXY_AUTH', os.environ.get('HTTP_PROXY_AUTH', ''))
+        su_env.setdefault('NO_PROXY', os.environ.get('NO_PROXY', ''))
 
         self.su_env = su_env
         self.callback = callback

--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -77,7 +77,11 @@ class IOCUpgrade:
             'PATH': path,
             'PWD': '/',
             'HOME': '/',
-            'TERM': 'xterm-256color'
+            'TERM': 'xterm-256color',
+            'HTTP_PROXY': os.environ.get('HTTP_PROXY', ''),
+            'HTTPS_PROXY': os.environ.get('HTTPS_PROXY', ''),
+            'HTTP_PROXY_AUTH': os.environ.get('HTTP_PROXY_AUTH', ''),
+            'NO_PROXY': os.environ.get('NO_PROXY', '')
         }
 
         self.callback = callback
@@ -180,7 +184,7 @@ class IOCUpgrade:
                 #  https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=239498
                 cp = su.Popen(
                     ['pkg-static', '-j', self.jid, 'install', '-q', '-f', '-y', 'pkg'],
-                    stdout=su.PIPE, stderr=su.PIPE
+                    stdout=su.PIPE, stderr=su.PIPE, env=self.upgrade_env
                 )
                 _, stderr = cp.communicate()
                 if cp.returncode:


### PR DESCRIPTION
This PR will fix the issue with updated iocage command which does not take any proxy settings into account #1159 .
`HTTP_PROXY`, `HTTPS_PROXY`, `HTTP_PROXY_AUTH` and `NO_PROXY` are taken into account for subprocesses requiring them.
`HTTPS_PROXY` will not be used by `fetch()` used in `freebsd-upgrade`  so this was intentionally left out.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
