### PR TITLE
add allow_mount_fdescfs option

### DIFF
--- a/iocage.8
+++ b/iocage.8
@@ -1644,6 +1644,18 @@ Default: 0
 .Pp
 Source:
 .Xr jail 8
+.It Pf allow_mount_fdescfs= Op 1 | 0
+Allow privileged users inside the jail to mount and unmount the fdescfs
+file system.
+This permission is effective only together with allow.mount and if
+enforce_statfs is set to a value lower than 2.
+.Pp
+Note: This is not supported on FreeBSD 9.3.
+.Pp
+Default: 0
+.Pp
+Source:
+.Xr jail 8
 .It Pf allow_mount_fusefs= Op 1 | 0
 Allow privileged users inside the jail to mount and unmount fusefs file
 systems.

--- a/iocage_lib/ioc_json.py
+++ b/iocage_lib/ioc_json.py
@@ -434,7 +434,7 @@ class IOCConfiguration:
     @staticmethod
     def get_version():
         """Sets the iocage configuration version."""
-        version = '28'
+        version = '29'
 
         return version
 
@@ -908,6 +908,10 @@ class IOCConfiguration:
         if not conf.get("vnet_default_mtu"):
             conf["vnet_default_mtu"] = '1500'
 
+        # Version 29 key
+        if not conf.get('allow_mount_fdescfs'):
+            conf['allow_mount_fdescfs'] = 0
+
         if not default:
             conf.update(jail_conf)
 
@@ -1164,6 +1168,7 @@ class IOCConfiguration:
             'allow_mlock': 0,
             'allow_mount': 0,
             'allow_mount_devfs': 0,
+            'allow_mount_fdescfs': 0,
             'allow_mount_fusefs': 0,
             'allow_mount_nullfs': 0,
             'allow_mount_procfs': 0,
@@ -1336,6 +1341,7 @@ class IOCJson(IOCConfiguration):
         'allow_mount_nullfs',
         'allow_mount_fusefs',
         'allow_mount_devfs',
+        'allow_mount_fdescfs',
         'allow_mount',
         'allow_mlock',
         'allow_chflags',
@@ -2083,6 +2089,7 @@ class IOCJson(IOCConfiguration):
             "allow_mlock": truth_variations,
             "allow_mount": truth_variations,
             "allow_mount_devfs": truth_variations,
+            "allow_mount_fdescfs": truth_variations,
             "allow_mount_fusefs": truth_variations,
             "allow_mount_nullfs": truth_variations,
             "allow_mount_procfs": truth_variations,

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -137,6 +137,7 @@ class IOCStart(object):
         allow_mlock = self.conf["allow_mlock"]
         allow_mount = self.conf["allow_mount"]
         allow_mount_devfs = self.conf["allow_mount_devfs"]
+        allow_mount_fdescfs = self.conf["allow_mount_fdescfs"]
         allow_mount_fusefs = self.conf["allow_mount_fusefs"]
         allow_mount_nullfs = self.conf["allow_mount_nullfs"]
         allow_mount_procfs = self.conf["allow_mount_procfs"]
@@ -335,9 +336,11 @@ class IOCStart(object):
         if userland_version <= 9.3:
             tmpfs = ""
             fdescfs = ""
+            _allow_mount_fdescfs = ""
         else:
             tmpfs = f"allow.mount.tmpfs={allow_mount_tmpfs}"
             fdescfs = f"mount.fdescfs={mount_fdescfs}"
+            _allow_mount_fdescfs = f"allow.mount.fdescfs={allow_mount_fdescfs}"
 
         # FreeBSD 10.3 and under do not support this.
 
@@ -541,7 +544,7 @@ class IOCStart(object):
 
         parameters = [
             fdescfs, _allow_mlock, tmpfs,
-            _allow_mount_fusefs, _allow_vmm,
+            _allow_mount_fdescfs, _allow_mount_fusefs, _allow_vmm,
             f"allow.set_hostname={allow_set_hostname}",
             f"mount.devfs={mount_devfs}",
             f"allow.raw_sockets={allow_raw_sockets}",


### PR DESCRIPTION
Patch adapted from https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=270016

Iocage has no property to allow the user to mount the fdescfs filesytem inside a jail. This prevents one from running a Samba 4.16 Domain Controller inside a jail.

This fixes that by adding allow_mount_fdescfs