### PR TITLE
Correctly log error message when pkg-install fails

### DIFF
--- a/iocage_lib/ioc_create.py
+++ b/iocage_lib/ioc_create.py
@@ -961,7 +961,10 @@ class IOCCreate(object):
                             log=not(self.silent)
                         )
                 except iocage_lib.ioc_exceptions.CommandFailed as e:
-                    pkg_stderr = e.message[-1].decode().rstrip()
+                    nonempty_lines = [line.rstrip() for line in e.message if line.rstrip()]
+                    pkg_stderr = ''
+                    if len(nonempty_lines) > 0:
+                        pkg_stderr = nonempty_lines[-1].decode()
                     pkg_err = True
 
                 if not pkg_err:


### PR DESCRIPTION
If `pkg-install` fails, we should ignore blank lines when attempting to send back a helpful error message to the user.

This is because `e.message` can look something like this:
```
[b"pkg: No packages available to install matching 'fake-package' have been found in the repositories\n", b'', b'', b'']
```

Which leads to a very unhelpful error message like this:
```
Installing plugin packages:
  - fake-package... 
    - fake-package failed to install, retry #1
    - fake-package failed to install, retry #2
    - fake-package failed to install, retry #3

pkg error:
  - fake-package :
```

After this change the message is propagated back to the user:
```
Installing plugin packages:
  - fake-package... 
    - fake-package failed to install, retry #1
    - fake-package failed to install, retry #2
    - fake-package failed to install, retry #3

pkg error:
  - fake-package :pkg: No packages available to install matching 'fake-package' have been found in the repositories
```

---

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
