### PR TITLE
Fix fetch 'latest' and EOL

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -690,11 +690,14 @@ def parse_latest_release():
         # We want a dynamic supported
         try:
             if "releng/" in rel[1]:
-                rel = rel[1].strip('</td').strip("releng/")
+                rel = rel[1].strip('</td').strip('</p').strip("releng/")
+                float(rel)
 
                 if rel not in sup_releases:
                     sup_releases.append(rel)
         except IndexError:
+            pass
+        except ValueError:
             pass
 
     latest = f"{sorted(sup_releases)[-1]}-RELEASE"

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -123,7 +123,7 @@ class IOCFetch:
             # We want a dynamic EOL
             try:
                 if "-RELEASE" in eol[1]:
-                    eol = eol[1].strip('</td')
+                    eol = eol[1].strip('</td').strip('</p')
 
                     if eol not in eol_releases:
                         eol_releases.append(eol)


### PR DESCRIPTION
Make sure to follow and check these boxes before submitting a PR! Thank you.

- [X] Explain the feature
- [X] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)

Fixes two issues with `iocage fetch -r`; Due to a change in the upstream FreeBSD.org website, the sections of code the parse the website to find the `latest` release and the `EOL` indicators are broken.  This PR addresses this issue.

Fixes #1244