### PR TITLE
iocage start: fix wrong hexmask for newer freebsd versions.

### DIFF
--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -907,7 +907,7 @@ class IOCStart(object):
                 # newer freebsd versions use 'ifconfig -f inet:cidr' and don't need any hex conversion
                 freebsd_version = iocage_lib.ioc_common.checkoutput(['freebsd-version']).split('-')[0].split('.')
                 freebsd_version_major = int(freebsd_version[0])
-                if freebsd_version_major < 12:
+                if freebsd_version_major < 11:
                     cmd = ['jexec', f'ioc-{self.uuid}', 'ifconfig', interface, 'inet']
                     out = su.check_output(cmd)
                     addr_split = out.splitlines()[2].split()

--- a/iocage_lib/ioc_start.py
+++ b/iocage_lib/ioc_start.py
@@ -902,20 +902,25 @@ class IOCStart(object):
                     # Jails default is epairNb
                     interface = f'{interface.replace("vnet", "epair")}b'
 
-                # We'd like to use ifconfig -f inet:cidr here,
-                # but only FreeBSD 11.0 and newer support it...
-                cmd = ['jexec', f'ioc-{self.uuid}', 'ifconfig',
-                       interface, 'inet']
-                out = su.check_output(cmd)
+                addr = 'ERROR, check jail logs'
 
-                # ...so we extract the ip4 address and mask,
-                # and calculate cidr manually
-                addr_split = out.splitlines()[2].split()
-                self.ip4_addr = addr_split[1].decode()
-                hexmask = addr_split[3].decode()
-                maskcidr = sum([bin(int(hexmask, 16)).count('1')])
-
-                addr = f'{self.ip4_addr}/{maskcidr}'
+                # newer freebsd versions use 'ifconfig -f inet:cidr' and don't need any hex conversion
+                freebsd_version = iocage_lib.ioc_common.checkoutput(['freebsd-version']).split('-')[0].split('.')
+                freebsd_version_major = int(freebsd_version[0])
+                if freebsd_version_major < 12:
+                    cmd = ['jexec', f'ioc-{self.uuid}', 'ifconfig', interface, 'inet']
+                    out = su.check_output(cmd)
+                    addr_split = out.splitlines()[2].split()
+                    self.ip4_addr = addr_split[1].decode()
+                    hexmask = addr_split[3].decode()
+                    maskcidr = sum([bin(int(hexmask, 16)).count('1')])
+                    addr = f'{self.ip4_addr}/{maskcidr}'
+                else:
+                    cmd = ['jexec', f'ioc-{self.uuid}', 'ifconfig', '-f', 'inet:cidr', interface]
+                    out = su.check_output(cmd)
+                    addr_split = out.splitlines()[2].split()
+                    self.ip4_addr = addr_split[1].decode()
+                    addr = self.ip4_addr
 
                 if '0.0.0.0' in addr:
                     failed_dhcp = True


### PR DESCRIPTION
the `iocage start` command has bit math that's unnecessary on newer freebsd versions.

to keep backwards compatibility a version check was introduced that runs the old code for freebsd <12.X.