### PR TITLE
small bugfix, when silent=True

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -761,7 +761,7 @@ class IOCFetch:
             status = "\r\n"
 
         if self.silent:
-            return
+            return ""
 
         text = "\r{} [{}] {:.0f}% {} {}MB/s".format(
             display_text,


### PR DESCRIPTION
When using the option silent=True, the following error occurs while fetching a new release:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/iocage.py", line 1139, in fetch
    ioc_fetch.IOCFetch(
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_fetch.py", line 212, in fetch_release
    rel = self.fetch_http_release(eol, _list=_list)
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_fetch.py", line 475, in fetch_http_release
    self.fetch_download(missing_files, missing=bool(missing_files))
  File "/usr/local/lib/python3.9/site-packages/iocage_lib/ioc_fetch.py", line 740, in fetch_download
    'message': text.rstrip()
AttributeError: 'NoneType' object has no attribute 'rstrip'
```

This pull request should fix this issue
