### PR TITLE
Correctly construct arguments for freebsd-update

### DIFF
--- a/iocage_lib/ioc_upgrade.py
+++ b/iocage_lib/ioc_upgrade.py
@@ -120,7 +120,7 @@ class IOCUpgrade:
                 tmp.name, "-b", self.path, "-d",
                 f"{self.path}/var/db/freebsd-update/", "-f",
                 f"{self.path}/etc/freebsd-update.conf",
-                "--not-running-from-cron", "--currently-running "
+                "--not-running-from-cron", "--currently-running",
                 f"{self.jail_release}", "-r", self.new_release, "upgrade"
             ]
 


### PR DESCRIPTION
When calling `freebsd-update`, `--currently-running` and the jail's current release should be separate arguments, instead of in the same argument separated by a space. This only works now because `freebsd-update` doesn't correctly handle spaces in its arguments and splits them by spaces internally. If this is fixed ([bug report](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=268686)), `iocage` will not be able to run it properly.