### PR TITLE
Pull `freebsd-update` from active branch of freebsd/freebsd-src

### DIFF
--- a/iocage_lib/ioc_fetch.py
+++ b/iocage_lib/ioc_fetch.py
@@ -892,7 +892,7 @@ class IOCFetch:
         su.Popen(cmd).communicate()
         if self.verify:
             f = "https://raw.githubusercontent.com/freebsd/freebsd-src" \
-                "/master/usr.sbin/freebsd-update/freebsd-update.sh"
+                "/main/usr.sbin/freebsd-update/freebsd-update.sh"
 
             tmp = tempfile.NamedTemporaryFile(delete=False)
             with urllib.request.urlopen(f) as fbsd_update:


### PR DESCRIPTION
The [master branch](https://github.com/freebsd/freebsd-src/tree/master) of freebsd-src is obsolete and is no longer receiving commits, so `iocage fetch` is using an old version of `freebsd-update`. They switched to the [main](https://github.com/freebsd/freebsd-src/tree/main) branch for active development. [A previous `iocage` commit](https://github.com/iocage/iocage/commit/23192260ead2303be9576a773d0140d98fc356f2) appears to have partially addressed this but neglected to change the branch name.

Note this is still different from the behavior in [ioc_upgrade.py](https://github.com/iocage/iocage/blob/master/iocage_lib/ioc_upgrade.py#L109) which pulls a release version.