### PR TITLE
Respect `resolver` configuration when updating jails

### DIFF
--- a/iocage_lib/ioc_common.py
+++ b/iocage_lib/ioc_common.py
@@ -1297,3 +1297,23 @@ def tmp_dataset_checks(_callback, silent):
                 _callback=_callback,
                 silent=silent
             )
+
+def generate_resolv(resolver, mount_root):
+        #                                     compat
+
+        if resolver != "/etc/resolv.conf" and resolver != "none" and \
+                resolver != "/dev/null":
+            with iocage_lib.ioc_common.open_atomic(
+                    f"{mount_root}/etc/resolv.conf", "w") as resolv_conf:
+
+                for line in resolver.split(";"):
+                    resolv_conf.write(line + "\n")
+        elif resolver == "none":
+            shutil.copy("/etc/resolv.conf",
+                        f"{mount_root}/etc/resolv.conf")
+        elif resolver == "/dev/null":
+            # They don't want the resolv.conf to be touched.
+
+            return
+        else:
+            shutil.copy(resolver, f"{mount_root}/etc/resolv.conf")

--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -842,6 +842,10 @@ class IOCFetch:
                 },
                 _callback=self.callback,
                 silent=self.silent)
+            iocage_lib.ioc_common.generate_resolv(
+                iocage_lib.ioc_json.IOCJson(
+                    mount, cli=False).json_get_value('resolver'),
+                mount_root)
         else:
             cmd = [
                 "mount", "-t", "devfs", "devfs",
@@ -860,8 +864,7 @@ class IOCFetch:
                 },
                 _callback=self.callback,
                 silent=self.silent)
-
-        shutil.copy("/etc/resolv.conf", f"{mount_root}/etc/resolv.conf")
+            shutil.copy("/etc/resolv.conf", f"{mount_root}/etc/resolv.conf")
 
         path = '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:'\
                '/usr/local/bin:/root/bin'

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -1366,25 +1366,9 @@ class IOCStart(object):
             return
 
     def start_generate_resolv(self):
-        resolver = self.get("resolver")
-        #                                     compat
-
-        if resolver != "/etc/resolv.conf" and resolver != "none" and \
-                resolver != "/dev/null":
-            with iocage_lib.ioc_common.open_atomic(
-                    f"{self.path}/root/etc/resolv.conf", "w") as resolv_conf:
-
-                for line in resolver.split(";"):
-                    resolv_conf.write(line + "\n")
-        elif resolver == "none":
-            shutil.copy("/etc/resolv.conf",
-                        f"{self.path}/root/etc/resolv.conf")
-        elif resolver == "/dev/null":
-            # They don't want the resolv.conf to be touched.
-
-            return
-        else:
-            shutil.copy(resolver, f"{self.path}/root/etc/resolv.conf")
+        iocage_lib.ioc_common.generate_resolv(
+            self.get("resolver"),
+            f"{self.path}/root")
 
     def __generate_mac_bytes(self, nic):
         m = hashlib.md5()


### PR DESCRIPTION
When updating a jail using `iocage update jailname`, iocage replaced
jailname's `/etc/resolv.conf` with the one from the jailhost, ignoring
the jail's `resolver` configuration.

This patch makes `fetch_update` use the same logic when generating
`/etc/resolv.conf` that is used when (re)starting a jail.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
