### PR TITLE
Updates for Python 3.8 and pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 ZPOOL=""
 SERVER=""
-PYTHON?=/usr/local/bin/python3.6
+PYTHON?=/usr/local/bin/python3.8
 
 depends:
 	@(pkg -vv | grep -e "url.*/latest") > /dev/null 2>&1 || (echo "It is advised pkg url is using \"latest\" instead of \"quarterly\" in /etc/pkg/FreeBSD.conf.";)
-	@test -s ${PYTHON} || (echo "Python binary ${PYTHON} not found, iocage will install python36"; pkg install -q -y python36)
-	pkg install -q -y py36-libzfs
+	@test -s ${PYTHON} || (echo "Python binary ${PYTHON} not found, iocage will install python38"; pkg install -q -y python38)
+	pkg install -q -y py38-libzfs
 	${PYTHON} -m ensurepip
 	${PYTHON} -m pip install -Ur requirements.txt
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ depends:
 	${PYTHON} -m pip install -Ur requirements.txt
 
 install: depends
-	${PYTHON} -m pip install -U .
+	${PYTHON} setup.py install 
 uninstall:
 	${PYTHON} -m pip uninstall -y iocage-lib iocage-cli
 test:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/iocage/iocage.svg)](http://isitmaintained.com/project/iocage/iocage "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/iocage/iocage.svg)](http://isitmaintained.com/project/iocage/iocage "Percentage of issues still open")
-![Python Version](https://img.shields.io/badge/Python-3.6-blue.svg)
+![Python Version](https://img.shields.io/badge/Python-3.8-blue.svg)
 [![GitHub issues](https://img.shields.io/github/issues/iocage/iocage.svg)](https://github.com/iocage/iocage/issues)
 [![GitHub forks](https://img.shields.io/github/forks/iocage/iocage.svg)](https://github.com/iocage/iocage/network)
 [![GitHub stars](https://img.shields.io/github/stars/iocage/iocage.svg)](https://github.com/iocage/iocage/stargazers)
@@ -15,7 +15,7 @@ technologies the FreeBSD operating system has to offer. It is geared for ease
  of use with a simple and easy to understand command syntax.
 
 iocage is in the FreeBSD ports tree as sysutils/py-iocage.
-To install using binary packages, simply run: `pkg install py37-iocage`
+To install using binary packages, simply run: `pkg install py38-iocage`
 
 ## Installation
 
@@ -23,8 +23,8 @@ To install using binary packages, simply run: `pkg install py37-iocage`
 
 The FreeBSD source tree ***must*** be located at `$SRC_BASE` (`/usr/src` by default) to build from git.
 
-- `pkg install python36 git-lite py36-cython py36-pip`
-- `git clone --recursive https://github.com/iocage/iocage`
+- `pkg install python38 git-lite py38-cython py38-libzfs py38-pip`
+- `git clone https://github.com/iocage/iocage`
 - `make install` as root
 
 To install subsequent updates: run `make install` as root.
@@ -35,7 +35,7 @@ To install subsequent updates: run `make install` as root.
 
 ### Pkg:
 
-- It is possible to install pre-built packages using pkg(8) if you are using FreeBSD 10 or above: `pkg install py37-iocage`
+- It is possible to install pre-built packages using pkg(8) if you are using FreeBSD 10 or above: `pkg install py38-iocage`
 
 #### Upgrading from `iocage_legacy`:
 
@@ -120,9 +120,9 @@ To see a list of commands available to you now, type `iocage` outside the jail.
 
 ### REQUIREMENTS
 
-- FreeBSD 9.3-RELEASE amd64 and higher or HardenedBSD/TrueOS
+- FreeBSD 11.4-RELEASE amd64 and higher or HardenedBSD/TrueOS
 - ZFS file system
-- Python 3.6+
+- Python 3.8+
 - UTF-8 locale (place into your ~/.login_conf):
 
 ```plain

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -14,7 +14,7 @@ Using binary packages
 
 To install using binary packages on a FreeBSD system, run:
 
-:samp:`sudo pkg install py37-iocage`
+:samp:`sudo pkg install py38-iocage`
 
 Using github
 ++++++++++++
@@ -24,9 +24,9 @@ at :samp:`$SRC_BASE` ( :samp:`/usr/src` by default).
 
 To install from github, run these commands:
 
-:samp:`pkg install python36 git-lite libgit2 cython3 py36-pip`
+:samp:`pkg install python38 git-lite py38-cython py38-libzfs py38-pip`
 
-:samp:`git clone --recursive https://github.com/iocage/iocage`
+:samp:`git clone https://github.com/iocage/iocage`
 
 :samp:`make install` as root.
 
@@ -41,7 +41,7 @@ FreeBSD 10 or above.
 
 To install using pkg(8), run:
 
-:samp:`sudo pkg install py37-iocage`
+:samp:`sudo pkg install py38-iocage`
 
 Building Ports
 ++++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ else:
 if os.path.isdir("/".join([sys.prefix, "share/zsh/site-functions/"])):
     _data.append(('share/zsh/site-functions', ['zsh-completion/_iocage']))
 
-if sys.version_info < (3, 6):
-    exit("Only Python 3.6 and higher is supported.")
+if sys.version_info < (3, 8):
+    exit("Only Python 3.8 and higher is supported.")
 
 VERSION = '1.2'
 


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Changes:
- The default version of Python is now 3.8; this PR addressed this
- Remove old _--recursive_ references from when libzfs was an embedded repo
- The newer versions of pip no longer support the existing setup.py file and abend in `ERROR: More than one .egg-info directory found in /tmp/blahblah`.  Calling `setup.py` directly in the Makefile still works.  There's some background here: pypa/pip#8201.

Thanks!