### PR TITLE
Prevent slashes in jail names when checking existence

### DIFF
--- a/iocage_lib/iocage.py
+++ b/iocage_lib/iocage.py
@@ -252,6 +252,18 @@ class IOCage:
                 tuple: The jails uuid, path
         """
 
+        if '/' in self.jail:
+            msg = f"jail '{self.jail}' not found ('/' not allowed in jail name)!"
+
+            ioc_common.logit(
+                {
+                    "level": "EXCEPTION",
+                    "message": msg
+                },
+                _callback=self.callback,
+                silent=self.silent)
+            return
+
         if os.path.isdir(f"{self.iocroot}/jails/{self.jail}"):
             path = f"{self.iocroot}/jails/{self.jail}"
 


### PR DESCRIPTION
Specifically trailing slashes cause issues, see
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=275738

Affects commands like console, start etc.

Jail creation is already covered by a strict regex, see ioc_create.py.

Make sure to follow and check these boxes before submitting a PR! Thank you.

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
