### PR TITLE
add plugin_manifest.json to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     author_email='https://groups.google.com/forum/#!forum/iocage',
     url='https://github.com/iocage/iocage',
     packages=find_packages(exclude=['tests']),
+    package_data={'iocage_lib': ['plugin_manifest.json']},
     include_package_data=True,
     install_requires=[
         'GitPython>=2.1.11',


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

As per #1255, file `plugin_manifest.json` was introduced to validate the plugin schema, but that file is missing in the python package and this results in a traceback when trying to install plugins.

```
➜  ~ sudo iocage fetch -P mineos.json -n mineos-plugin nat=1 vnet=1
Traceback (most recent call last):
  File "/usr/local/bin/iocage", line 10, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/iocage_lib-1.2-py3.8.egg/iocage_cli/fetch.py", line 181, in cli
    ioc.IOCage().fetch(**kwargs)
  File "/usr/local/lib/python3.8/site-packages/iocage_lib-1.2-py3.8.egg/iocage_lib/iocage.py", line 1072, in fetch
    plugin_obj.fetch_plugin(props, 0, accept)
  File "/usr/local/lib/python3.8/site-packages/iocage_lib-1.2-py3.8.egg/iocage_lib/ioc_plugin.py", line 306, in fetch_plugin
    iocage_lib.ioc_common.validate_plugin_manifest(conf, self.callback, self.silent)
  File "/usr/local/lib/python3.8/site-packages/iocage_lib-1.2-py3.8.egg/iocage_lib/ioc_common.py", line 1142, in validate_plugin_manifest
    v = jsonschema.Draft7Validator(cache.plugin_manifest_schema)
  File "/usr/local/lib/python3.8/site-packages/iocage_lib-1.2-py3.8.egg/iocage_lib/cache.py", line 127, in plugin_manifest_schema
    with open(schema_path, "r") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/site-packages/iocage_lib-1.2-py3.8.egg/iocage_lib/plugin_manifest.json'
```
This PR addresses this issue.